### PR TITLE
Redirect onboarding completion to root

### DIFF
--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -13,7 +13,7 @@ import {
  * - Validates all required responses are present (5 + 4 + 4 = 13 total)
  * - Updates user state to completed
  * - Triggers user memory synthesis (placeholder for now)
- * - Returns redirect to /today (not /chat per requirements)
+ * - Returns redirect to / (not /chat per requirements)
  * - Idempotent operation
  */
 export async function POST(request: NextRequest) {
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
     if (userState.status === 'completed') {
       const response: CompletionResponse = {
         ok: true,
-        redirect: `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/today`,
+        redirect: `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/`,
         completed_at: userState.completed_at!
       };
       return NextResponse.json(response);
@@ -112,7 +112,7 @@ export async function POST(request: NextRequest) {
 
     const response: CompletionResponse = {
       ok: true,
-      redirect: `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/today`,
+      redirect: `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/`,
       completed_at: now
     };
 

--- a/components/ethereal/EtherealChat.tsx
+++ b/components/ethereal/EtherealChat.tsx
@@ -197,7 +197,7 @@ export function EtherealChat() {
               onClick={async () => {
                 await endSession()
                 setConfirmOpen(false)
-                router.push('/today')
+                router.push('/')
               }}
             >
               End session


### PR DESCRIPTION
## Summary
- Redirect onboarding completion API to the application root `/` instead of `/today`
- Update EtherealChat session ending flow to route back to the root path

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c32a0fa4fc8323af192ea515bb3331