### PR TITLE
Redirect ethereal route to chat

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,15 @@ const nextConfig = {
     // Fail the build on ESLint errors
     ignoreDuringBuilds: false,
   },
+  async redirects() {
+    return [
+      {
+        source: '/ethereal',
+        destination: '/chat',
+        permanent: false,
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- redirect `/ethereal` to `/chat`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c32a185cdc8323848ea0cda79ac92c