### PR TITLE
fix(build): remove unsupported ai/elements import; render TaskList with local UI

### DIFF
--- a/components/chat/TaskList.tsx
+++ b/components/chat/TaskList.tsx
@@ -8,48 +8,25 @@ interface TaskListProps {
 }
 
 export function TaskList({ tasks }: TaskListProps) {
-  const [TaskComp, setTaskComp] = React.useState<React.ComponentType<Record<string, unknown>> | null>(null)
-
-  React.useEffect(() => {
-    let mounted = true
-    import('ai/elements')
-      .then((mod: { Task?: React.ComponentType<Record<string, unknown>> }) => {
-        if (!mounted) return
-        setTaskComp(() => mod.Task ?? null)
-      })
-      .catch(() => setTaskComp(null))
-    return () => {
-      mounted = false
-    }
-  }, [])
-
   if (!tasks || tasks.length === 0) return null
-
-  if (!TaskComp) {
-    // Fallback renderer if AI Elements Task is not available
-    return (
-      <div className="space-y-2" data-testid="task-list-fallback">
-        {tasks.map((t) => (
-          <div key={t.id} className="border border-border rounded-md p-2 text-sm bg-muted/30">
-            <div className="flex items-center justify-between">
-              <span className="font-medium">{t.title}</span>
-              <span className="text-xs text-muted-foreground">{t.status}{typeof t.progress === 'number' ? ` · ${t.progress}%` : ''}</span>
-            </div>
-            {t.details ? (
-              <div className="mt-1 text-muted-foreground text-xs">
-                {Array.isArray(t.details) ? t.details.join(' ') : t.details}
-              </div>
-            ) : null}
-          </div>
-        ))}
-      </div>
-    )
-  }
 
   return (
     <div className="space-y-2" data-testid="task-list">
       {tasks.map((t) => (
-        <TaskComp key={t.id} title={t.title} status={t.status} progress={t.progress} details={t.details} meta={t.meta} />
+        <div key={t.id} className="border border-border rounded-md p-2 text-sm bg-muted/30">
+          <div className="flex items-center justify-between">
+            <span className="font-medium">{t.title}</span>
+            <span className="text-xs text-muted-foreground">
+              {t.status}
+              {typeof t.progress === 'number' ? ` · ${t.progress}%` : ''}
+            </span>
+          </div>
+          {t.details ? (
+            <div className="mt-1 text-muted-foreground text-xs">
+              {Array.isArray(t.details) ? t.details.join(' ') : t.details}
+            </div>
+          ) : null}
+        </div>
       ))}
     </div>
   )


### PR DESCRIPTION
Why\n- Fix Next.js build failure due to unresolved import path 'ai/elements'.\n\nWhat changed\n- components/chat/TaskList.tsx: removed dynamic import('ai/elements') and always render tasks with a local, simple UI. Keeps behavior consistent with previous fallback path.\n\nHow tested\n- npm run typecheck (pass)\n- npm run lint (pass; warnings remain in other files per task.md)\n- npm run build (now passes previous module resolution step; build currently fails later due to missing Supabase env for prerender, unrelated to this PR).\n\nScope\n- Small, isolated change to unblock build from the 'ai/elements' error.\n