### PR TITLE
Refactor part tool error handling

### DIFF
--- a/app/garden/actions.ts
+++ b/app/garden/actions.ts
@@ -41,21 +41,21 @@ export async function updatePartDetails(formData: FormData) {
       color: '#6B7280',
   }
 
-  const result = await updatePart({
-    partId,
-    updates: {
-      name,
-      visualization: newVisualization,
-    },
-    auditNote: 'Updated name and emoji from Garden UI',
-  })
+  try {
+    const updated = await updatePart({
+      partId,
+      updates: {
+        name,
+        visualization: newVisualization,
+      },
+      auditNote: 'Updated name and emoji from Garden UI',
+    })
 
-  if (result.success) {
     // Revalidate the path to ensure the page is updated with the new data
     revalidatePath(`/garden/${partId}`)
     revalidatePath('/garden') // Also revalidate the main garden page
-    return { success: true, data: result.data }
-  } else {
-    return { success: false, error: result.error }
+    return { success: true, data: updated }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) }
   }
 }

--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -33,19 +33,23 @@ export function useChat() {
       // This is a new chat session focused on a specific part.
       // Let's create a custom initial message.
       const fetchPartAndStart = async () => {
-        const result = await getPartById({ partId })
-        if (result.success && result.data) {
-          const partName = result.data.name
-          const initialMessage: Message = {
-            id: generateId(),
-            role: 'assistant',
-            content: `Let's talk about your "${partName}" part. What's on your mind regarding it?`,
-            timestamp: Date.now(),
-            persona: 'claude',
-            streaming: false,
-            tasks: [],
+        try {
+          const part = await getPartById({ partId })
+          if (part) {
+            const partName = part.name
+            const initialMessage: Message = {
+              id: generateId(),
+              role: 'assistant',
+              content: `Let's talk about your "${partName}" part. What's on your mind regarding it?`,
+              timestamp: Date.now(),
+              persona: 'claude',
+              streaming: false,
+              tasks: [],
+            }
+            setState((prev: any) => ({ ...prev, messages: [initialMessage] }))
           }
-          setState((prev: any) => ({ ...prev, messages: [initialMessage] }))
+        } catch {
+          // ignore errors fetching part
         }
       }
       fetchPartAndStart()

--- a/lib/data/parts-lite.ts
+++ b/lib/data/parts-lite.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import type { Database, PartRow, ToolResult, PartRelationshipRow } from '@/lib/types/database'
+import type { Database, PartRow, PartRelationshipRow } from '@/lib/types/database'
 import { createClient as createBrowserSupabase } from '@/lib/supabase/client'
 
 function getSupabaseClient() {
@@ -28,7 +28,7 @@ const getPartRelationshipsSchema = z.object({
   limit: z.number().min(1).max(50).default(20),
 })
 
-export async function searchParts(input: z.infer<typeof searchPartsSchema>): Promise<ToolResult<PartRow[]>> {
+export async function searchParts(input: z.infer<typeof searchPartsSchema>): Promise<PartRow[]> {
   try {
     const validated = searchPartsSchema.parse(input)
     const supabase = getSupabaseClient()
@@ -50,15 +50,15 @@ export async function searchParts(input: z.infer<typeof searchPartsSchema>): Pro
     }
 
     const { data, error } = await query
-    if (error) return { success: false, error: `Database error: ${error.message}` }
+    if (error) throw new Error(`Database error: ${error.message}`)
 
-    return { success: true, data: (data as any) || [], confidence: 1.0 }
+    return (data as any) || []
   } catch (error) {
-    return { success: false, error: error instanceof Error ? error.message : 'Unknown error occurred' }
+    throw error instanceof Error ? error : new Error('Unknown error occurred')
   }
 }
 
-export async function getPartById(input: z.infer<typeof getPartByIdSchema>): Promise<ToolResult<PartRow | null>> {
+export async function getPartById(input: z.infer<typeof getPartByIdSchema>): Promise<PartRow | null> {
   try {
     const validated = getPartByIdSchema.parse(input)
     const supabase = getSupabaseClient()
@@ -71,18 +71,18 @@ export async function getPartById(input: z.infer<typeof getPartByIdSchema>): Pro
 
     if (error) {
       if ((error as any).code === 'PGRST116') {
-        return { success: true, data: null, confidence: 1.0 }
+        return null
       }
-      return { success: false, error: `Database error: ${error.message}` }
+      throw new Error(`Database error: ${error.message}`)
     }
 
-    return { success: true, data: data as any, confidence: 1.0 }
+    return data as any
   } catch (error) {
-    return { success: false, error: error instanceof Error ? error.message : 'Unknown error occurred' }
+    throw error instanceof Error ? error : new Error('Unknown error occurred')
   }
 }
 
-export async function getPartRelationships(input: z.infer<typeof getPartRelationshipsSchema>): Promise<ToolResult<Array<any>>> {
+export async function getPartRelationships(input: z.infer<typeof getPartRelationshipsSchema>): Promise<Array<any>> {
   try {
     const validated = getPartRelationshipsSchema.parse(input)
     const supabase = getSupabaseClient()
@@ -101,7 +101,7 @@ export async function getPartRelationships(input: z.infer<typeof getPartRelation
     }
 
     const { data, error } = await query
-    if (error) return { success: false, error: `Database error: ${error.message}` }
+    if (error) throw new Error(`Database error: ${error.message}`)
 
     let relationships = (data || []) as any[]
 
@@ -153,9 +153,9 @@ export async function getPartRelationships(input: z.infer<typeof getPartRelation
       }
     })
 
-    return { success: true, data: formatted, confidence: 1.0 }
+    return formatted
   } catch (error) {
-    return { success: false, error: error instanceof Error ? error.message : 'Unknown error occurred' }
+    throw error instanceof Error ? error : new Error('Unknown error occurred')
   }
 }
 

--- a/mastra/tools/part-tools.mastra.ts
+++ b/mastra/tools/part-tools.mastra.ts
@@ -111,9 +111,11 @@ export function getPartTools(userId?: string) {
       inputSchema: searchPartsSchema,
       execute: async ({ context }: any) => {
         const secureContext = { ...context, userId };
-        const result = await searchParts(secureContext);
-        if (!result.success) throw new Error(result.error);
-        return result.data;
+        try {
+          return await searchParts(secureContext);
+        } catch (err) {
+          throw err instanceof Error ? err : new Error(String(err));
+        }
       },
     }),
     getPartById: createTool({
@@ -122,9 +124,11 @@ export function getPartTools(userId?: string) {
       inputSchema: getPartByIdSchema,
       execute: async ({ context }: any) => {
         const secureContext = { ...context, userId };
-        const result = await getPartById(secureContext);
-        if (!result.success) throw new Error(result.error);
-        return result.data;
+        try {
+          return await getPartById(secureContext);
+        } catch (err) {
+          throw err instanceof Error ? err : new Error(String(err));
+        }
       },
     }),
     getPartDetail: createTool({
@@ -134,9 +138,11 @@ export function getPartTools(userId?: string) {
       inputSchema: getPartDetailSchema,
       execute: async ({ context }: any) => {
         const secureContext = { ...context, userId };
-        const result = await getPartDetail(secureContext);
-        if (!result.success) throw new Error(result.error);
-        return result.data;
+        try {
+          return await getPartDetail(secureContext);
+        } catch (err) {
+          throw err instanceof Error ? err : new Error(String(err));
+        }
       },
     }),
     createEmergingPart: createTool({
@@ -145,9 +151,11 @@ export function getPartTools(userId?: string) {
       inputSchema: createEmergingPartSchema,
       execute: async ({ context }: any) => {
         const secureContext = { ...context, userId };
-        const result = await createEmergingPart(secureContext);
-        if (!result.success) throw new Error(result.error);
-        return result.data;
+        try {
+          return await createEmergingPart(secureContext);
+        } catch (err) {
+          throw err instanceof Error ? err : new Error(String(err));
+        }
       },
     }),
     updatePart: createTool({
@@ -156,9 +164,11 @@ export function getPartTools(userId?: string) {
       inputSchema: updatePartSchema,
       execute: async ({ context }: any) => {
         const secureContext = { ...context, userId };
-        const result = await updatePart(secureContext);
-        if (!result.success) throw new Error(result.error);
-        return result.data;
+        try {
+          return await updatePart(secureContext);
+        } catch (err) {
+          throw err instanceof Error ? err : new Error(String(err));
+        }
       },
     }),
     getPartRelationships: createTool({
@@ -168,9 +178,11 @@ export function getPartTools(userId?: string) {
       inputSchema: getPartRelationshipsSchema,
       execute: async ({ context }: any) => {
         const secureContext = { ...context, userId };
-        const result = await getPartRelationships(secureContext);
-        if (!result.success) throw new Error(result.error);
-        return result.data;
+        try {
+          return await getPartRelationships(secureContext);
+        } catch (err) {
+          throw err instanceof Error ? err : new Error(String(err));
+        }
       },
     }),
     logRelationship: createTool({
@@ -180,9 +192,11 @@ export function getPartTools(userId?: string) {
       inputSchema: logRelationshipSchema,
       execute: async ({ context }: any) => {
         const secureContext = { ...context, userId };
-        const result = await logRelationship(secureContext);
-        if (!result.success) throw new Error(result.error);
-        return result.data;
+        try {
+          return await logRelationship(secureContext);
+        } catch (err) {
+          throw err instanceof Error ? err : new Error(String(err));
+        }
       },
     }),
   }


### PR DESCRIPTION
## Summary
- Throw errors from part data functions instead of returning success flags
- Catch and relay errors from Mastra part tool wrappers
- Update callers to expect exceptions and remove redundant success checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c289fe23e08323956b0beaf24d0c7b