### PR TITLE
Redirect ethereal end session to home

### DIFF
--- a/components/ethereal/EtherealChat.tsx
+++ b/components/ethereal/EtherealChat.tsx
@@ -197,7 +197,7 @@ export function EtherealChat() {
               onClick={async () => {
                 await endSession()
                 setConfirmOpen(false)
-                router.push('/today')
+                router.push('/')
               }}
             >
               End session

--- a/e2e/ethereal-end-session.spec.ts
+++ b/e2e/ethereal-end-session.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Ethereal chat', () => {
+  test('End session redirects to home page', async ({ page }) => {
+    await page.goto('/chat')
+
+    // Start a session by sending a message
+    await page.getByLabel('Message').fill('hello')
+    await page.getByRole('button', { name: 'send' }).click()
+
+    // End button appears once session is active
+    const endButton = page.getByRole('button', { name: 'end' })
+    await expect(endButton).toBeVisible()
+
+    // Confirm ending the session
+    await endButton.click()
+    await expect(page.getByRole('button', { name: 'End session' })).toBeVisible()
+    await page.getByRole('button', { name: 'End session' }).click()
+
+    // After ending, user should be redirected to the home (Today) page
+    await expect(page).toHaveURL('/')
+    await expect(page.getByText('DAILY MEDITATIONS')).toBeVisible()
+  })
+})
+


### PR DESCRIPTION
## Summary
- Redirect ethereal chat's end-session action to home page
- Add e2e test covering session termination navigation

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68c32a09345883238739f51f57c4d353