### PR TITLE
refactor: type-safe chat state

### DIFF
--- a/lib/hooks/use-google-auth.ts
+++ b/lib/hooks/use-google-auth.ts
@@ -20,7 +20,14 @@ declare global {
           ) => void;
           renderButton: (
             container: HTMLElement | null,
-            options: { theme: 'outline' | 'filled_blue' | 'filled_black' | 'standard' | 'icon' | 'text'; size: 'large' | 'medium' | 'small'; width?: string }
+            options: {
+              theme: 'outline' | 'filled_blue' | 'filled_black' | 'standard' | 'icon' | 'text';
+              size: 'large' | 'medium' | 'small';
+              width?: string;
+              text?: string;
+              shape?: string;
+              logo_alignment?: string;
+            }
           ) => void;
         };
       };


### PR DESCRIPTION
## Summary
- strongly type chat state and remove `as any` casts
- extend Google auth renderButton options to handle extra properties

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c289f687fc83238356a31dde518247