### PR TITLE
feat: add user context for profile

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@/components/theme-provider'
 import { ComingSoonProvider } from '@/components/common/ComingSoonProvider'
 import { GlobalBackdrop } from '@/components/ethereal/GlobalBackdrop'
 import { ThemeController } from '@/components/ethereal/ThemeController'
+import { UserProvider } from '@/context/UserContext'
 
 export const metadata: Metadata = {
   title: 'IFS Therapy Companion',
@@ -20,10 +21,12 @@ export default function RootLayout({
       <body className="bg-background text-foreground">
         <ThemeProvider>
           <ComingSoonProvider>
-            {/* Global ethereal backdrop & theme controller */}
-            <GlobalBackdrop />
-            <ThemeController />
-            {children}
+            <UserProvider>
+              {/* Global ethereal backdrop & theme controller */}
+              <GlobalBackdrop />
+              <ThemeController />
+              {children}
+            </UserProvider>
           </ComingSoonProvider>
         </ThemeProvider>
       </body>

--- a/context/UserContext.tsx
+++ b/context/UserContext.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+import { createClient } from '@/lib/supabase/client'
+
+interface Profile {
+  id: string
+  name: string
+  bio: string
+}
+
+interface UserContextValue {
+  profile: Profile | null
+  loading: boolean
+}
+
+const UserContext = createContext<UserContextValue | undefined>(undefined)
+
+export function UserProvider({ children }: { children: ReactNode }) {
+  const supabase = createClient()
+  const [profile, setProfile] = useState<Profile | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      setLoading(true)
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (user) {
+        const { data } = await supabase
+          .from('users')
+          .select('name, bio')
+          .eq('id', user.id)
+          .single()
+        setProfile({
+          id: user.id,
+          name: data?.name || '',
+          bio: data?.bio || '',
+        })
+      } else {
+        setProfile(null)
+      }
+      setLoading(false)
+    }
+    fetchProfile()
+  }, [supabase])
+
+  return (
+    <UserContext.Provider value={{ profile, loading }}>
+      {children}
+    </UserContext.Provider>
+  )
+}
+
+export function useUser() {
+  const context = useContext(UserContext)
+  if (context === undefined) {
+    throw new Error('useUser must be used within a UserProvider')
+  }
+  return context
+}
+

--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { useUser } from '@/context/UserContext'
 import { useSearchParams } from 'next/navigation'
 import { Message, ChatState, TaskEvent } from '@/types/chat';
 import { getPartById } from '@/lib/data/parts-lite'
@@ -11,6 +12,7 @@ import { useToast } from './use-toast';
 
 export function useChat() {
   const searchParams = useSearchParams()
+  const { profile } = useUser()
   const [state, setState] = useState<ChatState>({
     messages: [],
     isStreaming: false,
@@ -20,25 +22,6 @@ export function useChat() {
     hasActiveSession: false,
     tasksByMessage: {},
   } as any);
-
-  // #region Proposing Next Steps for Full Integration
-  // In a real app, this profile data would not be managed by local state here.
-  // Instead, it would be provided by a global UserContext or a similar state management solution (like Zustand or Redux).
-  // This would ensure that the profile data is consistent across the application (e.g., in the chat and on the profile page).
-  //
-  // Example with a context:
-  //
-  // import { useUser } from '@/context/UserContext'
-  // const { profile } = useUser()
-  //
-  // The UserContext would be responsible for fetching and storing the user's profile data from Supabase.
-  // #endregion
-
-  // In a real app, this would come from a user context or store
-  const [profile, setProfile] = useState({
-    name: 'Alex',
-    bio: 'Exploring the inner world, one part at a time.',
-  });
 
   const streamingCancelRef = useRef<(() => void) | null>(null);
   const sessionIdRef = useRef<string | null>(null);


### PR DESCRIPTION
## Summary
- add `UserContext` to fetch and share user profile info
- hook chat logic into `UserContext` instead of local profile state
- wrap app layout with `UserProvider` for global access

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c2320935ec83238c3a2589c5203a89