### PR TITLE
feat: add active task overlay

### DIFF
--- a/components/ethereal/ActiveTaskOverlay.tsx
+++ b/components/ethereal/ActiveTaskOverlay.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import type { TaskEvent } from "@/types/chat"
+import { Task as TaskBase, TaskTrigger, TaskContent, TaskItem, TaskItemFile } from "@/components/ai-elements/task"
+
+interface ActiveTaskOverlayProps {
+  tasks: TaskEvent[] | undefined
+}
+
+export function ActiveTaskOverlay({ tasks }: ActiveTaskOverlayProps) {
+  if (!tasks || tasks.length === 0) return null
+
+  return (
+    <div className="space-y-2 rounded-2xl border border-white/15 bg-white/10 p-4 backdrop-blur-xl shadow-[0_8px_40px_rgba(0,0,0,0.25)]">
+      {tasks.map((t) => (
+        <TaskBase key={t.id} defaultOpen={t.status !== "completed"}>
+          <TaskTrigger title={`${t.title}${typeof t.progress === "number" ? " · " + t.progress + "%" : ""} (${t.status})`} />
+          {t.details ? (
+            <TaskContent>
+              {Array.isArray(t.details) ? (
+                t.details.map((d, i) => <TaskItem key={i}>{d}</TaskItem>)
+              ) : (
+                <TaskItem>{t.details}</TaskItem>
+              )}
+              {t.meta && Array.isArray((t.meta as any)?.files) && (
+                <div className="pt-2 flex flex-wrap gap-2">
+                  {(t.meta as any).files.map((f: { name: string }, i: number) => (
+                    <TaskItemFile key={i}>{f?.name ?? "file"}</TaskItemFile>
+                  ))}
+                </div>
+              )}
+            </TaskContent>
+          ) : null}
+        </TaskBase>
+      ))}
+    </div>
+  )
+}
+

--- a/components/ethereal/EtherealChat.tsx
+++ b/components/ethereal/EtherealChat.tsx
@@ -9,10 +9,20 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import type { Message as ChatMessage } from "@/types/chat"
 import { useRouter } from "next/navigation"
 import { StreamingText } from "./StreamingText"
+import { ActiveTaskOverlay } from "./ActiveTaskOverlay"
 
 // Minimal, bubble-less chat presentation for /chat/ethereal
 export function EtherealChat() {
-  const { messages, sendMessage, isStreaming, hasActiveSession, endSession, addAssistantMessage } = useChat()
+  const {
+    messages,
+    sendMessage,
+    isStreaming,
+    hasActiveSession,
+    endSession,
+    addAssistantMessage,
+    tasksByMessage,
+    currentStreamingId,
+  } = useChat()
   const router = useRouter()
 
   // UI state
@@ -50,6 +60,8 @@ export function EtherealChat() {
       addAssistantMessage("what feels unresolved or undefined for you right now?", { persist: true, id: "ethereal-welcome" })
     }
   }, [messages?.length, addAssistantMessage])
+
+  const currentTasks = currentStreamingId ? tasksByMessage?.[currentStreamingId] : undefined
 
   return (
     <div className="absolute inset-0 flex flex-col">
@@ -105,8 +117,17 @@ export function EtherealChat() {
               </div>
             </motion.div>
           ))}
-        </div>
       </div>
+      </div>
+
+      {/* Task overlay */}
+      {currentTasks?.length ? (
+        <div className="pointer-events-none absolute inset-x-0 bottom-[calc(100px+env(safe-area-inset-bottom))] z-20 flex justify-center px-3">
+          <div className="pointer-events-auto w-full max-w-[900px]">
+            <ActiveTaskOverlay tasks={currentTasks} />
+          </div>
+        </div>
+      ) : null}
 
       {/* Translucent input bar (always visible) */}
       <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20 pb-[calc(12px+env(safe-area-inset-bottom))]">


### PR DESCRIPTION
## Summary
- show active server-driven tasks in Ethereal chat
- render task list overlay during streaming

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Type 'Profile | null' is not assignable to type 'Profile')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c25bcb81a8832384ed6ad32b74dec4