### PR TITLE
refactor chat POST helpers for reuse

### DIFF
--- a/app/api/chat/logic.ts
+++ b/app/api/chat/logic.ts
@@ -1,0 +1,147 @@
+import { createClient } from '@/lib/supabase/server'
+
+export async function getUserIdFromSupabase(): Promise<string | undefined> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  const hasSupabase =
+    typeof supabaseUrl === 'string' && /^https?:\/\//.test(supabaseUrl) &&
+    typeof supabaseAnon === 'string' && supabaseAnon.length > 20
+
+  if (!hasSupabase) {
+    return undefined
+  }
+  try {
+    const supabase = await createClient()
+    const {
+      data: { session }
+    } = await supabase.auth.getSession()
+    return session?.user?.id
+  } catch {
+    // If Supabase is misconfigured in local dev, continue without a user
+    return undefined
+  }
+}
+
+export function createDevStream(text: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(text))
+      controller.close()
+    }
+  })
+}
+
+export function provideDevFallbackStream(text: string): Response {
+  return new Response(createDevStream(text), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'no-store'
+    }
+  })
+}
+
+export async function handleAgentStream(
+  messages: unknown,
+  profile: Record<string, unknown>
+): Promise<Response> {
+  try {
+    // Lazy-load the agent only when credentials are available to avoid dev import side-effects
+    const { createIfsAgent } = await import('../../../mastra/agents/ifs-agent')
+    const ifsAgent = createIfsAgent(profile)
+
+    // Prefer vNext streaming in AI SDK (UI message) format so we can parse consistently on the client
+    const agent = ifsAgent as unknown as Partial<{
+      streamVNext: (messages: unknown, opts?: unknown) => unknown
+      stream: (messages: unknown) => unknown
+    }>
+    let stream: unknown = null
+    if (typeof agent.streamVNext === 'function') {
+      const vNext = (await agent.streamVNext(messages, { format: 'aisdk' })) as unknown
+      stream = vNext
+      if (
+        vNext &&
+        typeof (vNext as { toUIMessageStreamResponse?: unknown }).toUIMessageStreamResponse === 'function'
+      ) {
+        return (vNext as {
+          toUIMessageStreamResponse: (opts: { sendReasoning: boolean }) => Response
+        }).toUIMessageStreamResponse({ sendReasoning: false })
+      }
+    }
+    // Fallback to v2 streaming
+    if (!stream && typeof agent.stream === 'function') {
+      const v2 = (await agent.stream(messages)) as unknown
+      if (v2 && typeof (v2 as { toDataStreamResponse?: unknown }).toDataStreamResponse === 'function') {
+        return (v2 as { toDataStreamResponse: () => Response }).toDataStreamResponse()
+      }
+      if (v2 && typeof (v2 as { toReadableStream?: unknown }).toReadableStream === 'function') {
+        return new Response((v2 as { toReadableStream: () => ReadableStream<Uint8Array> }).toReadableStream(), {
+          headers: { 'Cache-Control': 'no-store' }
+        })
+      }
+      stream = v2
+    }
+
+    // Adapt to the returned stream type
+    const candidate = stream as Record<string, unknown> | undefined
+    if (
+      candidate &&
+      typeof (candidate as { toDataStreamResponse?: unknown }).toDataStreamResponse === 'function'
+    ) {
+      return (candidate as { toDataStreamResponse: () => Response }).toDataStreamResponse()
+    }
+    if (
+      candidate &&
+      typeof (candidate as { toReadableStream?: unknown }).toReadableStream === 'function'
+    ) {
+      return new Response(
+        (candidate as { toReadableStream: () => ReadableStream<Uint8Array> }).toReadableStream(),
+        { headers: { 'Cache-Control': 'no-store' } }
+      )
+    }
+    if (candidate && typeof (candidate as { toResponse?: unknown }).toResponse === 'function') {
+      return (candidate as { toResponse: () => Response }).toResponse()
+    }
+    if (
+      candidate &&
+      typeof (candidate as { toStreamResponse?: unknown }).toStreamResponse === 'function'
+    ) {
+      return (candidate as { toStreamResponse: () => Response }).toStreamResponse()
+    }
+    if (candidate && typeof candidate === 'object' && 'body' in candidate && 'headers' in candidate) {
+      // Looks like a web Response
+      return candidate as unknown as Response
+    }
+    if (candidate && Symbol.asyncIterator in candidate) {
+      // If it's an async iterator of chunks
+      const encoder = new TextEncoder()
+      const asyncIter = candidate as AsyncIterable<unknown>
+      const rs = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          for await (const chunk of asyncIter) {
+            const text = typeof chunk === 'string' ? chunk : JSON.stringify(chunk)
+            controller.enqueue(encoder.encode(text))
+          }
+          controller.close()
+        }
+      })
+      return new Response(rs, { headers: { 'Cache-Control': 'no-store' } })
+    }
+
+    // Fallback: dev stream instead of 500 to keep UI responsive
+    console.error(
+      'Unsupported stream type from agent. Keys:',
+      typeof candidate === 'object' ? Object.keys(candidate as Record<string, unknown>) : typeof candidate
+    )
+    return provideDevFallbackStream(
+      'Hello! (fallback)\nAgent returned unsupported stream shape.'
+    )
+  } catch (err) {
+    console.error('Error creating stream', err)
+    // Dev fallback stream on any error from agent/model/auth
+    return provideDevFallbackStream(
+      'Hello! (dev fallback stream)\nAgent streaming is unavailable (check OPENROUTER_API_KEY/model).'
+    )
+  }
+}
+

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
 import { dev } from '@/config/dev'
+import {
+  getUserIdFromSupabase,
+  provideDevFallbackStream,
+  handleAgentStream
+} from './logic'
 
 export async function POST(req: NextRequest) {
   try {
@@ -13,24 +17,7 @@ export async function POST(req: NextRequest) {
       })
     }
 
-    // Only attempt to create a Supabase server client if env is configured
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-    const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-    const hasSupabase =
-      typeof supabaseUrl === 'string' && /^https?:\/\//.test(supabaseUrl) &&
-      typeof supabaseAnon === 'string' && supabaseAnon.length > 20
-
-    let userId: string | undefined = undefined
-    if (hasSupabase) {
-      try {
-        const supabase = await createClient()
-        const { data: { session } } = await supabase.auth.getSession()
-        userId = session?.user?.id
-      } catch (e) {
-        // If Supabase is misconfigured in local dev, continue without a user
-        userId = undefined
-      }
-    }
+    const userId = await getUserIdFromSupabase()
 
     if (!userId && !dev.enabled) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), {
@@ -40,7 +27,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Add the secure user ID to the profile object
-    const secureProfile = { ...profile, userId: userId }
+    const secureProfile = { ...profile, userId }
 
     // Memory v2 first-run scaffolding: ensure overview exists for this user
     try {
@@ -57,119 +44,12 @@ export async function POST(req: NextRequest) {
     const hasOpenrouter = typeof process.env.OPENROUTER_API_KEY === 'string' && process.env.OPENROUTER_API_KEY.length > 10
     console.log('[CHAT] OpenRouter env', { hasOpenrouter, baseURL })
     if (!hasOpenrouter) {
-      const encoder = new TextEncoder()
-      const devText = 'Hello! (dev fallback stream)\nThis is a placeholder response because OPENROUTER_API_KEY is not configured.'
-      const stream = new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(encoder.encode(devText))
-          controller.close()
-        }
-      })
-      return new Response(stream, {
-        headers: {
-          'Content-Type': 'text/plain; charset=utf-8',
-          'Cache-Control': 'no-store'
-        }
-      })
+      return provideDevFallbackStream(
+        'Hello! (dev fallback stream)\nThis is a placeholder response because OPENROUTER_API_KEY is not configured.'
+      )
     }
 
-    try {
-      // Lazy-load the agent only when credentials are available to avoid dev import side-effects
-const { createIfsAgent } = await import('../../../mastra/agents/ifs-agent')
-      const ifsAgent = createIfsAgent(secureProfile)
-
-      // Prefer vNext streaming in AI SDK (UI message) format so we can parse consistently on the client
-      const agent = ifsAgent as unknown as Partial<{
-        streamVNext: (messages: unknown, opts?: unknown) => unknown
-        stream: (messages: unknown) => unknown
-      }>
-      let stream: unknown = null
-      if (typeof agent.streamVNext === 'function') {
-        const vNext = await (agent.streamVNext(messages, { format: 'aisdk' }) as unknown)
-        stream = vNext
-        if (
-          vNext && typeof (vNext as { toUIMessageStreamResponse?: unknown }).toUIMessageStreamResponse === 'function'
-        ) {
-          return (vNext as { toUIMessageStreamResponse: (opts: { sendReasoning: boolean }) => Response }).toUIMessageStreamResponse({ sendReasoning: false })
-        }
-      }
-      // Fallback to v2 streaming
-      if (!stream && typeof agent.stream === 'function') {
-        const v2 = await (agent.stream(messages) as unknown)
-        if (v2 && typeof (v2 as { toDataStreamResponse?: unknown }).toDataStreamResponse === 'function') {
-          return (v2 as { toDataStreamResponse: () => Response }).toDataStreamResponse()
-        }
-        if (v2 && typeof (v2 as { toReadableStream?: unknown }).toReadableStream === 'function') {
-          return new Response((v2 as { toReadableStream: () => ReadableStream<Uint8Array> }).toReadableStream(), { headers: { 'Cache-Control': 'no-store' } })
-        }
-        stream = v2
-      }
-
-      // Adapt to the returned stream type
-      const candidate = stream as Record<string, unknown> | undefined
-      if (
-        candidate && typeof (candidate as { toDataStreamResponse?: unknown }).toDataStreamResponse === 'function'
-      ) {
-        return (candidate as { toDataStreamResponse: () => Response }).toDataStreamResponse()
-      }
-      if (
-        candidate && typeof (candidate as { toReadableStream?: unknown }).toReadableStream === 'function'
-      ) {
-        return new Response((candidate as { toReadableStream: () => ReadableStream<Uint8Array> }).toReadableStream(), { headers: { 'Cache-Control': 'no-store' } })
-      }
-      if (candidate && typeof (candidate as { toResponse?: unknown }).toResponse === 'function') {
-        return (candidate as { toResponse: () => Response }).toResponse()
-      }
-      if (
-        candidate && typeof (candidate as { toStreamResponse?: unknown }).toStreamResponse === 'function'
-      ) {
-        return (candidate as { toStreamResponse: () => Response }).toStreamResponse()
-      }
-      if (candidate && typeof candidate === 'object' && 'body' in candidate && 'headers' in candidate) {
-        // Looks like a web Response
-        return candidate as unknown as Response
-      }
-      if (candidate && Symbol.asyncIterator in candidate) {
-        // If it's an async iterator of chunks
-        const encoder = new TextEncoder()
-        const asyncIter = candidate as AsyncIterable<unknown>
-        const rs = new ReadableStream<Uint8Array>({
-          async start(controller) {
-            for await (const chunk of asyncIter) {
-              const text = typeof chunk === 'string' ? chunk : JSON.stringify(chunk)
-              controller.enqueue(encoder.encode(text))
-            }
-            controller.close()
-          }
-        })
-        return new Response(rs, { headers: { 'Cache-Control': 'no-store' } })
-      }
-
-      // Fallback: dev stream instead of 500 to keep UI responsive
-      console.error('Unsupported stream type from agent. Keys:', typeof candidate === 'object' ? Object.keys(candidate as Record<string, unknown>) : typeof candidate)
-      const encoder = new TextEncoder()
-      const msg = 'Hello! (fallback)\nAgent returned unsupported stream shape.'
-      const rs = new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(encoder.encode(msg))
-          controller.close()
-        }
-      })
-      return new Response(rs, { headers: { 'Content-Type': 'text/plain; charset=utf-8', 'Cache-Control': 'no-store' } })
-    } catch (err) {
-      console.error('Error creating stream', err)
-      // Dev fallback stream on any error from agent/model/auth
-      const encoder = new TextEncoder()
-      const msg = 'Hello! (dev fallback stream)\nAgent streaming is unavailable (check OPENROUTER_API_KEY/model).'
-      const rs = new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(encoder.encode(msg))
-          controller.close()
-        }
-      })
-      return new Response(rs, { headers: { 'Content-Type': 'text/plain; charset=utf-8', 'Cache-Control': 'no-store' } })
-    }
-
+    return handleAgentStream(messages, secureProfile)
   } catch (error) {
     console.error('Chat API error:', error)
     return new Response(JSON.stringify({ error: 'Something went wrong' }), {


### PR DESCRIPTION
## Summary
- extract Supabase user lookup, fallback stream, and agent streaming into chat logic helpers
- consolidate TextEncoder fallbacks via reusable createDevStream utility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2322c682c83238cf5dcbaa677aca1