### PR TITLE
ci(security): tune Gitleaks and upload SARIF; docs: pending APP_BASE_URL/CRON_SECRET

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,10 +24,14 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Gitleaks
         uses: gitleaks/gitleaks-action@v2
-      - name: Run Gitleaks
+      - name: Run Gitleaks (with SARIF)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gitleaks detect --source=. --no-git --verbose
+        run: gitleaks detect --source=. --no-git --report-format sarif --report-path gitleaks.sarif --verbose
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif
  
    build:
      name: Typecheck, Lint, and Build

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,17 @@
+title = "IFS Gitleaks Config"
+
+[allowlist]
+paths = [
+  "node_modules/",
+  ".next/",
+  ".mastra/output/",
+  ".obsidian/",
+  "coverage/",
+  "supabase/.temp/"
+]
+
+# Optional: allowlist env VAR NAMES that are public by design (not values)
+# Uncomment if you see false positives on these names
+# regexes = [
+#   '''NEXT_PUBLIC_[A-Z0-9_]+'''
+# ]

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -2,6 +2,13 @@
 
 This document outlines features and improvements that were part of the initial design but have not yet been implemented. They are recorded here for future development cycles.
 
+## 0. Pending Deployment Configuration
+
+- APP_BASE_URL (for scheduled cron): Set to your deployed app’s base URL (e.g. https://your-app.com)
+- CRON_SECRET: Generate a random string; store as Actions secret and in app env so /api/cron endpoints can validate x-cron-key
+- Location to add: GitHub > Settings > Secrets and variables > Actions
+- After deployment, update memory-update-cron.yml secrets accordingly.
+
 ## 1. Implement the `potential_refinements` Table
 
 - **Purpose:** To store AI-generated suggestions for "Part Refinements" that the user has denied.


### PR DESCRIPTION
Adds a tuned Gitleaks config and improves CI visibility:\n\n- .gitleaks.toml: allowlists generated dirs (node_modules, .next, .mastra/output, .obsidian, coverage, supabase/.temp) to reduce false positives\n- CI: uploads SARIF to GitHub Code Scanning and grants security-events: write\n- Docs: adds NEXT_STEPS entry for pending deployment config (APP_BASE_URL, CRON_SECRET)\n\nNo app code changes.