### PR TITLE
refactor: remove deprecated tool messaging types

### DIFF
--- a/types/chat.ts
+++ b/types/chat.ts
@@ -13,17 +13,8 @@ export interface Message {
   content: string;
   timestamp: number;
   persona?: 'claude' | 'default';
-  tool?: ToolCall; // deprecated: replaced by server-driven TaskEvent UI
   streaming?: boolean;
   tasks?: TaskEvent[]; // server-driven tasks for this assistant message
-}
-
-export interface ToolCall {
-  name: string;
-  summary: string;
-  inputs?: Record<string, any>;
-  details?: string;
-  rawJson?: any;
 }
 
 export interface ChatState {


### PR DESCRIPTION
## Summary
- remove deprecated `tool` property and `ToolCall` interface from Message type

## Testing
- `npm run typecheck` *(fails: Profile | null not assignable to Profile)*

------
https://chatgpt.com/codex/tasks/task_e_68c289f95f8083239fcaa58492b46a27