### PR TITLE
centralize dev mode feature checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,9 +374,9 @@ npm run dev
 - **Fallback Systems**: Graceful degradation for development and testing scenarios
 
 #### Development Agent Simulator: `/api/chat/dev`
-- **Local Development**: Full-featured agent simulation without external API dependencies  
+- **Local Development**: Full-featured agent simulation without external API dependencies
 - **Task Visualization**: Realistic streaming task steps and reasoning display
-- **Auto-Activation**: Automatically used when `NEXT_PUBLIC_IFS_DEV_MODE=true`
+- **Access Control**: Available only when dev mode is enabled (`NEXT_PUBLIC_IFS_DEV_MODE=true` or `NODE_ENV=development`)
 
 ### Advanced Analytics & Insights Engine
 

--- a/app/api/chat/dev/route.ts
+++ b/app/api/chat/dev/route.ts
@@ -1,8 +1,12 @@
 import { simulateReadableStream } from 'ai'
+import { isDevMode } from '@/config/features'
 
 export const maxDuration = 60
 
 export async function POST() {
+  if (!isDevMode()) {
+    return new Response('Not Found', { status: 404 })
+  }
   const text =
     'here is a simulated answer for dev mode. it should stream in slowly and fade each letter so you can evaluate the ethereal pacing and typography. '
     + 'this stream is intentionally long to demonstrate the animation and throttled updates across multiple chunks. '

--- a/app/dev/flow/page.tsx
+++ b/app/dev/flow/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { isDevMode } from '@/config/features';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -14,15 +15,13 @@ import { AlertTriangle, CheckCircle } from 'lucide-react';
 
 // Dev mode guard
 function DevModeGuard({ children }: { children: React.ReactNode }) {
-  const [isDevMode, setIsDevMode] = useState(false);
+    const [devEnabled, setDevEnabled] = useState(false);
 
-  useEffect(() => {
-    const devMode = process.env.NODE_ENV === 'development' || 
-                    process.env.NEXT_PUBLIC_IFS_DEV_MODE === 'true';
-    setIsDevMode(devMode);
-  }, []);
+    useEffect(() => {
+      setDevEnabled(isDevMode());
+    }, []);
 
-  if (!isDevMode) {
+    if (!devEnabled) {
     return (
       <div className="min-h-screen flex items-center justify-center p-4">
         <Card className="max-w-md">

--- a/app/dev/onboarding/page.tsx
+++ b/app/dev/onboarding/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { isDevMode } from '@/config/features';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -21,16 +22,14 @@ import { AlertTriangle, CheckCircle, XCircle } from 'lucide-react';
 
 // Dev mode guard
 function DevModeGuard({ children }: { children: React.ReactNode }) {
-  const [isDevMode, setIsDevMode] = useState(false);
+    const [devEnabled, setDevEnabled] = useState(false);
 
-  useEffect(() => {
-    // Check if we're in dev mode
-    const devMode = process.env.NODE_ENV === 'development' || 
-                    process.env.NEXT_PUBLIC_IFS_DEV_MODE === 'true';
-    setIsDevMode(devMode);
-  }, []);
+    useEffect(() => {
+      // Check if we're in dev mode using centralized helper
+      setDevEnabled(isDevMode());
+    }, []);
 
-  if (!isDevMode) {
+    if (!devEnabled) {
     return (
       <div className="min-h-screen flex items-center justify-center p-4">
         <Card className="max-w-md">
@@ -39,17 +38,17 @@ function DevModeGuard({ children }: { children: React.ReactNode }) {
           </CardHeader>
           <CardContent>
             <p>This development tool is only available in development mode.</p>
-            <p className="text-sm text-muted-foreground mt-2">
-              Set <code>NEXT_PUBLIC_IFS_DEV_MODE=true</code> to access.
-            </p>
+              <p className="text-sm text-muted-foreground mt-2">
+                Set <code>NEXT_PUBLIC_IFS_DEV_MODE=true</code> to access.
+              </p>
           </CardContent>
         </Card>
       </div>
     );
   }
 
-  return <>{children}</>;
-}
+    return <>{children}</>;
+  }
 
 type Stage2Results = {
   selection: { ids: string[]; rationale: { top_themes: string[] } & Record<string, unknown> };

--- a/config/dev.ts
+++ b/config/dev.ts
@@ -1,4 +1,5 @@
 import { env } from './env'
+import { isDevMode } from './features'
 import { TEST_PERSONAS, getPersonaUserId, getCurrentPersona, type TestPersona } from './personas'
 
 // Compute dev flags using centralized environment parsing so behaviour
@@ -6,7 +7,7 @@ import { TEST_PERSONAS, getPersonaUserId, getCurrentPersona, type TestPersona } 
 const currentPersonaEnv = (env.IFS_TEST_PERSONA ?? env.NEXT_PUBLIC_IFS_TEST_PERSONA ?? 'beginner') as TestPersona
 
 export const dev = {
-  enabled: env.ifsDevMode,
+  enabled: isDevMode(),
   defaultUserId: env.IFS_DEFAULT_USER_ID ?? null,
   verbose: env.ifsVerbose,
   disablePolarizationUpdate: env.ifsDisablePolarizationUpdate,

--- a/config/env.ts
+++ b/config/env.ts
@@ -30,8 +30,12 @@ export const env = {
   isProd: raw.NODE_ENV === 'production',
   isDev: raw.NODE_ENV !== 'production',
   isTest: raw.NODE_ENV === 'test',
-  // Enable IFS dev mode when explicitly requested or when running tests
-  ifsDevMode: raw.NODE_ENV === 'test' || toBool(raw.IFS_DEV_MODE) || toBool(raw.NEXT_PUBLIC_IFS_DEV_MODE),
+  // Enable IFS dev mode in development, tests, or when explicitly requested
+  ifsDevMode:
+    raw.NODE_ENV === 'development' ||
+    raw.NODE_ENV === 'test' ||
+    toBool(raw.IFS_DEV_MODE) ||
+    toBool(raw.NEXT_PUBLIC_IFS_DEV_MODE),
   ifsVerbose: toBool(raw.IFS_VERBOSE),
   ifsDisablePolarizationUpdate: toBool(raw.IFS_DISABLE_POLARIZATION_UPDATE),
 }

--- a/config/features.ts
+++ b/config/features.ts
@@ -1,3 +1,5 @@
+import { env } from './env'
+
 export type FeatureStatus = 'enabled' | 'coming_soon' | 'disabled'
 export type FeatureKey =
   | 'chat'
@@ -11,9 +13,11 @@ export type FeatureKey =
 
 const isTrue = (v?: string) => v === 'true' || v === '1' || v === 'on'
 
-export const devMode =
-  isTrue(process.env.NEXT_PUBLIC_IFS_DEV_MODE) ||
-  process.env.NODE_ENV === 'development'
+export function isDevMode(): boolean {
+  return env.ifsDevMode
+}
+
+const devMode = isDevMode()
 
 // Whether to show the "Enable Dev Mode" toggle in the UI.
 // Default behavior: show in development, hide in production unless explicitly enabled.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -33,6 +33,8 @@ This guide explains how to configure the IFS Therapy application for development
 - `NEXT_PUBLIC_IFS_DEV_MODE=true` - Enables development mode features across SSR and CSR
 - `IFS_DEFAULT_USER_ID` - UUID to use as default user ID when none provided
 
+In code, prefer using `isDevMode()` from `config/features` to check whether development mode is active.
+
 ### Optional Development Variables
 
 - `NEXT_PUBLIC_IFS_SHOW_DEV_TOGGLE=true` - Shows an in-app "Enable Dev Mode" control on the home header (hidden by default in production). Clicking it sets a localStorage override used on the client.

--- a/docs/dev-mode.md
+++ b/docs/dev-mode.md
@@ -3,7 +3,7 @@
 This app uses a simple feature flag system to gate routes (e.g., Insights, Garden, Journey) while they’re being built. Dev mode makes local iteration easier by enabling non-production areas without flipping each flag.
 
 ## Feature gate behavior
-- Central config: `config/features.ts`
+- Central config: `config/features.ts` (use `isDevMode()` helper for checks)
 - Status values: `enabled | coming_soon | disabled`
 - In dev mode, any feature that is not `disabled` is treated as `enabled` on the client.
 


### PR DESCRIPTION
## Summary
- centralize dev mode check in `config/features.ts` and update server/client code to use it
- gate `/api/chat/dev` behind dev mode and document the route
- clarify dev mode helper usage in docs

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Profile | null not assignable to Profile; Google auth button theme errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c289f4c6b483238986928fcb8b0c9c