### PR TITLE
chore(ci-security): enable Gitleaks secrets scan in CI before build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Run Gitleaks
+      - name: Setup Gitleaks
         uses: gitleaks/gitleaks-action@v2
-        with:
-          args: detect --source=. --no-git -v
-
-  build:
-    name: Typecheck, Lint, and Build
+      - name: Run Gitleaks
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gitleaks detect --source=. --no-git --verbose
+ 
+   build:
+     name: Typecheck, Lint, and Build
     runs-on: ubuntu-latest
     needs: secrets-scan
     env:


### PR DESCRIPTION
Adds a secrets scanning step (Gitleaks) to GitHub Actions, executed before install/build. This helps prevent accidental credential leakage.\n\n- Fails CI on detected secrets\n- Positioned before dependency installation/build\n- Minimal changes to the existing workflow\n\nNo app code changes in this PR.