### PR TITLE
ci: remove secrets-scan job (no Gitleaks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  secrets-scan:
-    name: Secrets Scan (temporarily disabled)
-    runs-on: ubuntu-latest
-    steps:
-      - name: CI temporarily disabled for secrets scan
-        run: echo "ci temporarily disabled"
-
   build:
     name: Typecheck, Lint, and Build
     runs-on: ubuntu-latest
-    needs: secrets-scan
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}


### PR DESCRIPTION
Removes the secrets-scan job and its dependency from the CI workflow. This eliminates the previously added Gitleaks step.\n\n- Removes the job and the build job's 'needs' dependency\n- No changes to app code