### PR TITLE
Adjust home tab surfaces and typography

### DIFF
--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -8,19 +8,33 @@ import { CheckInCard } from '@/components/home/CheckInCard'
 export default function HomePage() {
 
   return (
-    <div className="min-h-screen bg-background text-foreground flex flex-col">
+    <div
+      className="min-h-screen text-foreground flex flex-col"
+      style={{
+        color: 'rgba(255,255,255,var(--eth-user-opacity))',
+        letterSpacing: 'var(--eth-letter-spacing-user)',
+      }}
+    >
       {/* Header */}
-      <header className="px-4 pt-6 pb-2 max-w-md w-full mx-auto" style={{ letterSpacing: 'var(--eth-letter-spacing-user)' }}>
-        <div className="flex items-center justify-between text-sm text-muted-foreground">
+      <header className="px-4 pt-6 pb-2 max-w-md w-full mx-auto">
+        <div
+          className="flex items-center justify-between text-sm"
+          style={{ color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.75))' }}
+        >
           <span>09:57</span>
           <span className="font-medium" style={{ color: 'rgba(255,255,255,var(--eth-user-opacity))' }}>good evening.</span>
-          <GuardedLink href="/profile" aria-label="profile" className="size-6 rounded-full bg-muted" />
+          <GuardedLink
+            href="/profile"
+            aria-label="profile"
+            className="size-6 rounded-full border border-border/40 bg-card/20 backdrop-blur"
+          />
         </div>
         <div className="mt-2 flex items-center gap-2">
           {showDevToggle && (
             <button
               type="button"
-              className="text-xs underline text-muted-foreground"
+              className="text-xs underline"
+              style={{ color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.7))' }}
               onClick={() => {
                 try {
                   localStorage.setItem('IFS_DEV_MODE', 'true')
@@ -39,11 +53,14 @@ export default function HomePage() {
 
       {/* Calendar strip */}
       <div className="max-w-md w-full mx-auto px-4 mt-2">
-        <div className="grid grid-cols-7 gap-2 text-center text-xs text-muted-foreground">
+        <div
+          className="grid grid-cols-7 gap-2 text-center text-xs"
+          style={{ color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.7))' }}
+        >
           {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map((d, i) => (
             <div key={d + i} className="flex flex-col gap-1">
               <span>{d}</span>
-              <div className="rounded-md bg-muted py-1">27</div>
+              <div className="rounded-md border border-border/40 bg-card/20 backdrop-blur py-1">27</div>
             </div>
           ))}
         </div>
@@ -55,13 +72,31 @@ export default function HomePage() {
           <CheckInCard />
 
           {/* Daily meditations (spans 2 columns) */}
-          <div className="col-span-2 rounded-xl border border-border bg-card p-4 mt-2">
-            <div className="text-xs font-semibold text-muted-foreground tracking-wide">DAILY MEDITATIONS</div>
+          <div className="col-span-2 rounded-xl border border-border/40 bg-card/20 backdrop-blur p-4 mt-2">
+            <div
+              className="text-xs font-semibold"
+              style={{
+                color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.75))',
+                letterSpacing: 'var(--eth-letter-spacing-user)',
+              }}
+            >
+              DAILY MEDITATIONS
+            </div>
             <div className="mt-3 text-sm">
               <blockquote className="italic">“So whatever you want to do, just do it… Making a damn fool of yourself is absolutely essential.”</blockquote>
-              <div className="text-xs text-muted-foreground mt-2">— Gloria Steinem</div>
+              <div
+                className="text-xs mt-2"
+                style={{ color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.65))' }}
+              >
+                — Gloria Steinem
+              </div>
             </div>
-            <div className="mt-3 text-xs text-muted-foreground">Tap to explore more insights</div>
+            <div
+              className="mt-3 text-xs"
+              style={{ color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.65))' }}
+            >
+              Tap to explore more insights
+            </div>
           </div>
         </div>
       </main>


### PR DESCRIPTION
## Summary
- remove the static background from the home tab root and rely on user CSS variables for base typography
- refresh muted and card surfaces to use translucent blurred treatments with shared border styles

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c862071d1c8323b15b7a691980bb24