### PR TITLE
refactor: use snapshot adapter for session reads in mastra tools

### DIFF
--- a/docs/current_state/02_feature_implementations.md
+++ b/docs/current_state/02_feature_implementations.md
@@ -23,7 +23,11 @@ The main user-facing feature is the chat interface. The agent's capabilities wit
 
 -   **Evidence & Pattern Analysis (`evidence-tools.ts`):**
     -   `logEvidence`: Add a specific piece of evidence (e.g., a direct quote) to an *existing* part's profile.
-    -   `findPatterns`: A utility tool that can scan a user's recent session history for regex patterns that suggest part language (e.g., "part of me feels..."). This is a standalone analysis tool and is not currently integrated into the agent's main conversational loop.
+    -   `findPatterns`: Scans recent session snapshots via the StorageAdapter for regex patterns that suggest part language (e.g., "part of me feels..."). This is a standalone analysis tool and is not currently integrated into the agent's main conversational loop.
+
+-   **Research Helpers (`insight-research-tools.ts`):**
+    -   `getRecentSessions`: Retrieves session snapshots for a user through the StorageAdapter, filtered by lookback window and limit.
+    -   `getActiveParts`, `getPolarizedRelationships`, `getRecentInsights`: Query Supabase for other research data.
 
 -   **Confidence & Workflow Management:**
     -   `recordPartAssessmentTool` (`assessment-tools.ts`): Records a confidence score for a part's identification, creating an entry in the `part_assessments` table and updating the part's `confidence` field.

--- a/docs/features/agent-tools.md
+++ b/docs/features/agent-tools.md
@@ -20,6 +20,7 @@ Encapsulates privileged operations (e.g., db mutations) behind auditable tools, 
 
 ## How it works
 - Mastra tools implement capabilities (parts, relationships, evidence, assessments, proposals, rollback)
+- Session analysis utilities read recent sessions via StorageAdapter snapshots to keep lookback/limit semantics consistent across environments
 - Agent prompt and configuration live under mastra/agents/
 - Insights generator scaffolding exists in lib/insights/generator.ts
 

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -25,4 +25,5 @@ NEXT_PUBLIC_SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... npm run snapshots:sca
 Notes
 - No agent write-path changes yet; this establishes storage plumbing and basic content generators.
 - All writes are via server/service-role for Supabase; the browser never accesses the bucket directly.
+- Session-oriented Mastra tools (e.g., insight research and evidence utilities) read recent sessions through this adapter instead of direct Supabase queries.
 


### PR DESCRIPTION
## Summary
- replace Supabase session queries with snapshot reads in insight research tools
- use adapter-based session snapshots for evidence pattern analysis
- document snapshot-based session reads in agent tools and snapshot docs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c339213eec8323aa3c095e5cf8e7d6