### PR TITLE
refactor: centralize part schema definitions

### DIFF
--- a/mastra/tools/part-schemas.ts
+++ b/mastra/tools/part-schemas.ts
@@ -1,0 +1,250 @@
+import { z } from 'zod'
+
+export const searchPartsSchema = z.object({
+  query: z.string().optional().describe('Search query for part names or roles'),
+  status: z
+    .enum(['emerging', 'acknowledged', 'active', 'integrated'])
+    .optional()
+    .describe('Filter by part status'),
+  category: z
+    .enum(['manager', 'firefighter', 'exile', 'unknown'])
+    .optional()
+    .describe('Filter by part category'),
+  limit: z
+    .number()
+    .min(1)
+    .max(50)
+    .default(20)
+    .describe('Maximum number of results to return'),
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User ID for the search (optional in development mode)'),
+})
+
+export const getPartByIdSchema = z.object({
+  partId: z.string().uuid().describe('The UUID of the part to retrieve'),
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User ID who owns the part (optional in development mode)'),
+})
+
+export const getPartDetailSchema = z.object({
+  partId: z.string().uuid().describe('The UUID of the part to retrieve details for'),
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User ID who owns the part (optional in development mode)'),
+})
+
+export const createEmergingPartSchema = z.object({
+  name: z.string().min(1).max(100).describe('Name of the emerging part'),
+  evidence: z
+    .array(
+      z.object({
+        type: z.enum(['direct_mention', 'pattern', 'behavior', 'emotion']),
+        content: z.string(),
+        confidence: z.number().min(0).max(1),
+        sessionId: z.string().uuid(),
+        timestamp: z.string().datetime(),
+      })
+    )
+    .min(3)
+    .describe('Evidence supporting the part (minimum 3 required)'),
+  category: z
+    .enum(['manager', 'firefighter', 'exile', 'unknown'])
+    .optional()
+    .default('unknown'),
+  age: z
+    .number()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe('Perceived age of the part'),
+  role: z.string().optional().describe('Role or function of the part'),
+  triggers: z
+    .array(z.string())
+    .optional()
+    .default([])
+    .describe('Known triggers for this part'),
+  emotions: z
+    .array(z.string())
+    .optional()
+    .default([])
+    .describe('Emotions associated with this part'),
+  beliefs: z
+    .array(z.string())
+    .optional()
+    .default([])
+    .describe('Beliefs held by this part'),
+  somaticMarkers: z
+    .array(z.string())
+    .optional()
+    .default([])
+    .describe('Physical sensations associated with this part'),
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User ID who owns the part (optional in development mode)'),
+  userConfirmed: z
+    .boolean()
+    .describe('Whether the user has confirmed this part exists through chat interaction'),
+})
+
+export const updatePartSchema = z.object({
+  partId: z.string().uuid().describe('The UUID of the part to update'),
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User ID who owns the part (optional in development mode)'),
+  updates: z
+    .object({
+      name: z.string().min(1).max(100).optional(),
+      status: z
+        .enum(['emerging', 'acknowledged', 'active', 'integrated'])
+        .optional(),
+      category: z
+        .enum(['manager', 'firefighter', 'exile', 'unknown'])
+        .optional(),
+      age: z.number().min(0).max(100).optional(),
+      role: z.string().optional(),
+      triggers: z.array(z.string()).optional(),
+      emotions: z.array(z.string()).optional(),
+      beliefs: z.array(z.string()).optional(),
+      somaticMarkers: z.array(z.string()).optional(),
+      visualization: z
+        .object({
+          emoji: z.string(),
+          color: z.string(),
+        })
+        .optional(),
+      confidenceBoost: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe('Amount to adjust identification confidence by (explicit only)'),
+      last_charged_at: z
+        .string()
+        .datetime()
+        .optional()
+        .describe("Timestamp for when the part's charge was last updated"),
+      last_charge_intensity: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe("Intensity of the part's last charge (0 to 1)"),
+    })
+    .describe('Fields to update'),
+  evidence: z
+    .object({
+      type: z.enum(['direct_mention', 'pattern', 'behavior', 'emotion']),
+      content: z.string(),
+      confidence: z.number().min(0).max(1),
+      sessionId: z.string().uuid(),
+      timestamp: z.string().datetime(),
+    })
+    .optional()
+    .describe('New evidence to add for this update'),
+  auditNote: z
+    .string()
+    .optional()
+    .describe('Note about why this update was made'),
+})
+
+export const getPartRelationshipsSchema = z.object({
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User ID to get relationships for (optional in development mode)'),
+  partId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('Optional: Get relationships for specific part'),
+  relationshipType: z
+    .enum(['polarized', 'protector-exile', 'allied'])
+    .optional()
+    .describe('Optional: Filter by relationship type'),
+  status: z
+    .enum(['active', 'healing', 'resolved'])
+    .optional()
+    .describe('Optional: Filter by relationship status'),
+  includePartDetails: z
+    .boolean()
+    .default(false)
+    .describe('Include part names and status in response'),
+  limit: z
+    .number()
+    .min(1)
+    .max(50)
+    .default(20)
+    .describe('Maximum number of relationships to return'),
+})
+
+export const logRelationshipSchema = z.object({
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User ID who owns the relationship (optional in development mode)'),
+  partIds: z
+    .array(z.string().uuid())
+    .min(2)
+    .max(2)
+    .describe('Exactly two part IDs involved in the relationship'),
+  type: z
+    .enum(['polarized', 'protector-exile', 'allied'])
+    .describe('Relationship type'),
+  description: z.string().optional().describe('Short description of the relationship'),
+  issue: z.string().optional().describe('Primary point of conflict or issue'),
+  commonGround: z
+    .string()
+    .optional()
+    .describe('Areas of agreement or shared goals'),
+  status: z
+    .enum(['active', 'healing', 'resolved'])
+    .optional()
+    .describe('Relationship status'),
+  polarizationLevel: z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .describe('Absolute polarization level to set (0..1)'),
+  dynamic: z
+    .object({
+      observation: z.string().min(1).describe('What was noticed about the interaction'),
+      context: z.string().min(1).describe('Context where this dynamic occurred'),
+      polarizationChange: z
+        .number()
+        .min(-1)
+        .max(1)
+        .optional()
+        .describe('Relative change in polarization (-1..1)'),
+      timestamp: z
+        .string()
+        .datetime()
+        .optional()
+        .describe('When this dynamic occurred (defaults to now)'),
+    })
+    .optional(),
+  lastAddressed: z
+    .string()
+    .datetime()
+    .optional()
+    .describe('When this relationship was last addressed'),
+  upsert: z
+    .boolean()
+    .default(true)
+    .describe('Update existing relationship if it exists; otherwise create'),
+})
+

--- a/mastra/tools/part-tools.mastra.ts
+++ b/mastra/tools/part-tools.mastra.ts
@@ -9,98 +9,14 @@ import {
   logRelationship,
 } from '@/lib/data/parts-server'
 import {
-  // reuse schemas from part-tools via type inference
-} from './part-tools'
-import { z } from 'zod'
-
-// Re-declare schemas with zod to satisfy createTool inputs without importing @mastra/core in client modules.
-// These must match the shapes in part-tools.ts
-const searchPartsSchema = z.object({
-  query: z.string().optional(),
-  status: z.enum(['emerging', 'acknowledged', 'active', 'integrated']).optional(),
-  category: z.enum(['manager', 'firefighter', 'exile', 'unknown']).optional(),
-  limit: z.number().min(1).max(50).default(20),
-})
-
-const getPartByIdSchema = z.object({
-  partId: z.string().uuid(),
-})
-
-const getPartDetailSchema = z.object({
-  partId: z.string().uuid(),
-})
-
-const createEmergingPartSchema = z.object({
-  name: z.string().min(1).max(100),
-  evidence: z.array(z.object({
-    type: z.enum(['direct_mention', 'pattern', 'behavior', 'emotion']),
-    content: z.string(),
-    confidence: z.number().min(0).max(1),
-    sessionId: z.string().uuid(),
-    timestamp: z.string().datetime()
-  })).min(3),
-  category: z.enum(['manager', 'firefighter', 'exile', 'unknown']).optional().default('unknown'),
-  age: z.number().min(0).max(100).optional(),
-  role: z.string().optional(),
-  triggers: z.array(z.string()).optional().default([]),
-  emotions: z.array(z.string()).optional().default([]),
-  beliefs: z.array(z.string()).optional().default([]),
-  somaticMarkers: z.array(z.string()).optional().default([]),
-  userConfirmed: z.boolean(),
-})
-
-const updatePartSchema = z.object({
-  partId: z.string().uuid(),
-  updates: z.object({
-    name: z.string().min(1).max(100).optional(),
-    status: z.enum(['emerging', 'acknowledged', 'active', 'integrated']).optional(),
-    category: z.enum(['manager', 'firefighter', 'exile', 'unknown']).optional(),
-    age: z.number().min(0).max(100).optional(),
-    role: z.string().optional(),
-    triggers: z.array(z.string()).optional(),
-    emotions: z.array(z.string()).optional(),
-    beliefs: z.array(z.string()).optional(),
-    somaticMarkers: z.array(z.string()).optional(),
-    visualization: z.object({ emoji: z.string(), color: z.string() }).optional(),
-    confidenceBoost: z.number().min(0).max(1).optional(),
-    last_charged_at: z.string().datetime().optional(),
-    last_charge_intensity: z.number().min(0).max(1).optional(),
-  }),
-  evidence: z.object({
-    type: z.enum(['direct_mention', 'pattern', 'behavior', 'emotion']),
-    content: z.string(),
-    confidence: z.number().min(0).max(1),
-    sessionId: z.string().uuid(),
-    timestamp: z.string().datetime()
-  }).optional(),
-  auditNote: z.string().optional(),
-})
-
-const getPartRelationshipsSchema = z.object({
-  partId: z.string().uuid().optional(),
-  relationshipType: z.enum(['polarized', 'protector-exile', 'allied']).optional(),
-  status: z.enum(['active', 'healing', 'resolved']).optional(),
-  includePartDetails: z.boolean().default(false),
-  limit: z.number().min(1).max(50).default(20),
-})
-
-const logRelationshipSchema = z.object({
-  partIds: z.array(z.string().uuid()).min(2).max(2),
-  type: z.enum(['polarized', 'protector-exile', 'allied']),
-  description: z.string().optional(),
-  issue: z.string().optional(),
-  commonGround: z.string().optional(),
-  status: z.enum(['active', 'healing', 'resolved']).optional(),
-  polarizationLevel: z.number().min(0).max(1).optional(),
-  dynamic: z.object({
-    observation: z.string().min(1),
-    context: z.string().min(1),
-    polarizationChange: z.number().min(-1).max(1).optional(),
-    timestamp: z.string().datetime().optional(),
-  }).optional(),
-  lastAddressed: z.string().datetime().optional(),
-  upsert: z.boolean().default(true),
-})
+  searchPartsSchema,
+  getPartByIdSchema,
+  getPartDetailSchema,
+  createEmergingPartSchema,
+  updatePartSchema,
+  getPartRelationshipsSchema,
+  logRelationshipSchema,
+} from './part-schemas'
 
 
 export function getPartTools(userId?: string) {

--- a/mastra/tools/part-tools.ts
+++ b/mastra/tools/part-tools.ts
@@ -5,105 +5,29 @@ import { actionLogger } from '../../lib/database/action-logger'
 import { isMemoryV2Enabled } from '@/lib/memory/config'
 import { onPartCreated, onPartUpdated } from '@/lib/memory/snapshots/updater'
 import { resolveUserId, requiresUserConfirmation, devLog, dev } from '@/config/dev'
-import type { Database, PartRow, PartInsert, PartUpdate, PartEvidence, PartRelationshipRow, PartRelationshipInsert, PartRelationshipUpdate, RelationshipType, RelationshipStatus, ToolResult, RelationshipDynamic } from '../../lib/types/database'
-
-// Input schemas for tool validation
-const searchPartsSchema = z.object({
-  query: z.string().optional().describe('Search query for part names or roles'),
-  status: z.enum(['emerging', 'acknowledged', 'active', 'integrated']).optional().describe('Filter by part status'),
-  category: z.enum(['manager', 'firefighter', 'exile', 'unknown']).optional().describe('Filter by part category'),
-  limit: z.number().min(1).max(50).default(20).describe('Maximum number of results to return'),
-  userId: z.string().uuid().optional().describe('User ID for the search (optional in development mode)')
-})
-
-const getPartByIdSchema = z.object({
-  partId: z.string().uuid().describe('The UUID of the part to retrieve'),
-  userId: z.string().uuid().optional().describe('User ID who owns the part (optional in development mode)')
-})
-
-const getPartDetailSchema = z.object({
-  partId: z.string().uuid().describe('The UUID of the part to retrieve details for'),
-  userId: z.string().uuid().optional().describe('User ID who owns the part (optional in development mode)')
-})
-
-const createEmergingPartSchema = z.object({
-  name: z.string().min(1).max(100).describe('Name of the emerging part'),
-  evidence: z.array(z.object({
-    type: z.enum(['direct_mention', 'pattern', 'behavior', 'emotion']),
-    content: z.string(),
-    confidence: z.number().min(0).max(1),
-    sessionId: z.string().uuid(),
-    timestamp: z.string().datetime()
-  })).min(3).describe('Evidence supporting the part (minimum 3 required)'),
-  category: z.enum(['manager', 'firefighter', 'exile', 'unknown']).optional().default('unknown'),
-  age: z.number().min(0).max(100).optional().describe('Perceived age of the part'),
-  role: z.string().optional().describe('Role or function of the part'),
-  triggers: z.array(z.string()).optional().default([]).describe('Known triggers for this part'),
-  emotions: z.array(z.string()).optional().default([]).describe('Emotions associated with this part'),
-  beliefs: z.array(z.string()).optional().default([]).describe('Beliefs held by this part'),
-  somaticMarkers: z.array(z.string()).optional().default([]).describe('Physical sensations associated with this part'),
-  userId: z.string().uuid().optional().describe('User ID who owns the part (optional in development mode)'),
-  userConfirmed: z.boolean().describe('Whether the user has confirmed this part exists through chat interaction')
-})
-
-const updatePartSchema = z.object({
-  partId: z.string().uuid().describe('The UUID of the part to update'),
-  userId: z.string().uuid().optional().describe('User ID who owns the part (optional in development mode)'),
-  updates: z.object({
-    name: z.string().min(1).max(100).optional(),
-    status: z.enum(['emerging', 'acknowledged', 'active', 'integrated']).optional(),
-    category: z.enum(['manager', 'firefighter', 'exile', 'unknown']).optional(),
-    age: z.number().min(0).max(100).optional(),
-    role: z.string().optional(),
-    triggers: z.array(z.string()).optional(),
-    emotions: z.array(z.string()).optional(),
-    beliefs: z.array(z.string()).optional(),
-    somaticMarkers: z.array(z.string()).optional(),
-    visualization: z.object({
-      emoji: z.string(),
-      color: z.string(),
-    }).optional(),
-    confidenceBoost: z.number().min(0).max(1).optional().describe('Amount to adjust identification confidence by (explicit only)'),
-    last_charged_at: z.string().datetime().optional().describe("Timestamp for when the part's charge was last updated"),
-    last_charge_intensity: z.number().min(0).max(1).optional().describe("Intensity of the part's last charge (0 to 1)")
-  }).describe('Fields to update'),
-  evidence: z.object({
-    type: z.enum(['direct_mention', 'pattern', 'behavior', 'emotion']),
-    content: z.string(),
-    confidence: z.number().min(0).max(1),
-    sessionId: z.string().uuid(),
-    timestamp: z.string().datetime()
-  }).optional().describe('New evidence to add for this update'),
-  auditNote: z.string().optional().describe('Note about why this update was made')
-})
-
-const getPartRelationshipsSchema = z.object({
-  userId: z.string().uuid().optional().describe('User ID to get relationships for (optional in development mode)'),
-  partId: z.string().uuid().optional().describe('Optional: Get relationships for specific part'),
-  relationshipType: z.enum(['polarized', 'protector-exile', 'allied']).optional().describe('Optional: Filter by relationship type'),
-  status: z.enum(['active', 'healing', 'resolved']).optional().describe('Optional: Filter by relationship status'),
-  includePartDetails: z.boolean().default(false).describe('Include part names and status in response'),
-  limit: z.number().min(1).max(50).default(20).describe('Maximum number of relationships to return')
-})
-
-const logRelationshipSchema = z.object({
-  userId: z.string().uuid().optional().describe('User ID who owns the relationship (optional in development mode)'),
-  partIds: z.array(z.string().uuid()).min(2).max(2).describe('Exactly two part IDs involved in the relationship'),
-  type: z.enum(['polarized', 'protector-exile', 'allied']).describe('Relationship type'),
-  description: z.string().optional().describe('Short description of the relationship'),
-  issue: z.string().optional().describe('Primary point of conflict or issue'),
-  commonGround: z.string().optional().describe('Areas of agreement or shared goals'),
-  status: z.enum(['active', 'healing', 'resolved']).optional().describe('Relationship status'),
-  polarizationLevel: z.number().min(0).max(1).optional().describe('Absolute polarization level to set (0..1)'),
-  dynamic: z.object({
-    observation: z.string().min(1).describe('What was noticed about the interaction'),
-    context: z.string().min(1).describe('Context where this dynamic occurred'),
-    polarizationChange: z.number().min(-1).max(1).optional().describe('Relative change in polarization (-1..1)'),
-    timestamp: z.string().datetime().optional().describe('When this dynamic occurred (defaults to now)')
-  }).optional(),
-  lastAddressed: z.string().datetime().optional().describe('When this relationship was last addressed'),
-  upsert: z.boolean().default(true).describe('Update existing relationship if it exists; otherwise create')
-})
+import type {
+  Database,
+  PartRow,
+  PartInsert,
+  PartUpdate,
+  PartEvidence,
+  PartRelationshipRow,
+  PartRelationshipInsert,
+  PartRelationshipUpdate,
+  RelationshipType,
+  RelationshipStatus,
+  ToolResult,
+  RelationshipDynamic,
+} from '../../lib/types/database'
+import {
+  searchPartsSchema,
+  getPartByIdSchema,
+  getPartDetailSchema,
+  createEmergingPartSchema,
+  updatePartSchema,
+  getPartRelationshipsSchema,
+  logRelationshipSchema,
+} from './part-schemas'
 
 // Helper to resolve env with fallbacks (supports Vite and Next-style vars)
 function getEnvVar(keys: string[]): string | undefined {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
-    "test:unit": "npm exec tsx scripts/tests/unit/scoring.test.ts && npm exec tsx scripts/tests/unit/selector.test.ts && npm exec tsx scripts/tests/unit/prompt.test.ts && npm exec tsx scripts/tests/unit/security.test.ts",
+    "test:unit": "npm exec tsx scripts/tests/unit/scoring.test.ts && npm exec tsx scripts/tests/unit/selector.test.ts && npm exec tsx scripts/tests/unit/prompt.test.ts && npm exec tsx scripts/tests/unit/security.test.ts && npm exec tsx scripts/tests/unit/part-schemas.test.ts",
     "test": "npm run test:unit && tsx scripts/test-onboarding.ts",
     "dev:mastra": "mastra dev --dir mastra",
     "build:mastra": "mastra build --dir mastra",

--- a/scripts/tests/unit/part-schemas.test.ts
+++ b/scripts/tests/unit/part-schemas.test.ts
@@ -1,0 +1,132 @@
+import {
+  searchPartsSchema,
+  getPartByIdSchema,
+  getPartDetailSchema,
+  createEmergingPartSchema,
+  updatePartSchema,
+  getPartRelationshipsSchema,
+  logRelationshipSchema,
+} from '../../../mastra/tools/part-schemas'
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(message)
+}
+
+async function main() {
+  const uuid1 = '11111111-1111-1111-1111-111111111111'
+  const uuid2 = '22222222-2222-2222-2222-222222222222'
+  const uuid3 = '33333333-3333-3333-3333-333333333333'
+  const uuid4 = '44444444-4444-4444-4444-444444444444'
+  const now = new Date().toISOString()
+
+  searchPartsSchema.parse({
+    query: 'firefighter',
+    status: 'emerging',
+    category: 'manager',
+    limit: 5,
+    userId: uuid1,
+  })
+
+  getPartByIdSchema.parse({ partId: uuid1, userId: uuid2 })
+  getPartDetailSchema.parse({ partId: uuid1, userId: uuid2 })
+
+  createEmergingPartSchema.parse({
+    name: 'Inner Critic',
+    evidence: [
+      {
+        type: 'direct_mention',
+        content: 'Said I am not good',
+        confidence: 0.9,
+        sessionId: uuid3,
+        timestamp: now,
+      },
+      {
+        type: 'pattern',
+        content: 'Always complains',
+        confidence: 0.8,
+        sessionId: uuid3,
+        timestamp: now,
+      },
+      {
+        type: 'behavior',
+        content: 'Avoids tasks',
+        confidence: 0.7,
+        sessionId: uuid3,
+        timestamp: now,
+      },
+    ],
+    category: 'manager',
+    age: 12,
+    role: 'Critic',
+    triggers: ['failure'],
+    emotions: ['shame'],
+    beliefs: ['must be perfect'],
+    somaticMarkers: ['tight chest'],
+    userId: uuid2,
+    userConfirmed: true,
+  })
+
+  updatePartSchema.parse({
+    partId: uuid1,
+    userId: uuid2,
+    updates: {
+      name: 'New Name',
+      status: 'acknowledged',
+      category: 'manager',
+      age: 13,
+      role: 'Helper',
+      triggers: ['stress'],
+      emotions: ['anger'],
+      beliefs: ['I must protect'],
+      somaticMarkers: ['stiff shoulders'],
+      visualization: { emoji: '🔥', color: '#ff0000' },
+      confidenceBoost: 0.1,
+      last_charged_at: now,
+      last_charge_intensity: 0.5,
+    },
+    evidence: {
+      type: 'behavior',
+      content: 'Calmed down',
+      confidence: 0.8,
+      sessionId: uuid3,
+      timestamp: now,
+    },
+    auditNote: 'Updated after session',
+  })
+
+  getPartRelationshipsSchema.parse({
+    userId: uuid2,
+    partId: uuid1,
+    relationshipType: 'polarized',
+    status: 'active',
+    includePartDetails: true,
+    limit: 10,
+  })
+
+  logRelationshipSchema.parse({
+    userId: uuid2,
+    partIds: [uuid1, uuid4],
+    type: 'allied',
+    description: 'Work together',
+    issue: 'None',
+    commonGround: 'Shared goal',
+    status: 'active',
+    polarizationLevel: 0.2,
+    dynamic: {
+      observation: 'Helped each other',
+      context: 'Meeting',
+      polarizationChange: -0.1,
+      timestamp: now,
+    },
+    lastAddressed: now,
+    upsert: true,
+  })
+
+  assert(true, 'schemas validated')
+  console.log('part-schemas unit test passed')
+}
+
+main().catch((err) => {
+  console.error('part-schemas unit test failed:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- extract Zod schemas for part tools into shared `part-schemas` module
- consume shared schemas in both `part-tools.ts` and `part-tools.mastra.ts`
- add unit test validating schema payloads

## Testing
- `npm run test:unit` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c289fc70008323a30a069f25827f55