### PR TITLE
refactor: centralize supabase env access

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { dev } from '@/config/dev'
+import { getSupabaseKey, getSupabaseUrl } from '@/lib/supabase/config'
 
 export async function POST(req: NextRequest) {
   try {
@@ -14,8 +15,8 @@ export async function POST(req: NextRequest) {
     }
 
     // Only attempt to create a Supabase server client if env is configured
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-    const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    const supabaseUrl = getSupabaseUrl()
+    const supabaseAnon = getSupabaseKey()
     const hasSupabase =
       typeof supabaseUrl === 'string' && /^https?:\/\//.test(supabaseUrl) &&
       typeof supabaseAnon === 'string' && supabaseAnon.length > 20

--- a/app/api/insights/[id]/feedback/route.ts
+++ b/app/api/insights/[id]/feedback/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getSupabaseKey, getSupabaseUrl } from '@/lib/supabase/config'
 
+const supabaseUrl = getSupabaseUrl()
+const supabaseAnon = getSupabaseKey()
 const hasSupabase =
-  typeof process.env.NEXT_PUBLIC_SUPABASE_URL === 'string' &&
-  /^https?:\/\//.test(process.env.NEXT_PUBLIC_SUPABASE_URL || '') &&
-  typeof process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY === 'string' &&
-  (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '').length > 20
+  typeof supabaseUrl === 'string' &&
+  /^https?:\/\//.test(supabaseUrl || '') &&
+  typeof supabaseAnon === 'string' &&
+  (supabaseAnon || '').length > 20
 
 export async function POST(req: NextRequest, context: { params: Promise<{ id: string }> }) {
   try {

--- a/app/api/insights/[id]/reveal/route.ts
+++ b/app/api/insights/[id]/reveal/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getSupabaseKey, getSupabaseUrl } from '@/lib/supabase/config'
 
+const supabaseUrl = getSupabaseUrl()
+const supabaseAnon = getSupabaseKey()
 const hasSupabase =
-  typeof process.env.NEXT_PUBLIC_SUPABASE_URL === 'string' &&
-  /^https?:\/\//.test(process.env.NEXT_PUBLIC_SUPABASE_URL || '') &&
-  typeof process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY === 'string' &&
-  (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '').length > 20
+  typeof supabaseUrl === 'string' &&
+  /^https?:\/\//.test(supabaseUrl || '') &&
+  typeof supabaseAnon === 'string' &&
+  (supabaseAnon || '').length > 20
 
 export async function POST(_req: NextRequest, context: { params: Promise<{ id: string }> }) {
   try {

--- a/app/api/insights/route.ts
+++ b/app/api/insights/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { jitTopUpInsights } from '@/lib/insights/generator'
-
+import { getSupabaseKey, getSupabaseUrl } from '@/lib/supabase/config'
+const supabaseUrl = getSupabaseUrl()
+const supabaseAnon = getSupabaseKey()
 const hasSupabase =
-  typeof process.env.NEXT_PUBLIC_SUPABASE_URL === 'string' &&
-  /^https?:\/\//.test(process.env.NEXT_PUBLIC_SUPABASE_URL || '') &&
-  typeof process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY === 'string' &&
-  (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '').length > 20
+  typeof supabaseUrl === 'string' &&
+  /^https?:\/\//.test(supabaseUrl || '') &&
+  typeof supabaseAnon === 'string' &&
+  (supabaseAnon || '').length > 20
 
 export async function GET(req: NextRequest) {
   try {

--- a/app/api/session/end/route.ts
+++ b/app/api/session/end/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 import { createClient as createServerSupabase } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { dev } from '@/config/dev'
+import { getSupabaseKey, getSupabaseUrl } from '@/lib/supabase/config'
 
 export async function POST(req: NextRequest) {
   try {
@@ -14,8 +15,8 @@ export async function POST(req: NextRequest) {
       })
     }
 
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-    const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    const supabaseUrl = getSupabaseUrl()
+    const supabaseAnon = getSupabaseKey()
     const hasSupabase =
       typeof supabaseUrl === 'string' && /^https?:\/\//.test(supabaseUrl) &&
       typeof supabaseAnon === 'string' && supabaseAnon.length > 20

--- a/app/api/session/message/route.ts
+++ b/app/api/session/message/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 import { createClient as createServerSupabase } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { dev } from '@/config/dev'
+import { getSupabaseKey, getSupabaseUrl } from '@/lib/supabase/config'
 
 export async function POST(req: NextRequest) {
   try {
@@ -14,8 +15,8 @@ export async function POST(req: NextRequest) {
       })
     }
 
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-    const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    const supabaseUrl = getSupabaseUrl()
+    const supabaseAnon = getSupabaseKey()
     const hasSupabase =
       typeof supabaseUrl === 'string' && /^https?:\/\//.test(supabaseUrl) &&
       typeof supabaseAnon === 'string' && supabaseAnon.length > 20

--- a/app/api/session/start/route.ts
+++ b/app/api/session/start/route.ts
@@ -2,14 +2,15 @@ import { NextRequest } from 'next/server'
 import { createClient as createServerSupabase } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { dev, resolveUserId } from '@/config/dev'
+import { getSupabaseKey, getSupabaseUrl } from '@/lib/supabase/config'
 
 export async function POST(req: NextRequest) {
   try {
     // Body is ignored for user identity; server derives user on its own
     await req.json().catch(() => ({} as any))
 
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-    const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    const supabaseUrl = getSupabaseUrl()
+    const supabaseAnon = getSupabaseKey()
     const hasSupabase =
       typeof supabaseUrl === 'string' && /^https?:\/\//.test(supabaseUrl) &&
       typeof supabaseAnon === 'string' && supabaseAnon.length > 20

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,11 +1,9 @@
 import { createBrowserClient } from '@supabase/ssr'
+import { getSupabaseKey, getSupabaseUrl } from './config'
 
 export function createClient() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
-  const key =
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY ||
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!
+  const url = getSupabaseUrl()!
+  const key = getSupabaseKey()!
 
   return createBrowserClient(url, key)
 }

--- a/lib/supabase/config.ts
+++ b/lib/supabase/config.ts
@@ -1,0 +1,11 @@
+export function getSupabaseUrl() {
+  return process.env.NEXT_PUBLIC_SUPABASE_URL
+}
+
+export function getSupabaseKey() {
+  return (
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY ||
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY
+  )
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
+import { getSupabaseKey, getSupabaseUrl } from './config'
 
 /**
  * If using Fluid compute: Don't put this client in a global variable. Always create a new client within each
@@ -8,11 +9,8 @@ import { cookies } from 'next/headers'
 export async function createClient() {
   const cookieStore = await cookies()
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
-  const key =
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY ||
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!
+  const url = getSupabaseUrl()!
+  const key = getSupabaseKey()!
 
   return createServerClient(
     url,


### PR DESCRIPTION
## Summary
- add helpers to read Supabase URL and key
- use shared helpers in Supabase client/server
- update API routes to share Supabase env logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c23224dac08323bf0e5a747a223251