### PR TITLE
refactor: add supabase guard util

### DIFF
--- a/app/api/session/end/route.ts
+++ b/app/api/session/end/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest } from 'next/server'
-import { createClient as createServerSupabase } from '@/lib/supabase/server'
-import { createAdminClient } from '@/lib/supabase/admin'
-import { dev } from '@/config/dev'
+import { withSupabaseOrDev } from '@/lib/api/supabaseGuard'
 
 export async function POST(req: NextRequest) {
   try {
@@ -14,73 +12,59 @@ export async function POST(req: NextRequest) {
       })
     }
 
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-    const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-    const hasSupabase =
-      typeof supabaseUrl === 'string' && /^https?:\/\//.test(supabaseUrl) &&
-      typeof supabaseAnon === 'string' && supabaseAnon.length > 20
+    return withSupabaseOrDev(req, async ctx => {
+      if (ctx.type === 'no-supabase') {
+        return new Response(JSON.stringify({ ok: true, ended: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
 
-    if (!hasSupabase) {
-      // Dev fallback when Supabase env is not configured
-      return new Response(JSON.stringify({ ok: true, ended: false }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
+      if (ctx.type === 'authed') {
+        const { chatSessionService } = await import('@/lib/session-service')
+        await chatSessionService.endSession(sessionId)
+        return new Response(JSON.stringify({ ok: true, ended: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+
+      if (ctx.type === 'admin') {
+        const { data: row, error: fetchError } = await ctx.admin
+          .from('sessions')
+          .select('start_time')
+          .eq('id', sessionId)
+          .single()
+
+        if (fetchError) throw fetchError
+
+        const endTime = new Date().toISOString()
+        let duration: number | null = null
+        try {
+          if (row?.start_time) {
+            const startMs = new Date(row.start_time as unknown as string).getTime()
+            const endMs = new Date(endTime).getTime()
+            duration = Math.max(0, Math.floor((endMs - startMs) / 1000))
+          }
+        } catch {}
+
+        const { error: updateError } = await ctx.admin
+          .from('sessions')
+          .update({ end_time: endTime, duration, updated_at: endTime })
+          .eq('id', sessionId)
+
+        if (updateError) throw updateError
+
+        return new Response(JSON.stringify({ ok: true, ended: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' }
       })
-    }
-
-    // Try authenticated path first (RLS-protected)
-    const supabase = await createServerSupabase()
-    const { data: { session } } = await supabase.auth.getSession()
-    const authedUserId = session?.user?.id
-
-    if (authedUserId) {
-      const { chatSessionService } = await import('@/lib/session-service')
-      await chatSessionService.endSession(sessionId)
-      return new Response(JSON.stringify({ ok: true, ended: true }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-
-    // Dev mode unauthenticated: admin client updates session
-    if (dev.enabled) {
-      const admin = createAdminClient()
-
-      // Fetch start_time to compute duration; if missing, set ended without duration
-      const { data: row, error: fetchError } = await admin
-        .from('sessions')
-        .select('start_time')
-        .eq('id', sessionId)
-        .single()
-
-      if (fetchError) throw fetchError
-
-      const endTime = new Date().toISOString()
-      let duration: number | null = null
-      try {
-        if (row?.start_time) {
-          const startMs = new Date(row.start_time as unknown as string).getTime()
-          const endMs = new Date(endTime).getTime()
-          duration = Math.max(0, Math.floor((endMs - startMs) / 1000))
-        }
-      } catch {}
-
-      const { error: updateError } = await admin
-        .from('sessions')
-        .update({ end_time: endTime, duration, updated_at: endTime })
-        .eq('id', sessionId)
-
-      if (updateError) throw updateError
-
-      return new Response(JSON.stringify({ ok: true, ended: true }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
     })
   } catch (error) {
     console.error('Session end API error:', error)

--- a/app/api/session/message/route.ts
+++ b/app/api/session/message/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest } from 'next/server'
-import { createClient as createServerSupabase } from '@/lib/supabase/server'
-import { createAdminClient } from '@/lib/supabase/admin'
-import { dev } from '@/config/dev'
+import { withSupabaseOrDev } from '@/lib/api/supabaseGuard'
 
 export async function POST(req: NextRequest) {
   try {
@@ -14,67 +12,53 @@ export async function POST(req: NextRequest) {
       })
     }
 
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-    const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-    const hasSupabase =
-      typeof supabaseUrl === 'string' && /^https?:\/\//.test(supabaseUrl) &&
-      typeof supabaseAnon === 'string' && supabaseAnon.length > 20
+    return withSupabaseOrDev(req, async ctx => {
+      if (ctx.type === 'no-supabase') {
+        return new Response(JSON.stringify({ ok: true, stored: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
 
-    if (!hasSupabase) {
-      // Development fallback when Supabase env is not configured
-      return new Response(JSON.stringify({ ok: true, stored: false }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
+      if (ctx.type === 'authed') {
+        const { chatSessionService } = await import('@/lib/session-service')
+        await chatSessionService.addMessage(sessionId, { role, content })
+        return new Response(JSON.stringify({ ok: true, stored: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+
+      if (ctx.type === 'admin') {
+        const { data: row, error: fetchError } = await ctx.admin
+          .from('sessions')
+          .select('messages')
+          .eq('id', sessionId)
+          .single()
+
+        if (fetchError) throw fetchError
+
+        const messages = Array.isArray(row?.messages) ? row.messages : []
+        const newMessage = { role, content, timestamp: new Date().toISOString() }
+        const updatedMessages = [...messages, newMessage]
+
+        const { error: updateError } = await ctx.admin
+          .from('sessions')
+          .update({ messages: updatedMessages, updated_at: new Date().toISOString() })
+          .eq('id', sessionId)
+
+        if (updateError) throw updateError
+
+        return new Response(JSON.stringify({ ok: true, stored: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' }
       })
-    }
-
-    // Try authenticated user path first (RLS-protected)
-    const supabase = await createServerSupabase()
-    const { data: { session } } = await supabase.auth.getSession()
-    const authedUserId = session?.user?.id
-
-    if (authedUserId) {
-      const { chatSessionService } = await import('@/lib/session-service')
-      await chatSessionService.addMessage(sessionId, { role, content })
-      return new Response(JSON.stringify({ ok: true, stored: true }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-
-    // Dev mode: use admin client to bypass RLS and append message for persona-owned session
-    if (dev.enabled) {
-      const admin = createAdminClient()
-
-      // Fetch current messages (admin bypasses RLS)
-      const { data: row, error: fetchError } = await admin
-        .from('sessions')
-        .select('messages')
-        .eq('id', sessionId)
-        .single()
-
-      if (fetchError) throw fetchError
-
-      const messages = Array.isArray(row?.messages) ? row.messages : []
-      const newMessage = { role, content, timestamp: new Date().toISOString() }
-      const updatedMessages = [...messages, newMessage]
-
-      const { error: updateError } = await admin
-        .from('sessions')
-        .update({ messages: updatedMessages, updated_at: new Date().toISOString() })
-        .eq('id', sessionId)
-
-      if (updateError) throw updateError
-
-      return new Response(JSON.stringify({ ok: true, stored: true }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
     })
   } catch (error) {
     console.error('Session message API error:', error)

--- a/app/api/session/start/route.ts
+++ b/app/api/session/start/route.ts
@@ -1,90 +1,74 @@
 import { NextRequest } from 'next/server'
-import { createClient as createServerSupabase } from '@/lib/supabase/server'
-import { createAdminClient } from '@/lib/supabase/admin'
-import { dev, resolveUserId } from '@/config/dev'
+import { resolveUserId } from '@/config/dev'
+import { withSupabaseOrDev } from '@/lib/api/supabaseGuard'
 
 export async function POST(req: NextRequest) {
   try {
     // Body is ignored for user identity; server derives user on its own
     await req.json().catch(() => ({} as any))
 
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-    const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-    const hasSupabase =
-      typeof supabaseUrl === 'string' && /^https?:\/\//.test(supabaseUrl) &&
-      typeof supabaseAnon === 'string' && supabaseAnon.length > 20
-
-    if (!hasSupabase) {
-      // Development fallback when Supabase env is not configured
-      const devSessionId = `dev-${Math.random().toString(36).slice(2)}`
-      return new Response(JSON.stringify({ sessionId: devSessionId }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-
-    // Try authenticated path first
-    const supabase = await createServerSupabase()
-    const { data: { session } } = await supabase.auth.getSession()
-    const authedUserId = session?.user?.id
-
-    if (authedUserId) {
-      const { chatSessionService } = await import('../../../../lib/session-service')
-      const sessionId = await chatSessionService.startSession(authedUserId)
-      return new Response(JSON.stringify({ sessionId }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-
-    // Unauthenticated: allow DB persistence in dev mode by using a seeded persona user via admin client
-    if (dev.enabled) {
-      const personaUserId = resolveUserId()
-      const admin = createAdminClient()
-
-      // Build a minimal session row mirroring ChatSessionService defaults
-      const nowIso = new Date().toISOString()
-      const sessionRow = {
-        user_id: personaUserId,
-        start_time: nowIso,
-        messages: [] as any[],
-        parts_involved: {} as Record<string, unknown>,
-        new_parts: [] as string[],
-        breakthroughs: [] as string[],
-        emotional_arc: {
-          start: { valence: 0, arousal: 0 },
-          peak: { valence: 0, arousal: 0 },
-          end: { valence: 0, arousal: 0 }
-        },
-        processed: false,
-        created_at: nowIso,
-        updated_at: nowIso,
+    return withSupabaseOrDev(req, async ctx => {
+      if (ctx.type === 'no-supabase') {
+        const devSessionId = `dev-${Math.random().toString(36).slice(2)}`
+        return new Response(JSON.stringify({ sessionId: devSessionId }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
       }
 
-      const { data, error } = await admin
-        .from('sessions')
-        .insert(sessionRow)
-        .select('id')
-        .single()
+      if (ctx.type === 'authed') {
+        const { chatSessionService } = await import('../../../../lib/session-service')
+        const sessionId = await chatSessionService.startSession(ctx.userId)
+        return new Response(JSON.stringify({ sessionId }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
 
-      if (error) throw error
+      if (ctx.type === 'admin') {
+        const personaUserId = resolveUserId()
+        const nowIso = new Date().toISOString()
+        const sessionRow = {
+          user_id: personaUserId,
+          start_time: nowIso,
+          messages: [] as any[],
+          parts_involved: {} as Record<string, unknown>,
+          new_parts: [] as string[],
+          breakthroughs: [] as string[],
+          emotional_arc: {
+            start: { valence: 0, arousal: 0 },
+            peak: { valence: 0, arousal: 0 },
+            end: { valence: 0, arousal: 0 }
+          },
+          processed: false,
+          created_at: nowIso,
+          updated_at: nowIso
+        }
 
-      return new Response(JSON.stringify({ sessionId: data.id }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
+        const { data, error } = await ctx.admin
+          .from('sessions')
+          .insert(sessionRow)
+          .select('id')
+          .single()
+
+        if (error) throw error
+
+        return new Response(JSON.stringify({ sessionId: data.id }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' }
       })
-    }
-
-    // Production (or dev disabled) and unauthenticated
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
     })
   } catch (error) {
     console.error('Session start API error:', error)
     return new Response(JSON.stringify({ error: 'Failed to start session' }), {
       status: 500,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json' }
     })
   }
 }

--- a/lib/api/supabaseGuard.ts
+++ b/lib/api/supabaseGuard.ts
@@ -1,0 +1,53 @@
+import { NextRequest } from 'next/server'
+import { createClient as createServerSupabase } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { dev } from '@/config/dev'
+
+export type SupabaseGuardContext =
+  | { type: 'no-supabase' }
+  | { type: 'authed'; supabase: Awaited<ReturnType<typeof createServerSupabase>>; userId: string }
+  | { type: 'admin'; admin: ReturnType<typeof createAdminClient> }
+
+export async function withSupabaseOrDev(
+  req: NextRequest,
+  handler: (ctx: SupabaseGuardContext) => Promise<Response>
+): Promise<Response> {
+  try {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    const hasSupabase =
+      typeof supabaseUrl === 'string' && /^https?:\/\//.test(supabaseUrl) &&
+      typeof supabaseAnon === 'string' && supabaseAnon.length > 20
+
+    if (!hasSupabase) {
+      return await handler({ type: 'no-supabase' })
+    }
+
+    const supabase = await createServerSupabase()
+    const {
+      data: { session }
+    } = await supabase.auth.getSession()
+    const authedUserId = session?.user?.id
+
+    if (authedUserId) {
+      return await handler({ type: 'authed', supabase, userId: authedUserId })
+    }
+
+    if (dev.enabled) {
+      const admin = createAdminClient()
+      return await handler({ type: 'admin', admin })
+    }
+
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  } catch (error) {
+    console.error('Supabase guard error:', error)
+    return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `withSupabaseOrDev` helper to centralize Supabase env checks and dev fallbacks
- wrap session API endpoints with guard to remove duplicated logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c23231b0388323845a35e2789deefc