### PR TITLE
refactor: remove user id from chat helpers

### DIFF
--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -23,18 +23,7 @@ export function useChat() {
 
   const streamingCancelRef = useRef<(() => void) | null>(null);
   const sessionIdRef = useRef<string | null>(null);
-  const DEV_FALLBACK = process.env.NEXT_PUBLIC_DEV_USER_ID ?? 'dev-user-1';
-  const userIdRef = useRef<string>(DEV_FALLBACK);
-
   const generateId = (): string => Math.random().toString(36).substr(2, 9);
-
-  useEffect(() => {
-    if (profile?.id) {
-      userIdRef.current = profile.id;
-    } else if (process.env.NODE_ENV !== 'development') {
-      userIdRef.current = '';
-    }
-  }, [profile]);
 
   useEffect(() => {
     const partId = searchParams.get('partId')
@@ -96,7 +85,6 @@ export function useChat() {
       const res = await fetch('/api/session/start', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: userIdRef.current }),
       });
       if (!res.ok) throw new Error('Failed to start session');
       const data = await res.json();
@@ -254,7 +242,6 @@ export function useChat() {
       await streamFromMastra({
         messages: apiMessages,
         sessionId,
-        userId: userIdRef.current,
         profile: profile ?? { name: '', bio: '' },
         signal: controller.signal,
         apiPath: chosenApiPath,

--- a/lib/chatClient.ts
+++ b/lib/chatClient.ts
@@ -7,7 +7,6 @@ import type { TaskEvent } from '@/types/chat'
 export async function streamFromMastra(params: {
   messages: BasicMessage[]
   sessionId: string
-  userId: string
   profile: Profile
   onChunk: (chunk: string, done: boolean) => void
   onTask?: (event: TaskEvent) => void
@@ -18,11 +17,10 @@ export async function streamFromMastra(params: {
   const res = await fetch(apiPath, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    // Include sessionId and userId for future server-side attribution; the route safely ignores extras
+    // Include sessionId for future server-side attribution; the route safely ignores extras
     body: JSON.stringify({
       messages: params.messages,
       sessionId: params.sessionId,
-      userId: params.userId,
       profile: params.profile,
     }),
     signal: params.signal,


### PR DESCRIPTION
## Summary
- remove userId from ensureSession request payload
- drop userId parameter from `streamFromMastra`
- clean up callers to no longer pass userId

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c33c3f5e448323b04daabccbb3af73