### PR TITLE
feat(api): update insights routes for Next.js async params

### DIFF
--- a/app/api/insights/[id]/feedback/route.ts
+++ b/app/api/insights/[id]/feedback/route.ts
@@ -7,9 +7,9 @@ const hasSupabase =
   typeof process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY === 'string' &&
   (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '').length > 20
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, context: { params: Promise<{ id: string }> }) {
   try {
-    const id = params.id
+    const { id } = await context.params
     const { rating, feedback } = await req.json().catch(() => ({}))
 
     if (!id || typeof rating === 'undefined') {

--- a/app/api/insights/[id]/reveal/route.ts
+++ b/app/api/insights/[id]/reveal/route.ts
@@ -7,9 +7,9 @@ const hasSupabase =
   typeof process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY === 'string' &&
   (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '').length > 20
 
-export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(_req: NextRequest, context: { params: Promise<{ id: string }> }) {
   try {
-    const id = params.id
+    const { id } = await context.params
     if (!id) {
       return new Response(JSON.stringify({ error: 'id is required' }), {
         status: 400,


### PR DESCRIPTION
## Why
Next.js 15+ requires route parameters to be accessed asynchronously in App Router API routes. The existing implementation used synchronous parameter access which is deprecated and causes compatibility issues with newer Next.js versions.

## What changed
- Updated `app/api/insights/[id]/feedback/route.ts` to use async params pattern
- Updated `app/api/insights/[id]/reveal/route.ts` to use async params pattern
- Changed from `{ params }: { params: { id: string } }` to `context: { params: Promise<{ id: string }> }`
- Updated parameter access from `params.id` to `await context.params.id`

## How tested
- ✅ Clean npm install and build
- ✅ ESLint passed (no new warnings introduced)
- ✅ TypeScript compilation successful
- ✅ Production build completed successfully
- ✅ All API routes compile correctly with new async pattern

## Technical details
This follows the Next.js App Router migration guide for async route parameters, ensuring compatibility with current and future Next.js versions while maintaining the same API contract for frontend consumers.