### PR TITLE
Add tool to surface unprocessed updates for memory sync

### DIFF
--- a/lib/memory/service.ts
+++ b/lib/memory/service.ts
@@ -281,3 +281,40 @@ export async function loadTodayData(userId: string, isoCutoff: string): Promise<
 
   return { sessions: sessions || [], insights: insights || [], checkIns: checkIns || [] }
 }
+
+export async function listUnprocessedUpdates(userId: string): Promise<TodayData> {
+  const supabase = createAdminClient()
+
+  const { data: sessions, error: sErr } = await supabase
+    .from('sessions')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('processed', false)
+    .order('created_at', { ascending: true })
+
+  if (sErr) throw sErr
+
+  const { data: insights, error: iErr } = await supabase
+    .from('insights')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('processed', false)
+    .order('created_at', { ascending: true })
+
+  if (iErr) throw iErr
+
+  const { data: checkIns, error: cErr } = await supabase
+    .from('check_ins')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('processed', false)
+    .order('created_at', { ascending: true })
+
+  if (cErr) throw cErr
+
+  return {
+    sessions: sessions || [],
+    insights: insights || [],
+    checkIns: checkIns || [],
+  }
+}

--- a/mastra/agents/ifs-agent.ts
+++ b/mastra/agents/ifs-agent.ts
@@ -6,6 +6,7 @@ import { proposalTools } from '../tools/proposal-tools'
 import { evidenceTools } from '../tools/evidence-tools'
 import { stubTools } from '../tools/stub-tools'
 import { memoryTools } from '../tools/memory-tools'
+import { updateSyncTools } from '../tools/update-sync-tools'
 import { generateSystemPrompt } from './ifs_agent_prompt'
 
 // Configure OpenRouter provider through Mastra
@@ -30,6 +31,7 @@ export function createIfsAgent(profile: Profile) {
       ...evidenceTools, // Evidence and pattern tools
       ...stubTools, // Stub creation tools
       ...memoryTools, // Memory and conversation search tools
+      ...updateSyncTools, // Sync unprocessed updates from Supabase
     },
   })
 }

--- a/mastra/tools/update-sync-tools.ts
+++ b/mastra/tools/update-sync-tools.ts
@@ -1,0 +1,39 @@
+import { createTool } from '@mastra/core'
+import { z } from 'zod'
+import { resolveUserId } from '@/config/dev'
+import { listUnprocessedUpdates } from '@/lib/memory/service'
+
+const listUnprocessedUpdatesSchema = z.object({
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User ID to fetch unprocessed updates for (optional in development mode).'),
+})
+
+export const listUnprocessedUpdatesTool = createTool({
+  id: 'listUnprocessedUpdates',
+  description:
+    "Fetches the user's unprocessed sessions, insights, and check-ins so the agent can sync memory updates.",
+  inputSchema: listUnprocessedUpdatesSchema,
+  execute: async ({ context }) => {
+    const input = listUnprocessedUpdatesSchema.parse(context)
+    const userId = resolveUserId(input.userId)
+    const updates = await listUnprocessedUpdates(userId)
+
+    return {
+      ...updates,
+      totals: {
+        sessions: updates.sessions.length,
+        insights: updates.insights.length,
+        checkIns: updates.checkIns.length,
+        overall:
+          updates.sessions.length + updates.insights.length + updates.checkIns.length,
+      },
+    }
+  },
+})
+
+export const updateSyncTools = {
+  listUnprocessedUpdates: listUnprocessedUpdatesTool,
+}


### PR DESCRIPTION
## Summary
- add a Supabase helper that collects all unprocessed sessions, insights, and check-ins for a user
- expose a Mastra tool that aggregates those pending updates and returns helpful totals
- register the new tool with the IFS agent alongside existing memory utilities

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c87705b4308323a92030ef0d445194