### PR TITLE
Add ethereal card variant for auth forms

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -17,6 +17,11 @@ import { useRouter } from 'next/navigation'
 import { useState, useRef, useEffect } from 'react'
 import { useGoogleAuth } from '@/lib/hooks/use-google-auth'
 
+const etherealTextStyle = {
+  letterSpacing: 'var(--eth-letter-spacing-user)',
+  color: 'rgba(255,255,255,var(--eth-user-opacity))',
+} as const
+
 export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) {
   // Added test comment to trigger AI docs workflow validation
   const [email, setEmail] = useState('')
@@ -62,10 +67,14 @@ export function LoginForm({ className, ...props }: React.ComponentPropsWithoutRe
 
   return (
     <div className={cn('flex flex-col gap-6', className)} {...props}>
-      <Card>
+      <Card variant="ethereal">
         <CardHeader>
-          <CardTitle className="text-2xl">Login</CardTitle>
-          <CardDescription>Enter your email below to login to your account</CardDescription>
+          <CardTitle className="text-2xl" style={etherealTextStyle}>
+            Login
+          </CardTitle>
+          <CardDescription style={etherealTextStyle}>
+            Enter your email below to login to your account
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <div className="flex flex-col gap-6">

--- a/components/auth/sign-up-form.tsx
+++ b/components/auth/sign-up-form.tsx
@@ -17,6 +17,11 @@ import { useRouter } from 'next/navigation'
 import { useState, useRef } from 'react'
 import { useGoogleAuth } from '@/lib/hooks/use-google-auth'
 
+const etherealTextStyle = {
+  letterSpacing: 'var(--eth-letter-spacing-user)',
+  color: 'rgba(255,255,255,var(--eth-user-opacity))',
+} as const
+
 export function SignUpForm({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -62,10 +67,14 @@ export function SignUpForm({ className, ...props }: React.ComponentPropsWithoutR
 
   return (
     <div className={cn('flex flex-col gap-6', className)} {...props}>
-      <Card>
+      <Card variant="ethereal">
         <CardHeader>
-          <CardTitle className="text-2xl">Sign up</CardTitle>
-          <CardDescription>Create a new account</CardDescription>
+          <CardTitle className="text-2xl" style={etherealTextStyle}>
+            Sign up
+          </CardTitle>
+          <CardDescription style={etherealTextStyle}>
+            Create a new account
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <div className="flex flex-col gap-6">

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -2,19 +2,30 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
-      className
-    )}
-    {...props}
-  />
-))
+type CardVariant = "default" | "ethereal"
+
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: CardVariant
+}
+
+const cardVariants: Record<CardVariant, string> = {
+  default: "bg-card border-border",
+  ethereal: "bg-card/20 border-border/40 backdrop-blur-md",
+}
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, variant = "default", ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-lg border text-card-foreground shadow-sm",
+        cardVariants[variant],
+        className
+      )}
+      {...props}
+    />
+  )
+)
 Card.displayName = "Card"
 
 const CardHeader = React.forwardRef<


### PR DESCRIPTION
## Summary
- add an `ethereal` variant to the Card component with translucent styling
- apply the ethereal card variant and ethereal text styling to the login and sign-up forms

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8620436d48323ae959f0f98eb6f0d