### PR TITLE
feat: add ethereal task overlay

### DIFF
--- a/components/ethereal/EtherealChat.tsx
+++ b/components/ethereal/EtherealChat.tsx
@@ -9,6 +9,7 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import type { Message as ChatMessage } from "@/types/chat"
 import { useRouter } from "next/navigation"
 import { StreamingText } from "./StreamingText"
+import { TaskOverlay } from "./TaskOverlay"
 
 // Minimal, bubble-less chat presentation for /chat/ethereal
 export function EtherealChat() {
@@ -53,6 +54,7 @@ export function EtherealChat() {
 
   return (
     <div className="absolute inset-0 flex flex-col">
+      <TaskOverlay />
       {/* Background image (optional) with gradient fallback */}
       <BackgroundImageLayer />
       <GradientBackdrop />

--- a/components/ethereal/TaskOverlay.tsx
+++ b/components/ethereal/TaskOverlay.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import React, { useMemo } from "react"
+import { useChat } from "@/hooks/useChat"
+import type { TaskEvent } from "@/types/chat"
+import { Task as TaskBase, TaskTrigger, TaskContent, TaskItem, TaskItemFile } from "@/components/ai-elements/task"
+
+interface MetaWithFiles {
+  files: { name: string }[]
+}
+
+export function TaskOverlay() {
+  const { tasksByMessage } = useChat()
+
+  const activeTasks: TaskEvent[] = useMemo(() => {
+    if (!tasksByMessage) return []
+    return Object.values(tasksByMessage)
+      .flat()
+      .filter((t) => t.status !== "completed")
+  }, [tasksByMessage])
+
+  if (activeTasks.length === 0) return null
+
+  return (
+    <div className="pointer-events-none fixed top-4 right-4 z-50 flex w-72 flex-col gap-2">
+      {activeTasks.map((t) => (
+        <TaskBase key={t.id} defaultOpen={false} className="pointer-events-auto">
+          <TaskTrigger
+            title={`${t.title}${typeof t.progress === "number" ? " · " + t.progress + "%" : ""} (${t.status})`}
+          />
+          {t.details ? (
+            <TaskContent>
+              {Array.isArray(t.details)
+                ? t.details.map((d, i) => <TaskItem key={i}>{d}</TaskItem>)
+                : <TaskItem>{t.details}</TaskItem>}
+              {t.meta && Array.isArray((t.meta as MetaWithFiles)?.files) && (
+                <div className="pt-2 flex flex-wrap gap-2">
+                  {(t.meta as MetaWithFiles).files.map((f: { name: string }, i: number) => (
+                    <TaskItemFile key={i}>{f?.name ?? "file"}</TaskItemFile>
+                  ))}
+                </div>
+              )}
+            </TaskContent>
+          ) : null}
+        </TaskBase>
+      ))}
+    </div>
+  )
+}
+
+export default TaskOverlay


### PR DESCRIPTION
## Summary
- show in-progress tasks in ethereal chat via fixed overlay
- filter tasks from messages and hide when none active
- integrate overlay into EtherealChat component

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Type 'Profile | null' is not assignable to type 'Profile')*


------
https://chatgpt.com/codex/tasks/task_e_68c251a4479883239ab539aa13f36797