### PR TITLE
Add processed tracking to insights and check-ins

### DIFF
--- a/app/api/check-ins/route.ts
+++ b/app/api/check-ins/route.ts
@@ -47,6 +47,7 @@ export async function POST(req: NextRequest) {
       gratitude: body.gratitude,
       parts_data: body.parts_data,
       somatic_markers: body.somatic_markers,
+      processed: false,
     }).select()
 
     if (error) {

--- a/app/api/cron/generate-insights/route.ts
+++ b/app/api/cron/generate-insights/route.ts
@@ -20,6 +20,8 @@ async function saveInsightsToDb(
     status: 'pending',
     content: { title: insight.title, body: insight.body, sourceSessionIds: insight.sourceSessionIds || [] } as Json,
     meta: { generator: 'insight-generator-agent-v1', trigger: 'daily-cron' } as Json,
+    processed: false,
+    processed_at: null,
     created_at: now,
     updated_at: now,
   }));

--- a/app/api/insights/request/route.ts
+++ b/app/api/insights/request/route.ts
@@ -28,6 +28,8 @@ async function saveInsightsToDb(
       generator: 'insight-generator-agent-v1',
       trigger: 'on-demand-request',
     } as Json,
+    processed: false,
+    processed_at: null,
     created_at: now,
     updated_at: now,
   }));

--- a/components/check-in/morning-form.tsx
+++ b/components/check-in/morning-form.tsx
@@ -35,6 +35,7 @@ export function MorningCheckInForm({ className, ...props }: Omit<React.Component
         morning_looking_forward_to: lookingForwardTo,
         status: 'morning_completed',
         completed_at: new Date().toISOString(),
+        processed: false,
       })
 
       if (error) throw error

--- a/lib/insights/generator.ts
+++ b/lib/insights/generator.ts
@@ -22,6 +22,8 @@ export async function jitTopUpInsights(opts: {
       sourceSessionIds: []
     } as Json,
     meta: { generator: 'jit-v0', jit: true, slotHint: i, created_via: 'api_get_jit' } as Json,
+    processed: false,
+    processed_at: null,
     created_at: now,
     updated_at: now
   }))

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -87,7 +87,20 @@ export interface Database {
           }
         ]
       }
-      ,
+      check_ins: {
+        Row: CheckInRow
+        Insert: CheckInInsert
+        Update: CheckInUpdate
+        Relationships: [
+          {
+            foreignKeyName: "check_ins_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
       insights: {
         Row: InsightRow
         Insert: InsightInsert
@@ -392,6 +405,64 @@ export interface SessionUpdate {
   updated_at?: string
 }
 
+// Check-in Types
+export type CheckInType = 'morning' | 'evening'
+
+export interface CheckInRow {
+  id: string;
+  [key: string]: unknown;
+  user_id: string
+  type: CheckInType
+  check_in_date: string
+  mood: number | null
+  energy_level: number | null
+  intention: string | null
+  reflection: string | null
+  gratitude: string | null
+  parts_data: Json | null
+  somatic_markers: string[] | null
+  processed: boolean
+  processed_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface CheckInInsert {
+  id?: string
+  user_id: string
+  type: CheckInType
+  check_in_date?: string
+  mood?: number | null
+  energy_level?: number | null
+  intention?: string | null
+  reflection?: string | null
+  gratitude?: string | null
+  parts_data?: Json | null
+  somatic_markers?: string[] | null
+  processed?: boolean
+  processed_at?: string | null
+  created_at?: string
+  updated_at?: string
+}
+
+export interface CheckInUpdate {
+  id?: string
+  user_id?: string
+  type?: CheckInType
+  check_in_date?: string
+  mood?: number | null
+  energy_level?: number | null
+  intention?: string | null
+  reflection?: string | null
+  gratitude?: string | null
+  parts_data?: Json | null
+  somatic_markers?: string[] | null
+  processed?: boolean
+  processed_at?: string | null
+  created_at?: string
+  updated_at?: string
+}
+
 // Part Relationship Types
 export type RelationshipType = 'polarized' | 'protector-exile' | 'allied'
 export type RelationshipStatus = 'active' | 'healing' | 'resolved'
@@ -572,6 +643,8 @@ export interface InsightRow {
   feedback: string | null
   revealed_at: string | null
   actioned_at: string | null
+  processed: boolean
+  processed_at: string | null
   meta: Json
   created_at: string
   updated_at: string
@@ -587,6 +660,8 @@ export interface InsightInsert {
   feedback?: string | null
   revealed_at?: string | null
   actioned_at?: string | null
+  processed?: boolean
+  processed_at?: string | null
   meta?: Json
   created_at?: string
   updated_at?: string
@@ -602,6 +677,8 @@ export interface InsightUpdate {
   feedback?: string | null
   revealed_at?: string | null
   actioned_at?: string | null
+  processed?: boolean
+  processed_at?: string | null
   meta?: Json
   created_at?: string
   updated_at?: string

--- a/scripts/import-persona-fixtures.ts
+++ b/scripts/import-persona-fixtures.ts
@@ -84,7 +84,12 @@ async function importFixture(supabase: any, fixture: Fixture) {
   // Insert insights
   if (fixture.insights?.length) {
     for (const i of fixture.insights) {
-      const { error } = await supabase.from('insights').insert(i)
+      const payload = {
+        ...i,
+        processed: typeof i.processed === 'boolean' ? i.processed : false,
+        processed_at: 'processed_at' in i ? (i.processed_at ?? null) : null,
+      }
+      const { error } = await supabase.from('insights').insert(payload)
       if (error) throw new Error(`Insight insert failed: ${error.message}`)
     }
   }

--- a/scripts/seed-check-ins.ts
+++ b/scripts/seed-check-ins.ts
@@ -75,6 +75,8 @@ async function seedUser(supabase: ReturnType<typeof createClient>, userId: strin
         gratitude: e.gratitude,
         parts_data: {},
         somatic_markers: e.somatic,
+        processed: false,
+        processed_at: null,
         created_at: new Date(dateOnly + (e.type === 'morning' ? 'T09:00:00Z' : 'T20:00:00Z')).toISOString(),
         updated_at: new Date().toISOString()
       }

--- a/supabase/migrations/005_insights.sql
+++ b/supabase/migrations/005_insights.sql
@@ -13,6 +13,8 @@ CREATE TABLE IF NOT EXISTS insights (
   feedback text NULL,
   revealed_at timestamptz NULL,
   actioned_at timestamptz NULL,
+  processed boolean NOT NULL DEFAULT false,
+  processed_at timestamptz NULL,
   meta jsonb NOT NULL DEFAULT '{}'::jsonb, -- provenance/generator/jit flag/etc.
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()

--- a/supabase/migrations/007_check_ins.sql
+++ b/supabase/migrations/007_check_ins.sql
@@ -15,6 +15,8 @@ CREATE TABLE check_ins (
     gratitude TEXT,
     parts_data JSONB,
     somatic_markers TEXT[] DEFAULT '{}',
+    processed BOOLEAN NOT NULL DEFAULT false,
+    processed_at TIMESTAMP WITH TIME ZONE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UNIQUE(user_id, check_in_date, type)


### PR DESCRIPTION
## Summary
- add processed tracking columns to the insights and check_ins migrations
- extend the generated database types with processed metadata and new check-in interfaces
- ensure application inserts for insights and check-ins explicitly default to `processed = false`

## Testing
- npm run typecheck *(fails: mastra/workflows/generate-insight-workflow.ts:52 Property 'run' does not exist on type 'Agent')*


------
https://chatgpt.com/codex/tasks/task_e_68c87703d2588323a22212a491e9214a