### PR TITLE
refactor: centralize JSON responses

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,16 +1,14 @@
 import { NextRequest } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { dev } from '@/config/dev'
+import { jsonResponse, errorResponse } from '@/lib/api/response'
 
 export async function POST(req: NextRequest) {
   try {
     const { messages, profile } = await req.json()
 
     if (!messages || !Array.isArray(messages)) {
-      return new Response(JSON.stringify({ error: 'Messages array is required' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' }
-      })
+      return errorResponse('Messages array is required', 400)
     }
 
     // Only attempt to create a Supabase server client if env is configured
@@ -33,10 +31,7 @@ export async function POST(req: NextRequest) {
     }
 
     if (!userId && !dev.enabled) {
-      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-        status: 401,
-        headers: { 'Content-Type': 'application/json' }
-      })
+      return errorResponse('Unauthorized', 401)
     }
 
     // Add the secure user ID to the profile object
@@ -172,9 +167,6 @@ const { createIfsAgent } = await import('../../../mastra/agents/ifs-agent')
 
   } catch (error) {
     console.error('Chat API error:', error)
-    return new Response(JSON.stringify({ error: 'Something went wrong' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' }
-    })
+    return errorResponse('Something went wrong', 500)
   }
 }

--- a/app/api/chat/ui/route.ts
+++ b/app/api/chat/ui/route.ts
@@ -1,19 +1,14 @@
 // DEPRECATED: This endpoint is no longer in use. Please POST to /api/chat instead.
 // Returning 410 Gone to signal clients to migrate.
+import { jsonResponse } from '@/lib/api/response'
 
 export async function POST() {
-  return new Response(
-    JSON.stringify({
+  return jsonResponse(
+    {
       error: 'Deprecated endpoint',
       message: 'Use /api/chat instead. This route has been superseded by the unified chat endpoint.'
-    }),
-    {
-      status: 410,
-      headers: {
-        'Content-Type': 'application/json',
-        'Deprecation': 'true',
-        'Link': '</api/chat>; rel="successor-version"'
-      }
-    }
+    },
+    410,
+    { headers: { Deprecation: 'true', Link: '</api/chat>; rel="successor-version"' } }
   )
 }

--- a/app/api/cron/generate-insights/route.ts
+++ b/app/api/cron/generate-insights/route.ts
@@ -1,7 +1,7 @@
-import { NextResponse } from 'next/server';
 import { mastra } from '@/mastra';
 import { createClient } from '@/lib/supabase/server';
 import type { Json } from '@/lib/types/database';
+import { jsonResponse, errorResponse } from '@/lib/api/response';
 
 const COOL_DOWN_HOURS = 48;
 
@@ -34,7 +34,7 @@ async function saveInsightsToDb(
 export async function GET(request: Request) {
   const authHeader = request.headers.get('authorization');
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new Response('Unauthorized', { status: 401 });
+    return errorResponse('Unauthorized', 401);
   }
 
   console.log('[Cron] Starting daily insight generation job.');
@@ -44,7 +44,7 @@ export async function GET(request: Request) {
 
   if (usersError) {
     console.error('[Cron] Error fetching users:', usersError);
-    return NextResponse.json({ error: 'Failed to fetch users' }, { status: 500 });
+    return errorResponse('Failed to fetch users', 500);
   }
 
   let totalInsightsGenerated = 0;
@@ -109,5 +109,5 @@ export async function GET(request: Request) {
   };
 
   console.log('[Cron] Job finished.', summary);
-  return NextResponse.json(summary);
+  return jsonResponse(summary);
 }

--- a/app/api/insights/[id]/feedback/route.ts
+++ b/app/api/insights/[id]/feedback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { jsonResponse, errorResponse } from '@/lib/api/response'
 
 const hasSupabase =
   typeof process.env.NEXT_PUBLIC_SUPABASE_URL === 'string' &&
@@ -13,17 +14,11 @@ export async function POST(req: NextRequest, context: { params: Promise<{ id: st
     const { rating, feedback } = await req.json().catch(() => ({}))
 
     if (!id || typeof rating === 'undefined') {
-      return new Response(JSON.stringify({ error: 'rating is required' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return errorResponse('rating is required', 400)
     }
 
     if (!hasSupabase) {
-      return new Response(JSON.stringify({ ok: true, stored: false }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return jsonResponse({ ok: true, stored: false })
     }
 
     const supabase = await createClient()
@@ -35,10 +30,7 @@ export async function POST(req: NextRequest, context: { params: Promise<{ id: st
       .single()
 
     if (fetchErr) {
-      return new Response(JSON.stringify({ error: 'Not found' }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return errorResponse('Not found', 404)
     }
 
     const updates: Record<string, unknown> = { rating, feedback }
@@ -56,16 +48,10 @@ export async function POST(req: NextRequest, context: { params: Promise<{ id: st
 
     if (error) throw error
 
-    return new Response(JSON.stringify(updated), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return jsonResponse(updated)
   } catch (e) {
     console.error('POST /api/insights/[id]/feedback error:', e)
-    return new Response(JSON.stringify({ error: 'Failed to submit feedback' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse('Failed to submit feedback', 500)
   }
 }
 

--- a/app/api/insights/route.ts
+++ b/app/api/insights/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { jitTopUpInsights } from '@/lib/insights/generator'
+import { jsonResponse, errorResponse } from '@/lib/api/response'
 
 const hasSupabase =
   typeof process.env.NEXT_PUBLIC_SUPABASE_URL === 'string' &&
@@ -27,7 +28,7 @@ export async function GET(req: NextRequest) {
           id: 'dev-insight-1',
           type: 'observation',
           status: 'pending',
-          content: { title: 'Dev Insight', body: 'OPENROUTER_API_KEY/Supabase not configured; this is a sample.' },
+          content: { title: 'Dev Insight', body: 'OPENROUTER_API_KEY\/Supabase not configured; this is a sample.' },
           rating: null,
           feedback: null,
           revealed_at: null,
@@ -36,10 +37,7 @@ export async function GET(req: NextRequest) {
           created_at: new Date().toISOString(),
         },
       ]
-      return new Response(JSON.stringify(sample.slice(0, limit)), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return jsonResponse(sample.slice(0, limit))
     }
 
     const supabase = await createClient()
@@ -58,10 +56,7 @@ if (!userId) {
       if (dev.enabled && dev.defaultUserId) {
         userId = dev.defaultUserId
       } else {
-        return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-          status: 401,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        return errorResponse('Unauthorized', 401)
       }
     }
 
@@ -95,16 +90,10 @@ if (!userId) {
       })
       .slice(0, limit)
 
-    return new Response(JSON.stringify(sorted), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return jsonResponse(sorted)
   } catch (e) {
     console.error('GET /api/insights error:', e)
-    return new Response(JSON.stringify({ error: 'Failed to fetch insights' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
+    return errorResponse('Failed to fetch insights', 500)
   }
 }
 

--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -1,0 +1,9 @@
+export function jsonResponse(data: unknown, status = 200, init: ResponseInit = {}) {
+  const headers = new Headers(init.headers)
+  headers.set('Content-Type', 'application/json')
+  return new Response(JSON.stringify(data), { ...init, status, headers })
+}
+
+export function errorResponse(message: string, status = 500, init?: ResponseInit) {
+  return jsonResponse({ error: message }, status, init)
+}


### PR DESCRIPTION
## Summary
- add `jsonResponse` and `errorResponse` helpers to consolidate JSON response headers
- refactor session, chat, insights and other API routes to use the new helpers
- ensure default `Content-Type` header is set in one place

## Testing
- `npm test` *(fails: npm not installed)*
- `apt-get update` *(fails: repository not signed, cannot install node/npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c23227a7e8832385efc903316fa84e