### PR TITLE
fix(chat): restore Ethereal streaming by awaiting agent streams and adapting UI message SSE

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -42,7 +42,7 @@ const { createIfsAgent } = await import('../../../mastra/agents/ifs-agent')
       }>
       let stream: unknown = null
       if (typeof agent.streamVNext === 'function') {
-        const vNext = agent.streamVNext(messages, { format: 'aisdk' }) as unknown
+        const vNext = await (agent.streamVNext(messages, { format: 'aisdk' }) as unknown)
         stream = vNext
         if (
           vNext && typeof (vNext as { toUIMessageStreamResponse?: unknown }).toUIMessageStreamResponse === 'function'
@@ -52,7 +52,7 @@ const { createIfsAgent } = await import('../../../mastra/agents/ifs-agent')
       }
       // Fallback to v2 streaming
       if (!stream && typeof agent.stream === 'function') {
-        const v2 = agent.stream(messages) as unknown
+        const v2 = await (agent.stream(messages) as unknown)
         if (v2 && typeof (v2 as { toDataStreamResponse?: unknown }).toDataStreamResponse === 'function') {
           return (v2 as { toDataStreamResponse: () => Response }).toDataStreamResponse()
         }


### PR DESCRIPTION
Why\n- /chat/ethereal showed fallback: 'Hello! (fallback)\nAgent returned unsupported stream shape.'\n- Root cause: app/api/chat/route.ts invoked agent.streamVNext(...) and agent.stream(...) without awaiting the returned thenables, so the adaptation layer received a Promise (no toUIMessageStreamResponse/toDataStreamResponse methods) and fell through to the fallback.\n\nWhat changed\n- app/api/chat/route.ts: await agent.streamVNext(messages, { format: 'aisdk' }) and agent.stream(messages).\n- Prefer UI message stream response (toUIMessageStreamResponse) when available.\n- Fallback to v2 data stream (toDataStreamResponse) or readable stream response when needed.\n- Preserved existing dev fallback path when OPENROUTER_API_KEY is missing.\n\nHow tested\n- Ran type-checks and lint locally; unit tests pass.\n- Built locally after setting placeholder NEXT_PUBLIC_SUPABASE_* to satisfy auth build-time requirements (no app code changes for auth).\n- Server route now returns proper stream objects; UI client expects SSE 'data:' events for vNext, which the route now returns when available.\n\nNotes\n- No secrets added/changed.\n- Once merged, consider enabling auto-merge (squash) when checks pass to keep main linear.