### PR TITLE
Refactor Mastra initialization for on-demand instantiation

### DIFF
--- a/app/api/chat/logic.ts
+++ b/app/api/chat/logic.ts
@@ -46,9 +46,10 @@ export async function handleAgentStream(
   profile: Record<string, unknown>
 ): Promise<Response> {
   try {
-    // Lazy-load the agent only when credentials are available to avoid dev import side-effects
-    const { createIfsAgent } = await import('../../../mastra/agents/ifs-agent')
-    const ifsAgent = createIfsAgent(profile)
+    // Lazy-load Mastra only when credentials are available to avoid dev import side-effects
+    const { createMastra } = await import('@/mastra')
+    const mastra = createMastra(profile)
+    const ifsAgent = mastra.getAgent('ifsAgent')
 
     // Prefer vNext streaming in AI SDK (UI message) format so we can parse consistently on the client
     const agent = ifsAgent as unknown as Partial<{

--- a/app/api/cron/generate-insights/route.ts
+++ b/app/api/cron/generate-insights/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { mastra } from '@/mastra';
+import { getMastra } from '@/mastra';
 import { createClient } from '@/lib/supabase/server';
 import type { Json } from '@/lib/types/database';
 
@@ -83,6 +83,7 @@ export async function GET(request: Request) {
     }
 
     console.log(`[Cron] Processing user ${userId}.`);
+    const mastra = getMastra();
     const insightWorkflow = mastra.getWorkflow('generateInsightWorkflow');
     const workflowRun = await insightWorkflow.execute({
       input: { userId },

--- a/app/api/insights/request/route.ts
+++ b/app/api/insights/request/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { mastra } from '@/mastra';
+import { getMastra } from '@/mastra';
 import { createClient } from '@/lib/supabase/server';
 import { resolveUserId } from '@/config/dev';
 import type { Json } from '@/lib/types/database';
@@ -50,6 +50,7 @@ export async function POST(req: Request) {
 
     console.log(`Insight generation request received for user: ${userId}`);
 
+    const mastra = getMastra();
     const insightWorkflow = mastra.getWorkflow('generateInsightWorkflow');
 
     const workflowRun = await insightWorkflow.execute({

--- a/mastra/index.ts
+++ b/mastra/index.ts
@@ -4,16 +4,29 @@ import { createIfsAgent } from './agents/ifs-agent'
 import { insightGeneratorAgent } from './agents/insight-generator'
 import { generateInsightWorkflow } from './workflows/generate-insight-workflow'
 
-export const mastra = (new Mastra({
-  logger: new PinoLogger({
-    name: 'IFS-Therapy-App',
-    level: 'info',
-  }),
-  agents: {
-    ifsAgent: createIfsAgent(null),
-    insightGeneratorAgent,
-  },
-  workflows: {
-    generateInsightWorkflow,
-  },
-})) as any
+type Profile = Parameters<typeof createIfsAgent>[0]
+
+let mastraInstance: any = null
+
+export function createMastra(profile: Profile = null) {
+  return (new Mastra({
+    logger: new PinoLogger({
+      name: 'IFS-Therapy-App',
+      level: 'info',
+    }),
+    agents: {
+      ifsAgent: createIfsAgent(profile),
+      insightGeneratorAgent,
+    },
+    workflows: {
+      generateInsightWorkflow,
+    },
+  })) as any
+}
+
+export function getMastra(profile: Profile = null) {
+  if (!mastraInstance) {
+    mastraInstance = createMastra(profile)
+  }
+  return mastraInstance as any
+}

--- a/mastra/workflows/generate-insight-workflow.ts
+++ b/mastra/workflows/generate-insight-workflow.ts
@@ -1,7 +1,7 @@
 import { createWorkflow } from '@mastra/core';
 import { z } from 'zod';
 import { insightResearchTools, getRecentSessions, getActiveParts, getPolarizedRelationships, getRecentInsights } from '../tools/insight-research-tools';
-import { mastra } from '..';
+import { getMastra } from '..';
 
 const workflowInputSchema = z.object({
   userId: z.string().uuid(),
@@ -48,6 +48,7 @@ export const generateInsightWorkflow = createWorkflow({
           Recent Insights: ${JSON.stringify(researchStepOutput.recentInsights, null, 2)}
         `;
 
+        const mastra = getMastra();
         const insightAgent = mastra.getAgent('insightGeneratorAgent');
         const agentRun = await insightAgent.run({
           input: researchSummary,


### PR DESCRIPTION
## Summary
- add `createMastra` and `getMastra` factories to instantiate Mastra when needed
- update chat, cron, and insights API handlers to request a Mastra instance at runtime
- defer insight workflow agent lookup via `getMastra`

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Profile | null is not assignable to type 'Profile'; object literal may only specify known properties)*
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c289f9cc388323b84f7d0bddbe60e0