### PR TITLE
chore(migrations): document duplicate prefixes and add migrations:verify

### DIFF
--- a/scripts/verify-migrations.ts
+++ b/scripts/verify-migrations.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env tsx
+/*
+  scripts/verify-migrations.ts
+  Verifies supabase/migrations filenames and flags duplicate numeric prefixes (e.g., two files starting with 007_...).
+*/
+
+import fs from 'fs'
+import path from 'path'
+
+function main() {
+  const dir = path.resolve(process.cwd(), 'supabase', 'migrations')
+  if (!fs.existsSync(dir)) {
+    console.log('No supabase/migrations directory found. Nothing to verify.')
+    return
+  }
+
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.sql'))
+  const byPrefix = new Map<string, string[]>()
+
+  for (const f of files) {
+    const m = f.match(/^(\d{3,})_/)
+    if (!m) continue
+    const prefix = m[1]
+    const list = byPrefix.get(prefix) || []
+    list.push(f)
+    byPrefix.set(prefix, list)
+  }
+
+  let duplicates = 0
+  for (const [prefix, list] of byPrefix.entries()) {
+    if (list.length > 1) {
+      duplicates++
+      console.warn(`Duplicate prefix ${prefix}:`)
+      for (const f of list.sort()) console.warn(`  - ${f}`)
+    }
+  }
+
+  if (duplicates > 0) {
+    console.warn(`\nFound ${duplicates} duplicate prefix group(s). See supabase/MIGRATIONS.md for guidance.`)
+  } else {
+    console.log('✅ No duplicate migration prefixes found.')
+  }
+}
+
+main()

--- a/supabase/MIGRATIONS.md
+++ b/supabase/MIGRATIONS.md
@@ -1,0 +1,38 @@
+# Supabase Migrations
+
+This project uses timestamp-less, lexicographically ordered SQL migrations in `supabase/migrations`.
+
+Current migration files (in recommended apply order):
+
+1. 001_initial_schema.sql
+2. 002_agent_actions.sql
+3. 003_part_assessments.sql
+4. 004_part_change_proposals.sql
+5. 005_insights.sql
+6. 006_user_memory.sql
+7. 007_check_ins.sql
+8. 007_handle_new_users.sql
+9. 008_add_charge_to_parts.sql
+10. 008_message_feedback.sql
+
+Notes about duplicate numeric prefixes
+- There are two files with the prefix `007_` and two with `008_`.
+- Supabase applies migrations in lexicographic order of the full filename, so the effective order is stable:
+  - `007_check_ins.sql` < `007_handle_new_users.sql`
+  - `008_add_charge_to_parts.sql` < `008_message_feedback.sql`
+- Because these migrations may already be applied in existing environments, do NOT rename these files retroactively.
+
+Bootstrapping a fresh environment
+- The recommended path is to let the Supabase CLI apply the migrations in filename order:
+  - `supabase start`
+  - `supabase db reset` (for a clean slate)
+  - `supabase db migrate`
+- This will apply files in the lexicographic order listed above.
+
+Future clean-up plan (optional)
+- If and when we confirm these migrations are not applied to any shared/long-lived environment, we can re-number to unique prefixes (e.g., `009_`, `010_`) to avoid numeric duplication. Until then, avoid renaming to preserve applied state integrity.
+
+Verification
+- A small script exists to flag duplicate numeric prefixes:
+  - `npm run migrations:verify`
+- It will warn if any numeric prefix (e.g., `007`) is used by multiple files.


### PR DESCRIPTION
Recreates PR #46 from a clean base to avoid a package.json merge conflict.\n\nChanges:\n- Adds supabase/MIGRATIONS.md documenting duplicate numbering and safe remediation guidance\n- Adds npm script migrations:verify and the scripts/verify-migrations.ts helper\n\nNo schema changes; docs + verification tooling only.