### PR TITLE
chore: unify cron auth scheme

### DIFF
--- a/.github/workflows/memory-update-cron.yml
+++ b/.github/workflows/memory-update-cron.yml
@@ -25,7 +25,7 @@ jobs:
           set -euo pipefail
           CODE=$(curl -s -o response.json -w "%{http_code}" -X POST \
             "$APP_BASE_URL/api/cron/memory-update" \
-            -H "x-cron-key: $CRON_SECRET")
+            -H "Authorization: Bearer $CRON_SECRET")
           echo "HTTP $CODE"
           cat response.json
           if [ "$CODE" -lt 200 ] || [ "$CODE" -ge 300 ]; then

--- a/app/api/cron/memory-update/route.ts
+++ b/app/api/cron/memory-update/route.ts
@@ -2,13 +2,13 @@ import { NextResponse } from 'next/server'
 import { listActiveUsersSince, reconstructMemory, loadTodayData, generateMemoryUpdate, saveNewSnapshot } from '@/lib/memory/service'
 
 function requireCronAuth(req: Request): boolean {
-  const configured = process.env.CRON_SECRET
-  if (!configured) {
+  const secret = process.env.CRON_SECRET
+  if (!secret) {
     // In dev, allow if not configured; in prod, CI should set CRON_SECRET
     return process.env.NODE_ENV !== 'production'
   }
-  const header = req.headers.get('x-cron-key') || req.headers.get('x-cron-secret')
-  return header === configured
+  const authHeader = req.headers.get('authorization')
+  return authHeader === `Bearer ${secret}`
 }
 
 async function runDailyMemoryUpdate(): Promise<Response> {

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -5,7 +5,7 @@ This document outlines features and improvements that were part of the initial d
 ## 0. Pending Deployment Configuration
 
 - APP_BASE_URL (for scheduled cron): Set to your deployed app’s base URL (e.g. https://your-app.com)
-- CRON_SECRET: Generate a random string; store as Actions secret and in app env so /api/cron endpoints can validate x-cron-key
+- CRON_SECRET: Generate a random string; store as Actions secret and in app env so /api/cron endpoints can validate the `Authorization` header (Bearer token)
 - Location to add: GitHub > Settings > Secrets and variables > Actions
 - After deployment, update memory-update-cron.yml secrets accordingly.
 

--- a/docs/current_state/consistency-audit-2025-08-30.md
+++ b/docs/current_state/consistency-audit-2025-08-30.md
@@ -50,10 +50,8 @@ Summary of findings
     - 008_add_charge_to_parts.sql and 008_message_feedback.sql
   - This can break bootstrap on fresh environments where lexicographic order matters
 
-- Cron/API auth inconsistency
-  - app/api/cron/memory-update/route.ts expects x-cron-key/x-cron-secret (allows dev when unset)
-  - app/api/cron/generate-insights/route.ts expects Authorization: Bearer ${CRON_SECRET}
-  - Recommend standardizing on Authorization: Bearer ${CRON_SECRET}
+- Cron/API auth
+  - app/api/cron/memory-update/route.ts and app/api/cron/generate-insights/route.ts both expect Authorization: Bearer ${CRON_SECRET}
 
 - Dependencies security/outdated
   - npm audit: 1 critical (Next.js), 3 moderate (react-syntax-highlighter → refractor → prismjs)
@@ -100,8 +98,7 @@ Details
 - If applied: do not rename; add corrective migrations and a MIGRATIONS.md explaining history and bootstrap order
 
 7) Cron/API auth
-- Standardize on Authorization: Bearer ${CRON_SECRET} (document in README and workflow)
-- Update memory-update route to match generate-insights
+- Cron routes standardized on Authorization: Bearer ${CRON_SECRET} (documented in README and workflow)
 
 8) Dependencies and security
 - Upgrade Next.js to >= 15.5.2 to address critical/high advisories

--- a/docs/user-memory.md
+++ b/docs/user-memory.md
@@ -16,7 +16,7 @@ This backend feature maintains an evolving, agent-readable "user memory" hub. It
 
 ## API
 - `POST /api/cron/memory-update`
-  - Header: `x-cron-key: <CRON_SECRET>`
+  - Header: `Authorization: Bearer <CRON_SECRET>`
   - Finds users active in last 24h, runs the update pipeline for each
   - Returns per-user result and latest version if saved
 
@@ -37,7 +37,7 @@ Use the GitHub Actions workflow `.github/workflows/memory-update-cron.yml`:
 ## Local testing
 - Apply migrations (see below)
 - Run dev server, then:
-  - `curl -X POST http://localhost:3000/api/cron/memory-update -H "x-cron-key: <CRON_SECRET>"`
+  - `curl -X POST http://localhost:3000/api/cron/memory-update -H "Authorization: Bearer <CRON_SECRET>"`
 
 ## Migration
 - File: `supabase/migrations/006_user_memory.sql`


### PR DESCRIPTION
## Summary
- standardize cron routes on `Authorization: Bearer <CRON_SECRET>`
- update scheduled workflow to send bearer token
- refresh docs to describe unified auth

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c28a081e44832391b8d57473940535