### PR TITLE
Mark memory cron inputs as processed

### DIFF
--- a/app/api/cron/memory-update/route.ts
+++ b/app/api/cron/memory-update/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { listActiveUsersSince, reconstructMemory, loadTodayData, generateMemoryUpdate, saveNewSnapshot } from '@/lib/memory/service'
+import { listActiveUsersSince, reconstructMemory, loadTodayData, generateMemoryUpdate, saveNewSnapshot, markUpdatesProcessed } from '@/lib/memory/service'
 
 function requireCronAuth(req: Request): boolean {
   const secret = process.env.CRON_SECRET
@@ -28,6 +28,7 @@ async function runDailyMemoryUpdate(): Promise<Response> {
       }
       const next = await generateMemoryUpdate({ userId, oldMemory: previous, todayData: today })
       const saved = await saveNewSnapshot({ userId, previous, next, source: 'cron-daily' })
+      await markUpdatesProcessed(userId, today)
       results.push({ userId, version: saved.version })
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : 'unknown-error'

--- a/lib/memory/service.ts
+++ b/lib/memory/service.ts
@@ -257,6 +257,7 @@ export async function loadTodayData(userId: string, isoCutoff: string): Promise<
     .select('*')
     .eq('user_id', userId)
     .gte('created_at', isoCutoff)
+    .eq('processed', false)
     .order('created_at', { ascending: true })
 
   if (sErr) throw sErr
@@ -266,6 +267,7 @@ export async function loadTodayData(userId: string, isoCutoff: string): Promise<
     .select('*')
     .eq('user_id', userId)
     .or(`created_at.gte.${isoCutoff},updated_at.gte.${isoCutoff}`)
+    .eq('processed', false)
     .order('created_at', { ascending: true })
 
   if (iErr) throw iErr
@@ -275,9 +277,46 @@ export async function loadTodayData(userId: string, isoCutoff: string): Promise<
     .select('*')
     .eq('user_id', userId)
     .gte('created_at', isoCutoff)
+    .eq('processed', false)
     .order('created_at', { ascending: true })
 
   if (cErr) throw cErr
 
   return { sessions: sessions || [], insights: insights || [], checkIns: checkIns || [] }
+}
+
+function extractIds(rows: Record<string, unknown>[] | undefined): string[] {
+  if (!rows || rows.length === 0) return []
+  return rows
+    .map((row) => {
+      const id = row['id']
+      return typeof id === 'string' && id.length > 0 ? id : null
+    })
+    .filter((id): id is string => Boolean(id))
+}
+
+export async function markUpdatesProcessed(userId: string, items: TodayData): Promise<void> {
+  const supabase = createAdminClient()
+  const processedAt = new Date().toISOString()
+
+  const updateTable = async (table: 'sessions' | 'insights' | 'check_ins', ids: string[]) => {
+    if (ids.length === 0) return
+    const { error } = await supabase
+      .from(table)
+      .update({ processed: true, processed_at: processedAt })
+      .in('id', ids)
+      .eq('user_id', userId)
+
+    if (error) throw error
+  }
+
+  const sessionIds = extractIds(items.sessions)
+  const insightIds = extractIds(items.insights)
+  const checkInIds = extractIds(items.checkIns)
+
+  await Promise.all([
+    updateTable('sessions', sessionIds),
+    updateTable('insights', insightIds),
+    updateTable('check_ins', checkInIds),
+  ])
 }


### PR DESCRIPTION
## Summary
- call `markUpdatesProcessed` after saving snapshots in the cron memory update route
- add a Supabase helper that stamps sessions, insights, and check-ins as processed
- limit daily memory data loading to only unprocessed records

## Testing
- npm run lint
- npm run typecheck *(fails: Property 'run' does not exist on type 'Agent<"insight-generator-agent", any, Record<string, Metric>>')*


------
https://chatgpt.com/codex/tasks/task_e_68c877234f7883238fd8b051a0c8ddf5