### PR TITLE
fix(dev): supabase offline fallback and toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,6 @@ MEMORY_AGENTIC_V2_ENABLED=true
 MEMORY_EVENTS_HMAC_SECRET=replace-with-strong-secret
 # Storage adapter for snapshots: local|supabase (prod/staging should use supabase)
 MEMORY_STORAGE_ADAPTER=local
+
+# Dev-only: force offline mode (skip Supabase) even if env vars are set
+# IFS_DEV_FORCE_NO_SUPABASE=false

--- a/config/env.ts
+++ b/config/env.ts
@@ -19,9 +19,35 @@ const EnvSchema = z.object({
   IFS_DEFAULT_USER_ID: z.string().uuid().optional(),
   IFS_VERBOSE: z.string().optional(),
   IFS_DISABLE_POLARIZATION_UPDATE: z.string().optional(),
+  // Dev overrides
+  IFS_DEV_FORCE_NO_SUPABASE: z.string().optional(),
 })
 
-const raw = EnvSchema.parse(process.env)
+// Important: avoid parsing the entire process.env object because in the browser
+// Next.js inlines only referenced variables and the runtime stub may be empty.
+// Explicitly map the keys we care about instead, and keep this module server-only.
+const raw = EnvSchema.parse({
+  NODE_ENV: process.env.NODE_ENV,
+
+  // Providers / Secrets
+  OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+
+  // Supabase
+  NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
+
+  // IFS dev toggles
+  IFS_DEV_MODE: process.env.IFS_DEV_MODE,
+  NEXT_PUBLIC_IFS_DEV_MODE: process.env.NEXT_PUBLIC_IFS_DEV_MODE,
+  IFS_TEST_PERSONA: process.env.IFS_TEST_PERSONA as any,
+  NEXT_PUBLIC_IFS_TEST_PERSONA: process.env.NEXT_PUBLIC_IFS_TEST_PERSONA as any,
+  IFS_DEFAULT_USER_ID: process.env.IFS_DEFAULT_USER_ID,
+  IFS_VERBOSE: process.env.IFS_VERBOSE,
+  IFS_DISABLE_POLARIZATION_UPDATE: process.env.IFS_DISABLE_POLARIZATION_UPDATE,
+  // Dev overrides
+  IFS_DEV_FORCE_NO_SUPABASE: process.env.IFS_DEV_FORCE_NO_SUPABASE,
+})
 
 const toBool = (v?: string) => v === 'true'
 
@@ -38,4 +64,5 @@ export const env = {
     toBool(raw.NEXT_PUBLIC_IFS_DEV_MODE),
   ifsVerbose: toBool(raw.IFS_VERBOSE),
   ifsDisablePolarizationUpdate: toBool(raw.IFS_DISABLE_POLARIZATION_UPDATE),
+  ifsForceNoSupabase: toBool(raw.IFS_DEV_FORCE_NO_SUPABASE),
 }

--- a/lib/api/supabaseGuard.ts
+++ b/lib/api/supabaseGuard.ts
@@ -3,6 +3,21 @@ import { createClient as createServerSupabase } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { dev } from '@/config/dev'
 import { getSupabaseKey, getSupabaseUrl } from '@/lib/supabase/config'
+import { env } from '@/config/env'
+
+async function isReachable(url?: string, timeoutMs = 800): Promise<boolean> {
+  if (!url) return false
+  try {
+    const controller = new AbortController()
+    const t = setTimeout(() => controller.abort(), timeoutMs)
+    // We only need to detect network availability; a 404 is still "reachable".
+    const res = await fetch(url, { method: 'HEAD', signal: controller.signal })
+    clearTimeout(t)
+    return !!res
+  } catch {
+    return false
+  }
+}
 
 export type SupabaseGuardContext =
   | { type: 'no-supabase' }
@@ -20,23 +35,47 @@ export async function withSupabaseOrDev(
       typeof supabaseUrl === 'string' && /^https?:\/\//.test(supabaseUrl) &&
       typeof supabaseAnon === 'string' && (supabaseAnon?.length ?? 0) > 20
 
+    // Dev override: allow forcing offline sessions regardless of env presence
+    if (env.ifsForceNoSupabase) {
+      return await handler({ type: 'no-supabase' })
+    }
+
     if (!hasSupabase) {
       return await handler({ type: 'no-supabase' })
     }
 
-    const supabase = await createServerSupabase()
-    const {
-      data: { session }
-    } = await supabase.auth.getSession()
-    const authedUserId = session?.user?.id
+    // If Supabase looks configured but is not reachable (local not started),
+    // gracefully fall back to offline sessions in dev.
+    const reachable = await isReachable(supabaseUrl)
+    if (!reachable && dev.enabled) {
+      return await handler({ type: 'no-supabase' })
+    }
 
-    if (authedUserId) {
-      return await handler({ type: 'authed', supabase, userId: authedUserId })
+    let authedUserId: string | undefined
+    try {
+      const supabase = await createServerSupabase()
+      const { data: { session } } = await supabase.auth.getSession()
+      authedUserId = session?.user?.id
+      if (authedUserId) {
+        return await handler({ type: 'authed', supabase, userId: authedUserId })
+      }
+    } catch (e) {
+      // Network or client init failure: treat as offline in dev
+      console.error('Supabase guard: auth session check failed', e)
+      if (dev.enabled) {
+        return await handler({ type: 'no-supabase' })
+      }
+      // In non-dev, fall through to unauthorized
     }
 
     if (dev.enabled) {
-      const admin = createAdminClient()
-      return await handler({ type: 'admin', admin })
+      // Only create an admin client if the instance is reachable
+      if (await isReachable(supabaseUrl)) {
+        const admin = createAdminClient()
+        return await handler({ type: 'admin', admin })
+      }
+      // If not reachable, prefer offline sessions over 500s
+      return await handler({ type: 'no-supabase' })
     }
 
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
@@ -51,4 +90,3 @@ export async function withSupabaseOrDev(
     })
   }
 }
-


### PR DESCRIPTION
- Adds IFS_DEV_FORCE_NO_SUPABASE to env schema and documents it\n- Supabase guard falls back to offline in dev when unreachable\n- Wraps auth.getSession in try/catch to avoid 500s during local dev\n\nTesting:\n- Stop Supabase: POST /api/session/start returns a dev sessionId\n- Start Supabase: same endpoint inserts into DB and returns real ID