### PR TITLE
feat(memory): finalize Memory v2 cutover (default on, no backfill)

### DIFF
--- a/docs/memory-cutover.md
+++ b/docs/memory-cutover.md
@@ -1,0 +1,21 @@
+# Memory v2 Cutover (No Backfill)
+
+We intentionally cut over to Memory v2 without backfilling historical snapshots.
+
+What this means
+- Snapshots (overview, part profiles, relationship profiles) begin at the cutover date.
+- Historical narrative prior to the cutover won’t be present in file-first snapshots.
+- Structured event logging (events ledger) is the source of truth going forward.
+
+Why we chose this
+- Simplicity and speed: avoids a large, error-prone backfill.
+- Clear separation from legacy constructs.
+
+Operational notes
+- Feature flag: MEMORY_AGENTIC_V2_ENABLED defaults ON. You can still explicitly disable it (0/false/no) for one release window if needed.
+- Observability: snapshot hit/miss/error rates and latency are logged (see memory-observability.md).
+- First reads may show “miss” until snapshots are created or updated; this is expected and non-fatal.
+
+If you later want history
+- You can implement an on-demand backfill for a specific user/part/relationship, or a batch backfill script, but this is not required for normal operation.
+

--- a/docs/memory-observability.md
+++ b/docs/memory-observability.md
@@ -1,0 +1,52 @@
+# Memory v2 Observability and Guardrails
+
+This page explains how we observe and debug Memory v2 snapshot reads, and what to do if something fails.
+
+What is logged
+- Structured JSON lines to stdout with tag MemoryV2 and event snapshot_usage.
+- Fields:
+  - ts: ISO timestamp
+  - kind: overview | part_profile | relationship_profile
+  - status: hit | miss | error
+  - latency_ms: optional timing for the read
+  - user_id, part_id, rel_id: when applicable
+  - error: string when an exception occurs
+
+Where logs are emitted
+- lib/data/parts.ts when MEMORY_AGENTIC_V2_ENABLED=1 and snapshot reads are attempted:
+  - getPartById: logs part_profile hit/miss/error
+  - getPartDetail: logs overview and part_profile; logs each relationship_profile
+  - getPartRelationships: logs each relationship_profile
+
+How to view
+- Locally: run any flow that calls the above functions, then grep the dev server logs:
+  - grep -F '"tag":"MemoryV2"' .next/server/logs/*  (or your process logs)
+- In CI or production: ship stdout to your log sink and filter tag=MemoryV2.
+
+Interpreting
+- hit: snapshot file exists and was parsed into a section map
+- miss: snapshot file not found or empty (non-fatal; system continues)
+- error: exception during read/parse; check error field and upstream adapter config (paths, bucket, permissions)
+
+Runbook: common issues
+1) Misses across the board
+- Likely snapshots were not scaffolded yet. Run the scaffold script to create baseline snapshots and retry.
+
+2) Errors for relationship_profile only
+- Some relationships may lack profiles; this is expected early in rollout. Consider backfilling or letting usage create them over time.
+
+3) Access errors with Supabase adapter
+- Verify: SUPABASE_* envs loaded, storage bucket memory-snapshots exists, policies allow service role writes and appropriate reads.
+
+4) Grammar/lint errors
+- Use the md linter and editor helpers to auto-fix anchors/headers; re-run the scaffold.
+
+KPIs to watch
+- Snapshot hit rate (per kind)
+- Read latency (p95)
+- Error rate < 1%
+
+Notes
+- Observability is best-effort and never blocks user flows.
+- Keep feature usage behind MEMORY_AGENTIC_V2_ENABLED until metrics look healthy.
+

--- a/lib/memory/config.ts
+++ b/lib/memory/config.ts
@@ -8,9 +8,13 @@ export function getStorageMode(): 'local' | 'supabase' {
 }
 
 // Feature flag helper for Memory v2 rollout
-// Enabled when MEMORY_AGENTIC_V2_ENABLED is a truthy value like: '1', 'true', 'yes'
+// Defaults to enabled unless explicitly disabled with '0', 'false', or 'no'.
 export function isMemoryV2Enabled(): boolean {
-  const val = (process.env.MEMORY_AGENTIC_V2_ENABLED || '').toString().trim().toLowerCase()
-  return val === '1' || val === 'true' || val === 'yes'
+  const raw = process.env.MEMORY_AGENTIC_V2_ENABLED
+  const val = (raw ?? '').toString().trim().toLowerCase()
+  if (!val) return true
+  if (val === '0' || val === 'false' || val === 'no') return false
+  // Any other value (including '1','true','yes') enables
+  return true
 }
 

--- a/lib/memory/observability.ts
+++ b/lib/memory/observability.ts
@@ -1,0 +1,42 @@
+// Lightweight observability helpers for Memory v2 snapshot usage.
+// This avoids adding dependencies; logs are structured JSON lines for easy grep or log shipping.
+
+export type SnapshotKind = 'overview' | 'part_profile' | 'relationship_profile'
+export type SnapshotStatus = 'hit' | 'miss' | 'error'
+
+function nowIso() {
+  try { return new Date().toISOString() } catch { return '' }
+}
+
+function toNumber(n: unknown): number | undefined {
+  const v = typeof n === 'number' ? n : Number(n)
+  return Number.isFinite(v) ? v : undefined
+}
+
+export function recordSnapshotUsage(kind: SnapshotKind, status: SnapshotStatus, extra?: {
+  latencyMs?: number
+  userId?: string
+  partId?: string
+  relId?: string
+  error?: unknown
+}) {
+  try {
+    const line = {
+      ts: nowIso(),
+      tag: 'MemoryV2',
+      event: 'snapshot_usage',
+      kind,
+      status,
+      latency_ms: toNumber(extra?.latencyMs),
+      user_id: extra?.userId,
+      part_id: extra?.partId,
+      rel_id: extra?.relId,
+      error: extra?.error ? String((extra.error as any)?.message || extra.error) : undefined,
+    }
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(line))
+  } catch {
+    // best effort
+  }
+}
+

--- a/mastra/tools/part-tools.ts
+++ b/mastra/tools/part-tools.ts
@@ -807,7 +807,7 @@ if (!dev.disablePolarizationUpdate) {
       // Always bump updated_at
       (updates as any).updated_at = nowIso
 
-      // Dev bypass with service role to avoid RLS, and manual action log
+      // Dev bypass with service role to avoid RLS (no legacy agent_actions logging)
       const serviceRole = getEnvVar(['SUPABASE_SERVICE_ROLE_KEY'])
 if (typeof window === 'undefined' && dev.enabled && serviceRole) {
         try {
@@ -822,22 +822,6 @@ if (typeof window === 'undefined' && dev.enabled && serviceRole) {
           if (updErr || !updatedDirect) {
             return { success: false, error: `Failed to update relationship (service role): ${updErr?.message || 'unknown'}` }
           }
-
-          await supabase.from('agent_actions').insert({
-            user_id: userId,
-            action_type: 'update_relationship',
-            target_table: 'part_relationships',
-            target_id: existing.id,
-            old_state: existing,
-            new_state: updatedDirect,
-            metadata: {
-              changeDescription: dyn ? `Appended dynamic: ${dyn.observation.substring(0, 60)}...` : 'Updated relationship fields',
-              polarizationDelta,
-              type: validated.type,
-              partIds
-            },
-            created_by: 'agent'
-          })
 
           return { success: true, data: updatedDirect as any, confidence: 1.0 }
         } catch (e: any) {
@@ -895,7 +879,7 @@ if (typeof window === 'undefined' && dev.enabled && serviceRole) {
       updated_at: nowIso
     }
 
-    // Dev bypass with service role to avoid RLS, and manual action log
+    // Dev bypass with service role to avoid RLS (no legacy agent_actions logging)
     const serviceRoleCreate = getEnvVar(['SUPABASE_SERVICE_ROLE_KEY'])
 if (typeof window === 'undefined' && dev.enabled && serviceRoleCreate) {
       const { data: createdDirect, error: insErr } = await supabase
@@ -906,21 +890,6 @@ if (typeof window === 'undefined' && dev.enabled && serviceRoleCreate) {
       if (insErr || !createdDirect) {
         return { success: false, error: `Failed to create relationship (service role): ${insErr?.message || 'unknown'}` }
       }
-
-      await supabase.from('agent_actions').insert({
-        user_id: userId,
-        action_type: 'create_relationship',
-        target_table: 'part_relationships',
-        target_id: createdDirect.id,
-        old_state: null,
-        new_state: createdDirect,
-        metadata: {
-          changeDescription: `Created ${validated.type} relationship between parts`,
-          type: validated.type,
-          partIds
-        },
-        created_by: 'agent'
-      })
 
       return { success: true, data: createdDirect as any, confidence: 1.0 }
     }


### PR DESCRIPTION
Why\n- Clean cutover to Memory v2 without backfill (Option A). Simplifies system and removes legacy coupling while retaining a one-release kill-switch.\n\nWhat changed\n- Default MEMORY_AGENTIC_V2_ENABLED to ON by default (explicit 0/false/no disables).\n- Remove legacy dev-bypass writes to agent_actions (table dropped); rely on events-logger / standard paths.\n- Add docs/memory-cutover.md clarifying no-backfill-by-design behavior.\n\nHow tested\n- Typecheck/lint/tests green locally.\n- Local snapshots cleared for a fresh sanity pass; code handles initial "miss" reads gracefully.\n\nNotes\n- Flag remains for one release; can be removed in the subsequent release once green.