### PR TITLE
feat: add types for insight generation workflow

### DIFF
--- a/mastra/workflows/generate-insight-workflow.ts
+++ b/mastra/workflows/generate-insight-workflow.ts
@@ -1,34 +1,75 @@
 import { createWorkflow } from '@mastra/core';
 import { z } from 'zod';
-import { insightResearchTools, getRecentSessions, getActiveParts, getPolarizedRelationships, getRecentInsights } from '../tools/insight-research-tools';
+import {
+  getRecentSessions,
+  getActiveParts,
+  getPolarizedRelationships,
+  getRecentInsights,
+} from '../tools/insight-research-tools';
 import { mastra } from '..';
+import type {
+  SessionRow,
+  PartRow,
+  PartRelationshipRow,
+  InsightRow,
+} from '../../lib/types/database';
+import { insightSchema, Insight } from '../agents/insight-generator';
 
 const workflowInputSchema = z.object({
   userId: z.string().uuid(),
 });
 
+export type GenerateInsightInput = z.infer<typeof workflowInputSchema>;
+
+const sessionRowSchema = z.custom<SessionRow>();
+const partRowSchema = z.custom<PartRow>();
+const partRelationshipRowSchema = z.custom<PartRelationshipRow>();
+const insightRowSchema = z.custom<InsightRow>();
+
+const toolResultSchema = <T extends z.ZodTypeAny>(data: T) =>
+  z.object({
+    success: z.boolean(),
+    data: data.optional(),
+    error: z.string().optional(),
+    confidence: z.number().optional(),
+  });
+
+const researchOutputSchema = z.object({
+  recentSessions: toolResultSchema(z.array(sessionRowSchema)),
+  activeParts: toolResultSchema(z.array(partRowSchema)),
+  polarizedRelationships: toolResultSchema(z.array(partRelationshipRowSchema)),
+  recentInsights: toolResultSchema(z.array(insightRowSchema)),
+});
+
+export type ResearchStepOutput = z.infer<typeof researchOutputSchema>;
+
+interface ExecutionParams<TInput> {
+  inputData: TInput;
+  [key: string]: unknown;
+}
+
+const writingOutputSchema = z.array(insightSchema);
+export type WritingStepOutput = Insight[];
+
 export const generateInsightWorkflow = createWorkflow({
   id: 'generate-insight-workflow',
   inputSchema: workflowInputSchema,
+  outputSchema: writingOutputSchema,
   steps: [
     {
       id: 'researchStep',
       description: 'Gathers research materials about the user.',
       inputSchema: workflowInputSchema,
-      outputSchema: z.object({
-        recentSessions: z.any(),
-        activeParts: z.any(),
-        polarizedRelationships: z.any(),
-        recentInsights: z.any(),
-      }),
-      async execute(input: any) {
-        console.log('Workflow: Starting research step for user', input.userId);
-        const [recentSessions, activeParts, polarizedRelationships, recentInsights] = await Promise.all([
-          getRecentSessions({ userId: input.userId, lookbackDays: 7, limit: 10 }),
-          getActiveParts({ userId: input.userId, limit: 10 }),
-          getPolarizedRelationships({ userId: input.userId, limit: 10 }),
-          getRecentInsights({ userId: input.userId, lookbackDays: 14, limit: 10 }),
-        ]);
+      outputSchema: researchOutputSchema,
+      async execute({ inputData }: ExecutionParams<GenerateInsightInput>): Promise<ResearchStepOutput> {
+        console.log('Workflow: Starting research step for user', inputData.userId);
+        const [recentSessions, activeParts, polarizedRelationships, recentInsights] =
+          await Promise.all([
+            getRecentSessions({ userId: inputData.userId, lookbackDays: 7, limit: 10 }),
+            getActiveParts({ userId: inputData.userId, limit: 10 }),
+            getPolarizedRelationships({ userId: inputData.userId, limit: 10 }),
+            getRecentInsights({ userId: inputData.userId, lookbackDays: 14, limit: 10 }),
+          ]);
         return { recentSessions, activeParts, polarizedRelationships, recentInsights };
       },
     },
@@ -36,26 +77,32 @@ export const generateInsightWorkflow = createWorkflow({
       id: 'writingStep',
       description: 'Analyzes research and writes insights.',
       inputSchema: workflowInputSchema,
-      outputSchema: z.any(),
-      // @ts-expect-error relax signature for engine
-      async execute(input: any, { step }: any): Promise<any> {
+      outputSchema: writingOutputSchema,
+      async execute(params: ExecutionParams<GenerateInsightInput>): Promise<WritingStepOutput> {
+        const { inputData } = params;
+        const { step } = params as unknown as { step: { researchStep: ResearchStepOutput } };
         const researchStepOutput = step.researchStep;
         console.log('Workflow: Starting writing step...');
         const researchSummary = `
           Recent Sessions: ${JSON.stringify(researchStepOutput.recentSessions, null, 2)}
           Active Parts: ${JSON.stringify(researchStepOutput.activeParts, null, 2)}
-          Polarized Relationships: ${JSON.stringify(researchStepOutput.polarizedRelationships, null, 2)}
+          Polarized Relationships: ${JSON.stringify(
+            researchStepOutput.polarizedRelationships,
+            null,
+            2
+          )}
           Recent Insights: ${JSON.stringify(researchStepOutput.recentInsights, null, 2)}
         `;
 
         const insightAgent = mastra.getAgent('insightGeneratorAgent');
-        const agentRun = await insightAgent.run({
-          input: researchSummary,
-          context: { userId: input.userId }, // Pass original userId through
-        });
+        const agentRun: { status: string; output?: { insights?: Insight[] } } =
+          await insightAgent.run({
+            input: researchSummary,
+            context: { userId: inputData.userId }, // Pass original userId through
+          });
 
-        if (agentRun.status === 'success' && agentRun.output) {
-          return agentRun.output.insights || [];
+        if (agentRun.status === 'success' && agentRun.output?.insights) {
+          return agentRun.output.insights;
         }
 
         return [];


### PR DESCRIPTION
## Summary
- define Insight schema and agent types for insight generator
- add typed research and writing steps with explicit schemas

## Testing
- `npm run typecheck` *(fails: Type 'Profile | null' is not assignable to type 'Profile')*


------
https://chatgpt.com/codex/tasks/task_e_68c28a06ba2883239b828143a55907c4