### PR TITLE
Align auth page typography with onboarding styles

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -2,7 +2,13 @@ import { LoginForm } from '@/components/auth/login-form'
 
 export default function Page() {
   return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+    <div
+      className="flex min-h-svh w-full items-center justify-center p-6 md:p-10"
+      style={{
+        letterSpacing: 'var(--eth-letter-spacing-user)',
+        color: 'rgba(255,255,255,var(--eth-user-opacity))',
+      }}
+    >
       <div className="w-full max-w-sm">
         <LoginForm />
       </div>

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -2,7 +2,13 @@ import { SignUpForm } from '@/components/auth/sign-up-form'
 
 export default function Page() {
   return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+    <div
+      className="flex min-h-svh w-full items-center justify-center p-6 md:p-10"
+      style={{
+        letterSpacing: 'var(--eth-letter-spacing-user)',
+        color: 'rgba(255,255,255,var(--eth-user-opacity))',
+      }}
+    >
       <div className="w-full max-w-sm">
         <SignUpForm />
       </div>

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -64,7 +64,12 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
     <div className={cn('flex flex-col gap-6', className)} {...props}>
       <Card>
         <CardHeader>
-          <CardTitle className="text-2xl">Login</CardTitle>
+          <CardTitle
+            className="text-2xl"
+            style={{ letterSpacing: 'var(--eth-letter-spacing-assistant)' }}
+          >
+            Login
+          </CardTitle>
           <CardDescription>Enter your email below to login to your account</CardDescription>
         </CardHeader>
         <CardContent>

--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -64,7 +64,12 @@ export function SignUpForm({ className, ...props }: React.ComponentPropsWithoutR
     <div className={cn('flex flex-col gap-6', className)} {...props}>
       <Card>
         <CardHeader>
-          <CardTitle className="text-2xl">Sign up</CardTitle>
+          <CardTitle
+            className="text-2xl"
+            style={{ letterSpacing: 'var(--eth-letter-spacing-assistant)' }}
+          >
+            Sign up
+          </CardTitle>
           <CardDescription>Create a new account</CardDescription>
         </CardHeader>
         <CardContent>


### PR DESCRIPTION
## Summary
- apply onboarding letter spacing and opacity styling to the auth page containers
- update auth form headings to use the assistant letter spacing variable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8620147388323889edff9f0a2520e