### PR TITLE
Track onboarding completion analytics

### DIFF
--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { 
-  CompletionRequest, 
-  CompletionResponse 
+import {
+  CompletionRequest,
+  CompletionResponse
 } from '@/lib/onboarding/types';
+import { track } from '@/lib/analytics';
 
 /**
  * POST /api/onboarding/complete
@@ -102,13 +103,11 @@ export async function POST(request: NextRequest) {
     // This will be implemented in a future task
     try {
       await synthesizeOnboardingMemories(user.id);
+      track('onboarding_completed', { userId: user.id, completed_at: now });
     } catch (memoryError) {
       console.warn('Failed to synthesize onboarding memories:', memoryError);
       // Don't fail the completion for memory synthesis issues
     }
-
-    // TODO: Track analytics event
-    // await trackEvent('onboarding_completed', { userId: user.id, duration: ... });
 
     const response: CompletionResponse = {
       ok: true,


### PR DESCRIPTION
## Summary
- import track helper into onboarding completion route
- log `onboarding_completed` event after synthesizing onboarding memories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c33e0952c88323917565a9f53bfa98