### PR TITLE
Add gitleaks secret scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Gitleaks
+      - name: Scan for secrets
         uses: gitleaks/gitleaks-action@v2
-      - name: Run Gitleaks (with SARIF)
+        with:
+          config-path: .gitleaks.toml
+          report-format: sarif
+          report-path: gitleaks.sarif
+          fail: true
+          args: --no-git --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gitleaks detect --source=. --no-git --report-format sarif --report-path gitleaks.sarif --verbose
       - name: Upload SARIF to Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/README.md
+++ b/README.md
@@ -398,3 +398,14 @@ The system includes a sophisticated insights generation system that demonstrates
 
 
 ## 🎨 Advanced Agent Development Patterns
+
+## 🔐 Secret Scanning
+
+This repository uses [gitleaks](https://github.com/gitleaks/gitleaks) to prevent committing secrets.
+Every pull request runs a gitleaks scan in CI and the build fails if any secrets are detected.
+
+Run a scan locally before pushing changes:
+
+```bash
+gitleaks detect --source=. --config=.gitleaks.toml --no-git
+```


### PR DESCRIPTION
## Summary
- run gitleaks in CI to fail builds when secrets are found
- document gitleaks usage and how to run scans locally

## Testing
- `npm test`
- `npm run lint`
- `gitleaks detect --source=. --config=.gitleaks.toml --no-git` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c28a0ad0b4832385103b9243c8afd0