### PR TITLE
Add chat gradient variant to ethereal theme

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -9,13 +9,7 @@ const inter = Inter({ subsets: ["latin"], weight: ["100", "300", "400", "600"], 
 export default function ChatPage() {
   return (
     <Suspense fallback={null}>
-      <div
-        className={`${inter.variable} font-sans min-h-dvh h-dvh relative overflow-hidden`}
-        style={{
-          // lock this route to a dark, teal-gray ambiance regardless of theme
-          background: "linear-gradient(180deg, rgba(4,13,16,1) 0%, rgba(14,26,30,1) 50%, rgba(10,20,22,1) 100%)",
-        }}
-      >
+      <div className={`${inter.variable} font-sans min-h-dvh h-dvh relative overflow-hidden`}>
         <EtherealChat />
       </div>
     </Suspense>

--- a/components/ethereal/GlobalBackdrop.tsx
+++ b/components/ethereal/GlobalBackdrop.tsx
@@ -1,12 +1,23 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
+import { usePathname } from 'next/navigation'
 import { motion } from 'framer-motion'
+import { defaultEtherealTheme as T } from '@/config/etherealTheme'
 
 export function GlobalBackdrop() {
+  const pathname = usePathname()
+  const variantGradientKey = useMemo(() => {
+    if (!pathname) return null
+    const normalized = pathname !== '/' && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
+    if (normalized === '/chat' && T.variants.chat?.gradient) return 'chat'
+    return null
+  }, [pathname])
+
   return (
     <div className="pointer-events-none fixed inset-0 -z-30 overflow-hidden" style={{ opacity: 'var(--eth-enabled, 1)' }}>
       <BackgroundImageLayer />
+      {variantGradientKey ? <VariantGradientLayer variantKey={variantGradientKey} /> : null}
       <GradientBackdrop />
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(0,0,0,0.10)_0%,rgba(0,0,0,0.22)_55%,rgba(0,0,0,0.38)_100%)]" />
     </div>
@@ -27,6 +38,15 @@ function BackgroundImageLayer() {
         draggable={false}
       />
     </>
+  )
+}
+
+function VariantGradientLayer({ variantKey }: { variantKey: string }) {
+  return (
+    <div
+      className="absolute inset-0 z-0"
+      style={{ background: `var(--eth-variant-${variantKey}-gradient, transparent)` }}
+    />
   )
 }
 

--- a/components/ethereal/ThemeController.tsx
+++ b/components/ethereal/ThemeController.tsx
@@ -23,6 +23,11 @@ export function ThemeController() {
       try {
         r.style.setProperty('--eth-blobs', JSON.stringify(T.blobs))
       } catch {}
+      Object.entries(T.variants).forEach(([key, variant]) => {
+        if (variant.gradient) {
+          r.style.setProperty(`--eth-variant-${key}-gradient`, variant.gradient)
+        }
+      })
     }
     // Allow a dev override from localStorage
     try {

--- a/config/etherealTheme.ts
+++ b/config/etherealTheme.ts
@@ -1,3 +1,7 @@
+export type EtherealThemeVariant = {
+  gradient?: string
+}
+
 export type EtherealTheme = {
   enabled: boolean
   imageUrl: string
@@ -16,6 +20,7 @@ export type EtherealTheme = {
     streamTickMs: number
     streamCharsPerTick: number
   }
+  variants: Record<string, EtherealThemeVariant>
 }
 
 export const defaultEtherealTheme: EtherealTheme = {
@@ -39,5 +44,10 @@ export const defaultEtherealTheme: EtherealTheme = {
     charDurationMs: 1000,
     streamTickMs: 150,
     streamCharsPerTick: 8,
+  },
+  variants: {
+    chat: {
+      gradient: 'linear-gradient(180deg, rgba(4,13,16,1) 0%, rgba(14,26,30,1) 50%, rgba(10,20,22,1) 100%)',
+    },
   },
 }


### PR DESCRIPTION
## Summary
- add variant support to the ethereal theme config and register the chat gradient
- propagate variant gradients through the ThemeController for CSS variable access
- update GlobalBackdrop to render the chat gradient variant and remove the inline background from the chat page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8620312a08323a198f45fb10564a0