### PR TITLE
feat(memory): behind flag, write/append snapshots on part/relationship changes and log events

### DIFF
--- a/lib/memory/snapshots/fs-helpers.ts
+++ b/lib/memory/snapshots/fs-helpers.ts
@@ -17,3 +17,7 @@ export function userOverviewPath(userId: string) {
   return `users/${userId}/overview.md`
 }
 
+export function relationshipProfilePath(userId: string, relId: string) {
+  return `users/${userId}/relationships/${relId}/profile.md`
+}
+

--- a/lib/memory/snapshots/grammar.ts
+++ b/lib/memory/snapshots/grammar.ts
@@ -4,6 +4,11 @@ export type SnapshotType = 'user_overview' | 'part_profile'
 
 export function buildUserOverviewMarkdown(userId: string): string {
   const content = `# User Overview\n\n## Identity\n[//]: # (anchor: identity v1)\n\n- User ID: ${userId}\n\n## Current Focus\n[//]: # (anchor: current_focus v1)\n\n- TBD\n\n## Confirmed Parts\n[//]: # (anchor: confirmed_parts v1)\n\n- TBD\n\n## Change Log\n[//]: # (anchor: change_log v1)\n\n- ${new Date().toISOString()}: initialized overview\n`
+return canonicalizeText(content)
+}
+
+export function buildRelationshipProfileMarkdown(params: { userId: string; relId: string; type: string }): string {
+  const content = `# Relationship\n\n## Participants\n[//]: # (anchor: participants v1)\n\n- TBD\n\n## Type\n[//]: # (anchor: type v1)\n\n- ${params.type}\n\n## Dynamics\n[//]: # (anchor: dynamics v1)\n\n- TBD\n\n## Change Log\n[//]: # (anchor: change_log v1)\n\n- ${new Date().toISOString()}: initialized relationship profile\n`
   return canonicalizeText(content)
 }
 


### PR DESCRIPTION
Why
- Continue Memory v2 rollout: record change log lines in markdown snapshots for parts/relationships and log to events with before/after hashes — all behind MEMORY_AGENTIC_V2_ENABLED.

What changed
- Grammar/paths: relationship profile path + minimal template.
- Updater: ensureRelationshipProfileExists, onRelationshipLogged; appendChangeLogWithEvent logs events.
- Integration: part-tools.ts calls onPartCreated/onPartUpdated and onRelationshipLogged behind the flag.

How tested
- Local: ran snapshots scaffold and md smoke locally, then simulated create/update paths (manual calls) to verify change log appends.
- Event logging validated earlier with smoke-memory-v2; this path uses the same logger.

Notes
- No agent read-path changes; only snapshot writes behind flag.
- Safe to enable flag on internal cohorts first.