### PR TITLE
refactor: remove unused tool detectors

### DIFF
--- a/lib/toolDetection.ts
+++ b/lib/toolDetection.ts
@@ -1,67 +1,6 @@
 import { ToolCall } from '@/types/chat';
 
 export function detectTool(text: string): ToolCall | null {
-  const lowerText = text.toLowerCase();
-  
-  // Weather detection
-  if (lowerText.includes('weather')) {
-    const location = extractLocation(text) || 'Unknown Location';
-    return {
-      name: 'lookup_weather',
-      summary: `7-day weather forecast for ${location}`,
-      inputs: { location },
-      details: 'Retrieved current conditions and 7-day forecast from weather API. Temperature, precipitation, and wind data included.',
-      rawJson: {
-        location,
-        current: {
-          temp: 65,
-          condition: 'partly_cloudy',
-          humidity: 72
-        },
-        forecast: [
-          { day: 'Today', high: 68, low: 52, condition: 'partly_cloudy' },
-          { day: 'Tomorrow', high: 71, low: 55, condition: 'sunny' }
-        ]
-      }
-    };
-  }
-  
-  // Calculator detection
-  if (lowerText.includes('calc') || lowerText.includes('calculate') || /\d+\s*[+\-*/]\s*\d+/.test(text)) {
-    const expression = extractMathExpression(text) || text;
-    const result = evaluateSafeMath(expression);
-    return {
-      name: 'calculate',
-      summary: `Mathematical calculation: ${expression}`,
-      inputs: { expression },
-      details: `Performed arithmetic calculation using safe math evaluation.`,
-      rawJson: {
-        input: expression,
-        result: result,
-        operation: 'arithmetic'
-      }
-    };
-  }
-  
-  // Search/lookup detection
-  if (lowerText.includes('search') || lowerText.includes('lookup') || lowerText.includes('find')) {
-    const query = extractSearchQuery(text) || text;
-    return {
-      name: 'web_search',
-      summary: `Search results for: ${query}`,
-      inputs: { query },
-      details: 'Performed web search and retrieved relevant results.',
-      rawJson: {
-        query,
-        results: [
-          { title: 'Example Result 1', url: 'https://example.com/1' },
-          { title: 'Example Result 2', url: 'https://example.com/2' }
-        ],
-        total_results: 1250
-      }
-    };
-  }
-  
   // Pattern-based tool detection: [tool:name param=value]
   const toolPattern = /\[tool:(\w+)\s+([^\]]+)\]/i;
   const match = text.match(toolPattern);
@@ -80,45 +19,7 @@ export function detectTool(text: string): ToolCall | null {
       }
     };
   }
-  
-  return null;
-}
 
-function extractLocation(text: string): string | null {
-  const patterns = [
-    /weather.*?in\s+([a-zA-Z\s,]+)/i,
-    /(?:what's|whats).*?weather.*?([a-zA-Z\s,]+)/i
-  ];
-  
-  for (const pattern of patterns) {
-    const match = text.match(pattern);
-    if (match) {
-      return match[1].trim();
-    }
-  }
-  
-  return null;
-}
-
-function extractMathExpression(text: string): string | null {
-  const mathPattern = /(\d+(?:\.\d+)?\s*[+\-*/]\s*\d+(?:\.\d+)?)/;
-  const match = text.match(mathPattern);
-  return match ? match[1] : null;
-}
-
-function extractSearchQuery(text: string): string | null {
-  const patterns = [
-    /(?:search|lookup|find)\s+(?:for\s+)?(.+)/i,
-    /(.+)(?:\s+search|\s+lookup)/i
-  ];
-  
-  for (const pattern of patterns) {
-    const match = text.match(pattern);
-    if (match) {
-      return match[1].trim();
-    }
-  }
-  
   return null;
 }
 
@@ -128,7 +29,7 @@ function parseToolParams(params: string): ToolParams {
   const result: ToolParams = {};
   const paramPattern = /(\w+)=([^\s]+)/g;
   let match;
-  
+
   while ((match = paramPattern.exec(params)) !== null) {
     const [, key, value] = match;
     // Try to parse as number or boolean, otherwise keep as string
@@ -137,17 +38,6 @@ function parseToolParams(params: string): ToolParams {
     else if (!isNaN(Number(value))) result[key] = Number(value);
     else result[key] = value.replace(/['"]/g, '');
   }
-  
-  return result;
-}
 
-function evaluateSafeMath(expression: string): number | string {
-  // Only allow basic math operations for safety
-  const safeExpression = expression.replace(/[^0-9+\-*/.() ]/g, '');
-  try {
-    // Use Function constructor for safe evaluation (limited scope)
-    return new Function(`"use strict"; return (${safeExpression})`)() as number;
-  } catch {
-    return 'Error: Invalid expression';
-  }
+  return result;
 }


### PR DESCRIPTION
## Summary
- drop weather, calculator, and search tool detectors
- simplify `detectTool` to support only pattern-based tools

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Profile | null is not assignable to Profile; unknown property 'text' in use-google-auth)*

------
https://chatgpt.com/codex/tasks/task_e_68c25c4963d88323bb54cef50785be52