### PR TITLE
End chat sessions on component unmount

### DIFF
--- a/components/ethereal/EtherealChat.tsx
+++ b/components/ethereal/EtherealChat.tsx
@@ -38,6 +38,13 @@ export function EtherealChat() {
   const [confirmOpen, setConfirmOpen] = useState(false)
   const inputRef = useRef<HTMLTextAreaElement>(null)
 
+  // End any active session when this component unmounts
+  useEffect(() => {
+    return () => {
+      if (hasActiveSession) void endSession()
+    }
+  }, [hasActiveSession, endSession])
+
   // Auto-resize textarea
   useEffect(() => {
     if (!inputRef.current) return


### PR DESCRIPTION
## Summary
- ensure EtherealChat ends any active session when component unmounts
- add unmount cleanup in legacy ChatLayout to end active sessions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c289f825788323b35c591c72635a14