### PR TITLE
refactor chat state and session management

### DIFF
--- a/context/UserContext.tsx
+++ b/context/UserContext.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { createContext, useContext, type ReactNode } from 'react';
+
+export interface UserProfile {
+  name: string;
+  bio: string;
+}
+
+export interface User {
+  id: string;
+  profile: UserProfile;
+}
+
+const UserContext = createContext<User | null>(null);
+
+interface ProviderProps {
+  value: User;
+  children: ReactNode;
+}
+
+export function UserProvider({ value, children }: ProviderProps) {
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+}
+
+export function useUser(): User {
+  const ctx = useContext(UserContext);
+  if (!ctx) {
+    throw new Error('useUser must be used within a UserProvider');
+  }
+  return ctx;
+}

--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -1,60 +1,34 @@
 'use client'
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useCallback, useRef, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation'
-import { Message, ChatState, TaskEvent } from '@/types/chat';
+import { Message, TaskEvent } from '@/types/chat';
 import { getPartById } from '@/lib/data/parts-lite'
 import { detectTool } from '@/lib/toolDetection';
 import { streamFromMastra } from '@/lib/chatClient';
 import { devMode } from '@/config/features';
 import { useToast } from './use-toast';
+import { useChatState } from './useChatState';
+import { useChatSession } from './useChatSession';
+import { useUser } from '@/context/UserContext';
 
 export function useChat() {
-  const searchParams = useSearchParams()
-  const [state, setState] = useState<ChatState>({
-    messages: [],
-    isStreaming: false,
-    currentStreamingId: undefined,
-    // augmenting state shape locally; downstream components only read fields we return
-    // hasActiveSession is maintained for UI checks like confirming before exiting chat
-    hasActiveSession: false,
-    tasksByMessage: {},
-  } as any);
-
-  // #region Proposing Next Steps for Full Integration
-  // In a real app, this profile data would not be managed by local state here.
-  // Instead, it would be provided by a global UserContext or a similar state management solution (like Zustand or Redux).
-  // This would ensure that the profile data is consistent across the application (e.g., in the chat and on the profile page).
-  //
-  // Example with a context:
-  //
-  // import { useUser } from '@/context/UserContext'
-  // const { profile } = useUser()
-  //
-  // The UserContext would be responsible for fetching and storing the user's profile data from Supabase.
-  // #endregion
-
-  // In a real app, this would come from a user context or store
-  const [profile, setProfile] = useState({
-    name: 'Alex',
-    bio: 'Exploring the inner world, one part at a time.',
-  });
+  const searchParams = useSearchParams();
+  const { state, addMessage, updateMessage, mergeState, setTasks, reset } = useChatState();
+  const { ensureSession, persistMessage, endSession: endSessionRequest, getSessionId } = useChatSession();
+  const { id: userId, profile } = useUser();
 
   const streamingCancelRef = useRef<(() => void) | null>(null);
-  const sessionIdRef = useRef<string | null>(null);
-  const userIdRef = useRef<string>('dev-user-1'); // TODO: replace with real identity later
 
   const generateId = (): string => Math.random().toString(36).substr(2, 9);
 
   useEffect(() => {
-    const partId = searchParams.get('partId')
-    if (partId && (state as any).messages.length === 0) {
-      // This is a new chat session focused on a specific part.
-      // Let's create a custom initial message.
+    const partId = searchParams.get('partId');
+    if (partId && state.messages.length === 0) {
       const fetchPartAndStart = async () => {
-        const result = await getPartById({ partId })
+        const result = await getPartById({ partId });
         if (result.success && result.data) {
-          const partName = result.data.name
+          const partName = result.data.name;
           const initialMessage: Message = {
             id: generateId(),
             role: 'assistant',
@@ -63,328 +37,290 @@ export function useChat() {
             persona: 'claude',
             streaming: false,
             tasks: [],
-          }
-          setState((prev: any) => ({ ...prev, messages: [initialMessage] }))
+          };
+          mergeState({ messages: [initialMessage] });
         }
-      }
-      fetchPartAndStart()
+      };
+      fetchPartAndStart();
     }
-  }, [searchParams])
+  }, [searchParams, state.messages, mergeState]);
 
-  const updateMessage = useCallback((id: string, updates: Partial<Message>) => {
-    setState((prev: any) => ({
-      ...prev,
-      messages: prev.messages.map((msg: Message) => (msg.id === id ? { ...msg, ...updates } : msg)),
-    }));
-  }, []);
-
-  const upsertTaskForMessage = useCallback((messageId: string, evt: TaskEvent) => {
-    setState((prev: any) => {
-      const existing: Record<string, TaskEvent[]> = prev.tasksByMessage || {}
-      const currentList = existing[messageId] || []
-      const idx = currentList.findIndex((t) => t.id === evt.id)
-      const nextList = idx >= 0
-        ? currentList.map((t) => (t.id === evt.id ? { ...t, ...evt } : t))
-        : [...currentList, evt]
-      return {
-        ...prev,
-        tasksByMessage: { ...existing, [messageId]: nextList },
-        messages: (prev.messages || []).map((m: any) => m.id === messageId ? { ...m, tasks: nextList } : m),
-      }
-    })
-  }, [])
-
-  const ensureSession = useCallback(async (): Promise<string> => {
-    if (sessionIdRef.current) return sessionIdRef.current;
-    const res = await fetch('/api/session/start', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ userId: userIdRef.current }),
-    });
-    if (!res.ok) throw new Error('Failed to start session');
-    const data = await res.json();
-    sessionIdRef.current = data.sessionId;
-    setState((prev: any) => ({ ...prev, hasActiveSession: true }));
-    return data.sessionId;
-  }, []);
-
-  const persistMessage = useCallback(async (sessionId: string, role: 'user' | 'assistant', content: string) => {
-    try {
-      await fetch('/api/session/message', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessionId, role, content }),
-      });
-    } catch {
-      // non-blocking
-    }
-  }, []);
+  const upsertTaskForMessage = useCallback(
+    (messageId: string, evt: TaskEvent) => {
+      const existing = state.tasksByMessage?.[messageId] || [];
+      const idx = existing.findIndex((t) => t.id === evt.id);
+      const nextList =
+        idx >= 0 ? existing.map((t) => (t.id === evt.id ? { ...t, ...evt } : t)) : [...existing, evt];
+      setTasks(messageId, nextList);
+    },
+    [setTasks, state.tasksByMessage]
+  );
 
   // Add a non-streaming assistant message (optionally persisted)
-  const addAssistantMessage = useCallback(async (content: string, opts?: { persist?: boolean; id?: string; persona?: 'claude' | 'default' }) => {
-    const id = (opts && opts.id) || generateId()
-    const msg: Message = {
-      id,
-      role: 'assistant',
-      content,
-      timestamp: Date.now(),
-      persona: opts?.persona || 'claude',
-      streaming: false,
-      tasks: [],
-    }
-    setState((prev: any) => ({ ...prev, messages: [...prev.messages, msg] }))
-    if (opts?.persist) {
-      try {
-        const sessionId = await ensureSession()
-        await persistMessage(sessionId, 'assistant', content)
-      } catch {}
-    }
-  }, [ensureSession, persistMessage])
-
-  const sendMessage = useCallback(async (content: string) => {
-    if (!content.trim() || (state as any).isStreaming) return;
-
-    // Cancel any ongoing streaming
-    if (streamingCancelRef.current) {
-      streamingCancelRef.current();
-    }
-
-    // Add user message locally
-    const userMessage: Message = {
-      id: generateId(),
-      role: 'user',
-      content: content.trim(),
-      timestamp: Date.now(),
-    };
-
-    setState((prev: any) => ({ ...prev, messages: [...prev.messages, userMessage] }));
-
-    // Detect tool to show in UI (still purely client-side for now)
-    const tool = detectTool(content);
-
-    // Create streaming assistant placeholder
-    const assistantId = generateId();
-    const assistantMessage: Message = {
-      id: assistantId,
-      role: 'assistant',
-      content: '',
-      timestamp: Date.now(),
-      persona: 'claude',
-      // tool UI deprecated in favor of Task UI
-      streaming: true,
-      tasks: [],
-    };
-
-    setState((prev: any) => ({
-      ...prev,
-      messages: [...prev.messages, assistantMessage],
-      isStreaming: true,
-      currentStreamingId: assistantId,
-      tasksByMessage: { ...(prev as any).tasksByMessage, [assistantId]: [] },
-    }));
-
-    // Ensure session and persist the user message (fire-and-forget)
-    const sessionId = await ensureSession();
-    persistMessage(sessionId, 'user', userMessage.content).catch(() => {});
-
-    // Prepare AbortController for stream cancellation
-    const controller = new AbortController();
-    streamingCancelRef.current = () => controller.abort();
-
-    // Build plain messages array for the API
-    const apiMessages = [...(state as any).messages, userMessage].map((m: any) => ({ role: m.role as 'user' | 'assistant' | 'system', content: m.content }));
-
-    let accumulated = '';
-    let buffer = '';
-    let flushInterval: any = null
-    let finalizeTimer: any = null
-
-    const finalize = () => {
-      updateMessage(assistantId, { content: accumulated, streaming: false })
-      setState((prev: any) => ({ ...prev, isStreaming: false, currentStreamingId: undefined }));
-      streamingCancelRef.current = null;
-    }
-
-    const scheduleFinalizeCheck = () => {
-      if (finalizeTimer) return
-      finalizeTimer = setInterval(() => {
-        if (!flushInterval && buffer.length === 0) {
-          clearInterval(finalizeTimer)
-          finalizeTimer = null
-          finalize()
-        }
-      }, 60)
-    }
-
-    // Read CSS variables for streaming cadence
-    const stepMs = typeof window !== 'undefined' ? (Number(getComputedStyle(document.documentElement).getPropertyValue('--eth-stream-tick').trim()) || 150) : 150
-    const stepChars = typeof window !== 'undefined' ? (Number(getComputedStyle(document.documentElement).getPropertyValue('--eth-stream-chars').trim()) || 8) : 8
-    const startFlusher = () => {
-      if (flushInterval) return
-      flushInterval = setInterval(() => {
-        if (buffer.length > 0) {
-          const take = Math.min(stepChars, buffer.length)
-          const part = buffer.slice(0, take)
-          buffer = buffer.slice(take)
-          accumulated += part
-          updateMessage(assistantId, { content: accumulated, streaming: true })
-        } else {
-          // no buffer left; flusher can stop
-          clearInterval(flushInterval)
-          flushInterval = null
-          // If a done signal was received earlier, ensure finalization proceeds
-          scheduleFinalizeCheck()
-        }
-      }, stepMs)
-    }
-    const stopFlusher = () => {
-      if (flushInterval) {
-        clearInterval(flushInterval)
-        flushInterval = null
+  const addAssistantMessage = useCallback(
+    async (content: string, opts?: { persist?: boolean; id?: string; persona?: 'claude' | 'default' }) => {
+      const id = (opts && opts.id) || generateId();
+      const msg: Message = {
+        id,
+        role: 'assistant',
+        content,
+        timestamp: Date.now(),
+        persona: opts?.persona || 'claude',
+        streaming: false,
+        tasks: [],
+      };
+      addMessage(msg);
+      if (opts?.persist) {
+        try {
+          const sessionId = await ensureSession();
+          mergeState({ hasActiveSession: true });
+          await persistMessage(sessionId, 'assistant', content);
+        } catch {}
       }
-    }
+    },
+    [addMessage, ensureSession, persistMessage, mergeState]
+  );
 
-    try {
-      // Always use main agent for ethereal chat (not the dev stream)
-      const chosenApiPath = '/api/chat'
-      let doneReceived = false
+  const sendMessage = useCallback(
+    async (content: string) => {
+      if (!content.trim() || state.isStreaming) return;
 
-      await streamFromMastra({
-        messages: apiMessages,
-        sessionId,
-        userId: userIdRef.current,
-        profile,
-        signal: controller.signal,
-        apiPath: chosenApiPath,
-        onTask: (evt) => {
-          upsertTaskForMessage(assistantId, evt)
-        },
-        onChunk: (chunk, done) => {
-          // accumulate; flusher reveals a few characters per tick for ethereal smoothness
-          if (chunk) buffer += chunk
-          startFlusher()
-          if (done) {
-            doneReceived = true
-            // Begin polling for flusher completion; finalize when buffer empties
-            scheduleFinalizeCheck()
-            // Also persist once finalized; we hook into finalize() by adding a microtask here
-            queueMicrotask(() => {
-              const tryPersist = () => {
-                if (!flushInterval && buffer.length === 0) {
-                  persistMessage(sessionId, 'assistant', accumulated).catch(() => {})
-                } else {
-                  // retry shortly until finalize completes
-                  setTimeout(tryPersist, 120)
-                }
-              }
-              tryPersist()
-            })
-          }
-        },
+      if (streamingCancelRef.current) {
+        streamingCancelRef.current();
+      }
+
+      const userMessage: Message = {
+        id: generateId(),
+        role: 'user',
+        content: content.trim(),
+        timestamp: Date.now(),
+      };
+
+      addMessage(userMessage);
+
+      const _tool = detectTool(content);
+
+      const assistantId = generateId();
+      const assistantMessage: Message = {
+        id: assistantId,
+        role: 'assistant',
+        content: '',
+        timestamp: Date.now(),
+        persona: 'claude',
+        streaming: true,
+        tasks: [],
+      };
+
+      addMessage(assistantMessage);
+      mergeState({
+        isStreaming: true,
+        currentStreamingId: assistantId,
+        tasksByMessage: { ...(state.tasksByMessage ?? {}), [assistantId]: [] },
       });
-    } catch (e) {
-      // Mark stream ended and show basic error if needed
-      stopFlusher()
-      setState((prev: any) => ({ ...prev, isStreaming: false, currentStreamingId: undefined }));
-      streamingCancelRef.current = null;
-      if (accumulated.length === 0) {
-        updateMessage(assistantId, { content: 'Sorry, something went wrong while streaming the response.', streaming: false });
+
+      const sessionId = await ensureSession();
+      mergeState({ hasActiveSession: true });
+      persistMessage(sessionId, 'user', userMessage.content).catch(() => {});
+
+      const controller = new AbortController();
+      streamingCancelRef.current = () => controller.abort();
+
+      const apiMessages = [...state.messages, userMessage].map((m) => ({
+        role: m.role,
+        content: m.content,
+      }));
+
+      let accumulated = '';
+      let buffer = '';
+      let flushInterval: any = null;
+      let finalizeTimer: any = null;
+
+      const finalize = () => {
+        updateMessage(assistantId, { content: accumulated, streaming: false });
+        mergeState({ isStreaming: false, currentStreamingId: undefined });
+        streamingCancelRef.current = null;
+      };
+
+      const scheduleFinalizeCheck = () => {
+        if (finalizeTimer) return;
+        finalizeTimer = setInterval(() => {
+          if (!flushInterval && buffer.length === 0) {
+            clearInterval(finalizeTimer);
+            finalizeTimer = null;
+            finalize();
+          }
+        }, 60);
+      };
+
+      const stepMs =
+        typeof window !== 'undefined'
+          ? Number(getComputedStyle(document.documentElement).getPropertyValue('--eth-stream-tick').trim()) || 150
+          : 150;
+      const stepChars =
+        typeof window !== 'undefined'
+          ? Number(getComputedStyle(document.documentElement).getPropertyValue('--eth-stream-chars').trim()) || 8
+          : 8;
+
+      const startFlusher = () => {
+        if (flushInterval) return;
+        flushInterval = setInterval(() => {
+          if (buffer.length > 0) {
+            const take = Math.min(stepChars, buffer.length);
+            const part = buffer.slice(0, take);
+            buffer = buffer.slice(take);
+            accumulated += part;
+            updateMessage(assistantId, { content: accumulated, streaming: true });
+          } else {
+            clearInterval(flushInterval);
+            flushInterval = null;
+            scheduleFinalizeCheck();
+          }
+        }, stepMs);
+      };
+      const stopFlusher = () => {
+        if (flushInterval) {
+          clearInterval(flushInterval);
+          flushInterval = null;
+        }
+      };
+
+      try {
+        const chosenApiPath = '/api/chat';
+        let doneReceived = false;
+
+        await streamFromMastra({
+          messages: apiMessages,
+          sessionId,
+          userId,
+          profile,
+          signal: controller.signal,
+          apiPath: chosenApiPath,
+          onTask: (evt) => {
+            upsertTaskForMessage(assistantId, evt);
+          },
+          onChunk: (chunk, done) => {
+            if (chunk) buffer += chunk;
+            startFlusher();
+            if (done) {
+              doneReceived = true;
+              scheduleFinalizeCheck();
+              queueMicrotask(() => {
+                const tryPersist = () => {
+                  if (!flushInterval && buffer.length === 0) {
+                    persistMessage(sessionId, 'assistant', accumulated).catch(() => {});
+                  } else {
+                    setTimeout(tryPersist, 120);
+                  }
+                };
+                tryPersist();
+              });
+            }
+          },
+        });
+      } catch (e) {
+        stopFlusher();
+        mergeState({ isStreaming: false, currentStreamingId: undefined });
+        streamingCancelRef.current = null;
+        if (accumulated.length === 0) {
+          updateMessage(assistantId, {
+            content: 'Sorry, something went wrong while streaming the response.',
+            streaming: false,
+          });
+        }
       }
-    }
-  }, [ensureSession, persistMessage, (state as any).isStreaming, (state as any).messages, updateMessage]);
+    },
+    [
+      ensureSession,
+      persistMessage,
+      state.isStreaming,
+      state.messages,
+      state.tasksByMessage,
+      updateMessage,
+      mergeState,
+      addMessage,
+      userId,
+      profile,
+      upsertTaskForMessage,
+    ]
+  );
 
   const clearChat = useCallback(() => {
     if (streamingCancelRef.current) {
       streamingCancelRef.current();
     }
-    setState((prev: any) => ({ ...prev, messages: [], isStreaming: false, currentStreamingId: undefined }));
-    // Intentionally do not reset sessionIdRef here to satisfy: no resume within same page; new session will be created on first send after reload
-  }, []);
+    mergeState({ messages: [], isStreaming: false, currentStreamingId: undefined });
+  }, [mergeState]);
 
   const endSession = useCallback(async () => {
-    const id = sessionIdRef.current
-    if (!id) {
-      // Nothing to end
-      setState((prev: any) => ({ ...prev, hasActiveSession: false, messages: [], isStreaming: false, currentStreamingId: undefined }))
-      return
-    }
-    try {
-      await fetch('/api/session/end', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessionId: id }),
-      })
-    } catch {
-      // ignore
-    } finally {
-      sessionIdRef.current = null
-      setState((prev: any) => ({ ...prev, hasActiveSession: false, messages: [], isStreaming: false, currentStreamingId: undefined }))
-    }
-  }, [])
+    await endSessionRequest();
+    reset();
+  }, [endSessionRequest, reset]);
 
-  const rerunTool = useCallback((messageId: string) => {
-    const message = (state as any).messages.find((m: any) => m.id === messageId);
-    if (!message || !message.tool) return;
-    const idx = (state as any).messages.findIndex((m: any) => m.id === messageId);
-    const userMessage = idx > 0 ? (state as any).messages[idx - 1] : null;
-    if (userMessage && userMessage.role === 'user') {
-      sendMessage(userMessage.content);
-    }
-  }, [(state as any).messages, sendMessage]);
+  const rerunTool = useCallback(
+    (messageId: string) => {
+      const message = state.messages.find((m) => m.id === messageId);
+      if (!message || !message.tool) return;
+      const idx = state.messages.findIndex((m) => m.id === messageId);
+      const userMessage = idx > 0 ? state.messages[idx - 1] : null;
+      if (userMessage && userMessage.role === 'user') {
+        sendMessage(userMessage.content);
+      }
+    },
+    [state.messages, sendMessage]
+  );
 
   const { toast } = useToast();
 
-  const sendFeedback = useCallback(async (
-    messageId: string,
-    rating: 'thumb_up' | 'thumb_down',
-    explanation?: string
-  ) => {
-    const sessionId = sessionIdRef.current;
-    if (!sessionId) {
-      toast({
-        title: 'Error',
-        description: 'No active session to submit feedback for.',
-        variant: 'destructive',
-      });
-      return;
-    }
-
-    try {
-      const response = await fetch('/api/feedback', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          sessionId,
-          messageId,
-          rating,
-          explanation,
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to submit feedback');
+  const sendFeedback = useCallback(
+    async (messageId: string, rating: 'thumb_up' | 'thumb_down', explanation?: string) => {
+      const sessionId = getSessionId();
+      if (!sessionId) {
+        toast({
+          title: 'Error',
+          description: 'No active session to submit feedback for.',
+          variant: 'destructive',
+        });
+        return;
       }
 
-      toast({
-        title: 'Feedback submitted',
-        description: 'Thank you for your feedback!',
-      });
-    } catch (error) {
-      console.error('Error submitting feedback:', error);
-      toast({
-        title: 'Error',
-        description: 'Could not submit feedback. Please try again later.',
-        variant: 'destructive',
-      });
-    }
-  }, [toast]);
+      try {
+        const response = await fetch('/api/feedback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId,
+            messageId,
+            rating,
+            explanation,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error('Failed to submit feedback');
+        }
+
+        toast({
+          title: 'Feedback submitted',
+          description: 'Thank you for your feedback!',
+        });
+      } catch (error) {
+        console.error('Error submitting feedback:', error);
+        toast({
+          title: 'Error',
+          description: 'Could not submit feedback. Please try again later.',
+          variant: 'destructive',
+        });
+      }
+    },
+    [toast, getSessionId]
+  );
 
   return {
-    messages: (state as any).messages,
-    isStreaming: (state as any).isStreaming,
-    currentStreamingId: (state as any).currentStreamingId,
-    hasActiveSession: (state as any).hasActiveSession as boolean,
-    tasksByMessage: (state as any).tasksByMessage as Record<string, TaskEvent[]>,
+    messages: state.messages,
+    isStreaming: state.isStreaming,
+    currentStreamingId: state.currentStreamingId,
+    hasActiveSession: state.hasActiveSession ?? false,
+    tasksByMessage: state.tasksByMessage,
     sendMessage,
     addAssistantMessage,
     clearChat,
@@ -393,3 +329,4 @@ export function useChat() {
     sendFeedback,
   };
 }
+

--- a/hooks/useChatSession.ts
+++ b/hooks/useChatSession.ts
@@ -1,0 +1,57 @@
+'use client'
+
+import { useCallback, useRef } from 'react';
+import { useUser } from '@/context/UserContext';
+
+export function useChatSession() {
+  const { id: userId } = useUser();
+  const sessionIdRef = useRef<string | null>(null);
+
+  const ensureSession = useCallback(async (): Promise<string> => {
+    if (sessionIdRef.current) return sessionIdRef.current;
+    const res = await fetch('/api/session/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId }),
+    });
+    if (!res.ok) throw new Error('Failed to start session');
+    const data = await res.json();
+    sessionIdRef.current = data.sessionId;
+    return data.sessionId;
+  }, [userId]);
+
+  const persistMessage = useCallback(
+    async (sessionId: string, role: 'user' | 'assistant', content: string) => {
+      try {
+        await fetch('/api/session/message', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId, role, content }),
+        });
+      } catch {
+        // non-blocking
+      }
+    },
+    []
+  );
+
+  const endSession = useCallback(async () => {
+    const id = sessionIdRef.current;
+    if (!id) return;
+    try {
+      await fetch('/api/session/end', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: id }),
+      });
+    } catch {
+      // ignore
+    } finally {
+      sessionIdRef.current = null;
+    }
+  }, []);
+
+  const getSessionId = useCallback(() => sessionIdRef.current, []);
+
+  return { ensureSession, persistMessage, endSession, getSessionId };
+}

--- a/hooks/useChatState.ts
+++ b/hooks/useChatState.ts
@@ -1,0 +1,62 @@
+'use client'
+
+import { useReducer } from 'react';
+import { ChatState, Message, TaskEvent } from '@/types/chat';
+
+const initialState: ChatState = {
+  messages: [],
+  isStreaming: false,
+  currentStreamingId: undefined,
+  hasActiveSession: false,
+  tasksByMessage: {},
+};
+
+type Action =
+  | { type: 'ADD_MESSAGE'; message: Message }
+  | { type: 'UPDATE_MESSAGE'; id: string; updates: Partial<Message> }
+  | { type: 'MERGE_STATE'; payload: Partial<ChatState> }
+  | { type: 'SET_TASKS'; messageId: string; tasks: TaskEvent[] }
+  | { type: 'RESET' };
+
+function reducer(state: ChatState, action: Action): ChatState {
+  switch (action.type) {
+    case 'ADD_MESSAGE':
+      return { ...state, messages: [...state.messages, action.message] };
+    case 'UPDATE_MESSAGE':
+      return {
+        ...state,
+        messages: state.messages.map((m) =>
+          m.id === action.id ? { ...m, ...action.updates } : m
+        ),
+      };
+    case 'MERGE_STATE':
+      return { ...state, ...action.payload };
+    case 'SET_TASKS':
+      return {
+        ...state,
+        tasksByMessage: { ...state.tasksByMessage, [action.messageId]: action.tasks },
+        messages: state.messages.map((m) =>
+          m.id === action.messageId ? { ...m, tasks: action.tasks } : m
+        ),
+      };
+    case 'RESET':
+      return { ...initialState };
+    default:
+      return state;
+  }
+}
+
+export function useChatState() {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const addMessage = (message: Message) => dispatch({ type: 'ADD_MESSAGE', message });
+  const updateMessage = (id: string, updates: Partial<Message>) =>
+    dispatch({ type: 'UPDATE_MESSAGE', id, updates });
+  const mergeState = (payload: Partial<ChatState>) =>
+    dispatch({ type: 'MERGE_STATE', payload });
+  const setTasks = (messageId: string, tasks: TaskEvent[]) =>
+    dispatch({ type: 'SET_TASKS', messageId, tasks });
+  const reset = () => dispatch({ type: 'RESET' });
+
+  return { state, addMessage, updateMessage, mergeState, setTasks, reset };
+}


### PR DESCRIPTION
## Summary
- replace local chat state with `useChatState` reducer hook
- centralize session lifecycle in new `useChatSession`
- pull user identity from `UserContext` instead of local ref

## Testing
- `npm run lint`
- `npm run typecheck` (fails: Object literal may only specify known properties in lib/hooks/use-google-auth.ts)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2321ba3d48323b0343b1c7c810578