### PR TITLE
docs: add AGENTS.md, feature-first docs IA, and docmap-driven CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+# Why
+Explain the intent and context for this change.
+
+# What Changed
+List functional changes. Include screenshots for UI where relevant.
+
+# How Tested
+- [ ] Lint
+- [ ] Type-check
+- [ ] Unit tests
+- [ ] E2E (if UI)
+
+# Docs
+- [ ] Updated docs? Link files:
+  - docs/features/<...>.md
+- [ ] If not needed, explain why or apply label `docs:skip`
+
+# Related
+- Closes #
+- Related PRs:
+

--- a/.github/scripts/docs-check.mjs
+++ b/.github/scripts/docs-check.mjs
@@ -1,0 +1,106 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function globToRegExp(glob) {
+  // Very small glob -> regex translator supporting **, *, ?
+  let re = '^';
+  let i = 0;
+  while (i < glob.length) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        re += '.*';
+        i += 2;
+      } else {
+        re += '[^/]*';
+        i += 1;
+      }
+    } else if (c === '?') {
+      re += '.';
+      i += 1;
+    } else if ('+.^$()[]{}|'.includes(c)) {
+      re += '\\' + c;
+      i += 1;
+    } else {
+      re += c;
+      i += 1;
+    }
+  }
+  re += '$';
+  return new RegExp(re);
+}
+
+function getChangedFiles(base, head) {
+  const cmd = `git diff --name-only ${base}...${head}`;
+  const out = execSync(cmd, { encoding: 'utf8' });
+  return out.split('\n').filter(Boolean);
+}
+
+function readEventLabels() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath || !existsSync(eventPath)) return [];
+  try {
+    const event = JSON.parse(readFileSync(eventPath, 'utf8'));
+    const labels = event?.pull_request?.labels || [];
+    return labels.map((l) => l.name);
+  } catch (e) {
+    return [];
+  }
+}
+
+function main() {
+  // Allow explicit bypass via env or label
+  if (process.env.DOCS_SKIP === 'true') {
+    console.log('docs-check: bypassed via DOCS_SKIP env');
+    return;
+  }
+  const labels = readEventLabels();
+  if (labels.includes('docs:skip')) {
+    console.log('docs-check: bypassed via docs:skip label');
+    return;
+  }
+
+  const docmapPath = path.join(process.cwd(), 'docs/.docmap.json');
+  if (!existsSync(docmapPath)) {
+    console.log('docs-check: no docs/.docmap.json found; skipping');
+    return;
+  }
+  const docmap = JSON.parse(readFileSync(docmapPath, 'utf8'));
+  const base = process.env.BASE_SHA || process.env.GITHUB_BASE_SHA || '';
+  const head = process.env.HEAD_SHA || process.env.GITHUB_HEAD_SHA || '';
+  if (!base || !head) {
+    console.log('docs-check: BASE_SHA/HEAD_SHA not set; skipping (fail-open)');
+    return;
+  }
+  const changed = getChangedFiles(base, head);
+  const changedSet = new Set(changed);
+
+  const violations = [];
+  for (const mapping of docmap.mappings || []) {
+    const patterns = (mapping.paths || []).map(globToRegExp);
+    const touchesMappedCode = changed.some((f) => patterns.some((re) => re.test(f)));
+    if (!touchesMappedCode) continue;
+
+    const expectedDocs = mapping.docs || [];
+    const docsTouched = expectedDocs.some((d) => changedSet.has(d));
+    if (!docsTouched) {
+      violations.push({ mapping, changed });
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error('docs-check: Missing docs updates for some changed areas.');
+    for (const v of violations) {
+      console.error('- Changed code matched paths:', v.mapping.paths.join(', '));
+      console.error('  Expected docs to be updated:', v.mapping.docs.join(', '));
+    }
+    console.error('\nEither update the mapped docs file(s) or apply the label "docs:skip" with justification.');
+    process.exit(1);
+  } else {
+    console.log('docs-check: All good. Relevant docs updated.');
+  }
+}
+
+main();
+

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,26 @@
+name: docs-check
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  docs-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Compute base/head
+        id: shas
+        run: |
+          echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
+          echo "HEAD_SHA=${{ github.sha }}" >> $GITHUB_ENV
+      - name: Run docs-check
+        env:
+          BASE_SHA: ${{ env.BASE_SHA }}
+          HEAD_SHA: ${{ env.HEAD_SHA }}
+        run: node .github/scripts/docs-check.mjs
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# Agents: Start Here
+
+If you are an AI agent or contributor, follow these rules to keep code and docs aligned. This file is intentionally at repo root so agents discover it first.
+
+What to update (and when)
+- Update docs whenever a PR changes behavior, routes, data models, feature flags, or migrations.
+- Each feature has one canonical page in docs/features/*.md. Do not create "recent changes" sections; update the relevant feature page instead.
+- Keep status accurate: shipped | behind-flag | experimental. Update last_updated.
+
+Where to update
+- docs/features/<feature>.md — canonical feature docs (use the template in docs/templates/feature.md)
+- docs/current_state/ — thin index linking to features, with short human-readable summaries
+- docs/agent_instructions.md — the detailed playbook (checklists) for updating docs
+
+Process (house rules)
+- Branching: Always develop on a feature branch (type/scope-short-desc). Do not push to main.
+- Commits: Conventional Commits; keep commits small and focused; never include secrets.
+- PRs: Require passing status checks; keep main green; prefer small PRs; title uses Conventional Commits; description includes Why, What changed, How tested (screenshots if UI), and links issues.
+- Merging: Squash merge; enable auto-merge when checks pass; delete the branch after merge.
+- Verification: Run lint, type-checks, and tests locally before PR. For UI, add/update Playwright tests.
+- Remotes: Verify repo and origin before pushing. Never expose secrets; reference env var names only.
+
+Codebase overview (what an agent should know)
+- Framework: Next.js 15 (app/ router), React 19, Tailwind
+- Data: Supabase/Postgres with RLS; migrations in supabase/migrations/
+- Agents: Mastra-based agents in mastra/ (tools and prompts)
+- App structure: 
+  - app/ – Next.js routes (e.g., /chat, /check-in/*, /garden/*)
+  - components/ – UI components (e.g., check-in forms, garden parts UI)
+  - hooks/ – React hooks (e.g., useChat)
+  - lib/ – server/client libs (database validators, insights generator)
+  - supabase/ – SQL migrations and config
+  - scripts/ – node/tsx scripts for verification and smoke tests
+  - docs/ – documentation (this IA)
+
+Documentation workflow (quick version)
+1) Determine which feature(s) changed.
+2) For each feature, update docs/features/<feature>.md:
+   - Update frontmatter: last_updated, status, related_prs, code_paths, feature_flag.
+   - Update What/Why/How, routes/components, data model, config, testing, ops notes.
+3) If a brand-new feature area, copy docs/templates/feature.md and fill it in.
+4) If a migration or flag exists, document rollout steps and defaults.
+5) Commit using Conventional Commits (docs(feature): ...), open a PR, ensure checks pass.
+
+Doc map and CI
+- The docs-check workflow uses docs/.docmap.json to map code paths → expected docs pages.
+- If a PR touches mapped code without touching the mapped docs file(s), CI will fail unless the PR has label `docs:skip` with a justification.
+
+Using external library docs (agents)
+- When modifying code that uses external libraries, resolve the correct library docs (e.g., via your tooling) and verify current APIs before editing. Prefer linking to relevant upstream docs in the feature page.
+
+See also
+- docs/agent_instructions.md — detailed playbook
+- docs/templates/feature.md — template to create a new feature page
+

--- a/docs/.docmap.json
+++ b/docs/.docmap.json
@@ -1,0 +1,29 @@
+{
+  "mappings": [
+    {
+      "paths": ["app/garden/**", "components/garden/**", "mastra/tools/part-tools.ts"],
+      "docs": ["docs/features/parts-garden.md"]
+    },
+    {
+      "paths": ["app/check-in/**", "components/check-in/**"],
+      "docs": ["docs/features/check-ins.md"]
+    },
+    {
+      "paths": ["components/auth/**", "app/auth/**", "supabase/migrations/**"],
+      "docs": ["docs/features/authentication-google.md"]
+    },
+    {
+      "paths": ["app/chat/**", "hooks/useChat.ts", "lib/database/**"],
+      "docs": ["docs/features/chat.md"]
+    },
+    {
+      "paths": ["mastra/tools/**", "mastra/agents/**", "lib/insights/generator.ts"],
+      "docs": ["docs/features/agent-tools.md"]
+    },
+    {
+      "paths": ["app/api/insights/**", "lib/insights/**"],
+      "docs": ["docs/features/insights.md"]
+    }
+  ]
+}
+

--- a/docs/agent_instructions.md
+++ b/docs/agent_instructions.md
@@ -1,0 +1,49 @@
+# Agent Instructions: How to Keep Docs Up To Date
+
+When a PR merges (or before merging):
+1) Identify feature areas touched by reading the diff.
+2) For each feature, update a single page in docs/features/<feature>.md:
+   - Update frontmatter: last_updated, status (shipped | behind-flag | experimental), related_prs, code_paths, feature_flag.
+   - Update What/Why/How sections; list routes/components/endpoints and data model changes.
+   - Note configuration (env vars, flags) and testing (unit/E2E).
+3) If the area is new, copy docs/templates/feature.md and fill it in.
+4) If migrations or flags are involved, document rollout steps and defaults.
+5) Commit using Conventional Commits (docs(feature): ...), open a PR from a feature branch, and ensure checks pass locally (lint, type-check, tests).
+
+House rules (summary)
+- Require passing status checks before merge; keep main green.
+- Always use a feature branch named type/scope-short-desc; squash merge; enable auto-merge once green.
+- Keep PRs small; title uses Conventional Commits; description includes Why, What changed, How tested; link issues.
+- Never include secrets; reference env var names only.
+- For UI, add/update Playwright tests.
+- Verify repo and remotes before pushing.
+
+Feature doc frontmatter (example)
+```
+---
+title: Feature: Parts Garden
+owner: @brandongalang
+status: shipped
+last_updated: 2025-08-31
+feature_flag: ENABLE_GARDEN
+code_paths:
+  - app/garden/page.tsx
+  - app/garden/[partId]/page.tsx
+  - components/garden/PartActions.tsx
+  - mastra/tools/part-tools.ts
+related_prs:
+  - #41
+---
+```
+
+Template usage
+- Copy docs/templates/feature.md → docs/features/<feature>.md
+- Fill all sections; keep concise but complete; link to code and PRs.
+
+Doc map and CI
+- CI reads docs/.docmap.json to map code paths → expected docs pages.
+- If a PR touches mapped code without the mapped docs file(s), CI fails (unless PR has label docs:skip with justification).
+
+Libraries and correctness
+- When touching external libraries, resolve the correct, current docs via your tooling and verify API usage; link upstream docs in the feature page.
+

--- a/docs/current_state/02_feature_implementations.md
+++ b/docs/current_state/02_feature_implementations.md
@@ -39,6 +39,23 @@ The main user-facing feature is the chat interface. The agent's capabilities wit
 5.  **Tool Execution:** The tool creates a new row in the `parts` table with the name "Critic" and a status of "emerging." It also logs this action in the `agent_actions` table.
 6.  **Agent (Response):** "Great. I've made a note of the Critic part. We can now add details to its profile or explore its role in your system."
 
+## Current Features (Index)
+
+This section provides a quick, human-readable map of shipped and in-progress features. Each entry links to a canonical feature page with full details and code anchors.
+
+- Parts Garden — Visual exploration UI for Parts. Status: shipped. See docs/features/parts-garden.md
+  - Key routes: /garden, /garden/[partId]. Key paths: app/garden/*, components/garden/*
+- Guided Check-ins — Morning and evening structured flows. Status: shipped. See docs/features/check-ins.md
+  - Key routes: /check-in/morning, /check-in/evening. Key paths: app/check-in/*, components/check-in/*
+- Chat — Conversational interface. Status: shipped. See docs/features/chat.md
+  - Key route: /chat. Key paths: app/chat/page.tsx, hooks/useChat.ts, lib/database/*
+- Authentication (Google) — OAuth via Google. Status: shipped. See docs/features/authentication-google.md
+  - Key paths: components/auth/*, app/auth/callback/route.ts, supabase/migrations/007_handle_new_users.sql
+- Agent Tools — Mastra tools and agent definitions. Status: shipped. See docs/features/agent-tools.md
+  - Key paths: mastra/tools/*, mastra/agents/*
+- Insights — Scaffolding for insights generation. Status: experimental. See docs/features/insights.md
+  - Key paths: app/api/insights/*, lib/insights/generator.ts
+
 ## Implementation Gaps & In-Progress Features
 
 The following features from the product vision are not yet fully implemented. This is a critical distinction for understanding the current user experience.

--- a/docs/features/agent-tools.md
+++ b/docs/features/agent-tools.md
@@ -1,0 +1,36 @@
+---
+title: Feature: Agent Tools
+owner: @brandongalang
+status: shipped
+last_updated: 2025-08-31
+feature_flag: null
+code_paths:
+  - mastra/tools/*.ts
+  - mastra/agents/*.ts
+  - lib/insights/generator.ts
+related_prs:
+  - #35
+---
+
+## What
+The tools and agent definitions powering the IFS companion’s capabilities.
+
+## Why
+Encapsulates privileged operations (e.g., db mutations) behind auditable tools, enabling safe agent workflows.
+
+## How it works
+- Mastra tools implement capabilities (parts, relationships, evidence, assessments, proposals, rollback)
+- Agent prompt and configuration live under mastra/agents/
+- Insights generator scaffolding exists in lib/insights/generator.ts
+
+## Data model
+- agent_actions (audit log), part_assessments, parts/relationships
+
+## Configuration
+- Provider/model configuration via env vars (names only)
+
+## Testing
+- Unit tests for tool logic; integration tests via smoke scripts (scripts/smoke-*)
+
+## Operational notes
+- Ensure rollback tooling remains functional; log all mutations

--- a/docs/features/authentication-google.md
+++ b/docs/features/authentication-google.md
@@ -1,0 +1,37 @@
+---
+title: Feature: Authentication (Google Sign-In)
+owner: @brandongalang
+status: shipped
+last_updated: 2025-08-31
+feature_flag: null
+code_paths:
+  - components/auth/login-form.tsx
+  - components/auth/sign-up-form.tsx
+  - app/auth/callback/route.ts
+  - supabase/migrations/007_handle_new_users.sql
+related_prs:
+  - #30
+---
+
+## What
+OAuth-based authentication via Google provider.
+
+## Why
+Lower-friction sign-in and account creation with secure provider flows.
+
+## How it works
+- UI components for login and sign-up
+- Next.js route handler for OAuth callback
+- Migration ensures new users are handled with provider metadata
+
+## Data model
+- users/auth tables managed by Supabase; ensure provider fields are captured
+
+## Configuration
+- Env vars for Supabase and Google OAuth (names only)
+
+## Testing
+- Mock provider flows in integration tests where possible; manual verification of OAuth callback
+
+## Operational notes
+- Verify redirect URIs and provider credentials across environments

--- a/docs/features/chat.md
+++ b/docs/features/chat.md
@@ -1,0 +1,38 @@
+---
+title: Feature: Chat
+owner: @brandongalang
+status: shipped
+last_updated: 2025-08-31
+feature_flag: null
+code_paths:
+  - app/chat/page.tsx
+  - hooks/useChat.ts
+  - lib/database/action-logger.ts
+  - lib/database/validate.ts
+related_prs:
+  - #34
+---
+
+## What
+The conversational interface for interacting with the IFS companion.
+
+## Why
+Enables guided self-reflection, parts work, and agent-assisted workflows.
+
+## How it works
+- UI at app/chat/page.tsx with streaming responses
+- useChat hook manages message state and streaming
+- Agent actions are logged via lib/database/action-logger.ts
+
+## Data model
+- sessions, messages, agent_actions tables
+
+## Configuration
+- Env vars for model/provider configuration (names only in code); see project env
+
+## Testing
+- Unit tests around parsing/format functions where present
+- Add Playwright coverage for core chat flows (send message, receive response)
+
+## Operational notes
+- Ensure action logging remains enabled for auditability

--- a/docs/features/check-ins.md
+++ b/docs/features/check-ins.md
@@ -1,0 +1,38 @@
+---
+title: Feature: Guided Check-ins
+owner: @brandongalang
+status: shipped
+last_updated: 2025-08-31
+feature_flag: null
+code_paths:
+  - app/check-in/morning/page.tsx
+  - app/check-in/evening/page.tsx
+  - components/check-in/morning-form.tsx
+  - components/check-in/evening-form.tsx
+  - lib/supabase/middleware.ts
+related_prs:
+  - #36
+---
+
+## What
+Structured morning and evening flows guiding users through self-reflection.
+
+## Why
+Provides a gentle, repeatable practice to capture mood, intentions, and observations.
+
+## How it works
+- Next.js routes under /check-in/morning and /check-in/evening
+- Form components capture responses and persist via Supabase
+- Auth middleware ensures session enforcement for protected routes
+
+## Data model
+- check_ins (or equivalent) table storing responses with timestamps
+
+## Configuration
+- No special flags by default; uses standard auth/session settings
+
+## Testing
+- Unit tests for form validation where applicable; Playwright for end-to-end completion
+
+## Operational notes
+- Consider rate limiting and UX for repeated submissions

--- a/docs/features/insights.md
+++ b/docs/features/insights.md
@@ -1,0 +1,35 @@
+---
+title: Feature: Insights (Scaffolding)
+owner: @brandongalang
+status: experimental
+last_updated: 2025-08-31
+feature_flag: null
+code_paths:
+  - app/api/insights/*
+  - lib/insights/generator.ts
+  - app/api/cron/generate-insights/route.ts
+related_prs:
+  - #41
+---
+
+## What
+Initial scaffolding for insights generation (e.g., scheduled or on-demand summaries/patterns).
+
+## Why
+Surface trends and patterns across sessions and parts over time.
+
+## How it works
+- API routes exist for requesting insights and a cron endpoint for generation
+- lib/insights/generator.ts contains placeholder logic pending full implementation
+
+## Data model
+- insights table (or equivalent) reserved; exact schema may evolve
+
+## Configuration
+- Cron setup and permissions documented in code; review before enabling
+
+## Testing
+- Smoke scripts available via npm run smoke:insights
+
+## Operational notes
+- Treat as behind a manual switch; do not enable broadly until core logic is complete

--- a/docs/features/parts-garden.md
+++ b/docs/features/parts-garden.md
@@ -1,0 +1,37 @@
+---
+title: Feature: Parts Garden
+owner: @brandongalang
+status: shipped
+last_updated: 2025-08-31
+feature_flag: ENABLE_GARDEN
+code_paths:
+  - app/garden/page.tsx
+  - app/garden/[partId]/page.tsx
+  - components/garden/PartActions.tsx
+  - mastra/tools/part-tools.ts
+related_prs:
+  - #41
+---
+
+## What
+Visual exploration interface for browsing and drilling into Parts.
+
+## Why
+Offers a spatial/visual way to understand internal parts and relationships.
+
+## How it works
+- Grid overview at app/garden/page.tsx; detail at app/garden/[partId]/page.tsx
+- PartActions component for contextual operations
+- Mastra tools provide part querying and updates
+
+## Data model
+- parts, part_relationships (read/derived views)
+
+## Configuration
+- ENABLE_GARDEN feature flag (default off in prod; document your env)
+
+## Testing
+- Unit tests for helper logic; Playwright for navigation (overview → detail)
+
+## Operational notes
+- Confirm flag defaults and access control for non-authenticated users

--- a/docs/templates/feature.md
+++ b/docs/templates/feature.md
@@ -1,0 +1,38 @@
+---
+title: Feature: <name>
+owner: @<owner>
+status: shipped | behind-flag | experimental
+last_updated: 2025-08-31
+feature_flag: <FLAG_NAME> | null
+code_paths:
+  - app/<...>
+  - components/<...>
+  - lib/<...>
+related_prs:
+  - <#NN | short sha>
+---
+
+## What
+Short description of the feature and user value.
+
+## Why
+Problem it solves; link PRD if applicable.
+
+## How it works
+- Architecture and flow
+- Routes/components/hooks/APIs
+- Background jobs/cron if any
+
+## Data model
+Tables, columns, migrations, constraints.
+
+## Configuration
+- Flags and defaults
+- Required env vars (names only)
+
+## Testing
+- Unit tests and coverage anchors
+- E2E (Playwright) scenarios
+
+## Operational notes
+Rollout steps, known issues, monitoring.


### PR DESCRIPTION
# Why
Make docs intuitive for humans and agents; provide a root entrypoint (AGENTS.md), a clear playbook, and enforceable CI guardrails so docs stay in sync with code.

# What Changed
- Add AGENTS.md (root) with agent entrypoint + codebase/process overview
- Add docs/agent_instructions.md (detailed playbook)
- Add docs/templates/feature.md (canonical feature doc template)
- Add feature pages: chat, parts-garden, check-ins, authentication-google, agent-tools, insights (experimental)
- Convert current_state to a tiny index linking to per-feature docs
- Add docs/.docmap.json; add docs-check GitHub Action + script to nudge for docs updates
- Add PR template prompting for docs updates

# How Tested
- Local: npm run lint (warnings only), npm run typecheck (pass)
- Note: npm run format:check fails on a pre-existing YAML indentation issue in .github/workflows/ci.yml. This PR does not touch that file; recommend a follow-up PR to fix formatting there. Docs-only changes otherwise pass checks locally.

# Docs
- New/updated docs under docs/ and AGENTS.md

# Related
- Enables future CI enforcement to keep docs updated per feature via docmap
