### PR TITLE
Adjust tabs layout background layering

### DIFF
--- a/app/(tabs)/layout.tsx
+++ b/app/(tabs)/layout.tsx
@@ -3,8 +3,8 @@ import { BottomTabs } from '@/components/nav/BottomTabs'
 
 export default function TabsLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen bg-background text-foreground flex flex-col">
-      <div className="flex-1 flex flex-col pb-20">{children}</div>
+    <div className="min-h-screen text-foreground flex flex-col">
+      <div className="flex-1 flex flex-col pb-20 bg-background/50 backdrop-blur">{children}</div>
       <BottomTabs />
     </div>
   )


### PR DESCRIPTION
## Summary
- remove the opaque background from the tabs layout wrapper so the shared GlobalBackdrop can show through
- apply a subtle translucent surface to the scrolling content area to retain readability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c86208d6948323a090da76906fbe84