### PR TITLE
Fix chat routing and onboarding redirects

### DIFF
--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -13,7 +13,7 @@ import {
  * - Validates all required responses are present (5 + 4 + 4 = 13 total)
  * - Updates user state to completed
  * - Triggers user memory synthesis (placeholder for now)
- * - Returns redirect to /today (not /chat per requirements)
+ * - Returns redirect to / (not /chat per requirements)
  * - Idempotent operation
  */
 export async function POST(request: NextRequest) {
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
     if (userState.status === 'completed') {
       const response: CompletionResponse = {
         ok: true,
-        redirect: `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/today`,
+        redirect: `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/`,
         completed_at: userState.completed_at!
       };
       return NextResponse.json(response);
@@ -112,7 +112,7 @@ export async function POST(request: NextRequest) {
 
     const response: CompletionResponse = {
       ok: true,
-      redirect: `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/today`,
+      redirect: `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/`,
       completed_at: now
     };
 

--- a/components/ethereal/EtherealChat.tsx
+++ b/components/ethereal/EtherealChat.tsx
@@ -197,7 +197,7 @@ export function EtherealChat() {
               onClick={async () => {
                 await endSession()
                 setConfirmOpen(false)
-                router.push('/today')
+                router.push('/')
               }}
             >
               End session

--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -23,9 +23,18 @@ export function useChat() {
 
   const streamingCancelRef = useRef<(() => void) | null>(null);
   const sessionIdRef = useRef<string | null>(null);
-  const userIdRef = useRef<string>('dev-user-1'); // TODO: replace with real identity later
+  const DEV_FALLBACK = process.env.NEXT_PUBLIC_DEV_USER_ID ?? 'dev-user-1';
+  const userIdRef = useRef<string>(DEV_FALLBACK);
 
   const generateId = (): string => Math.random().toString(36).substr(2, 9);
+
+  useEffect(() => {
+    if (profile?.id) {
+      userIdRef.current = profile.id;
+    } else if (process.env.NODE_ENV !== 'development') {
+      userIdRef.current = '';
+    }
+  }, [profile]);
 
   useEffect(() => {
     const partId = searchParams.get('partId')

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,15 @@ const nextConfig = {
     // Fail the build on ESLint errors
     ignoreDuringBuilds: false,
   },
+  async redirects() {
+    return [
+      {
+        source: '/ethereal',
+        destination: '/chat',
+        permanent: false,
+      },
+    ];
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- use authenticated user ID with dev fallback in chat sessions
- redirect end-session and onboarding completion to home route
- add `/ethereal` -> `/chat` redirect

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c313aa4f38832399d8b875d5afd754