### PR TITLE
Add feature-flagged garden grid view

### DIFF
--- a/components/garden/PartCard.tsx
+++ b/components/garden/PartCard.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import Link from 'next/link'
+import type { PartRow } from '@/lib/types/database'
+import { Card } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+interface PartCardProps {
+  part: PartRow
+  className?: string
+}
+
+export function PartCard({ part, className }: PartCardProps) {
+  const emoji = (part.visualization as { emoji?: string } | null)?.emoji ?? '🤗'
+
+  return (
+    <Link
+      href={`/garden/${part.id}`}
+      className={cn(
+        'group relative block rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        className
+      )}
+      aria-label={`View ${part.name}`}
+    >
+      <Card className="aspect-square flex flex-col items-center justify-center gap-4 p-6 text-center transition-transform duration-200 group-hover:-translate-y-1 group-hover:shadow-lg group-focus-visible:-translate-y-1">
+        <span className="text-5xl md:text-6xl" aria-hidden="true">
+          {emoji}
+        </span>
+        <span className="text-lg font-semibold text-foreground line-clamp-2">
+          {part.name}
+        </span>
+      </Card>
+    </Link>
+  )
+}

--- a/config/features.ts
+++ b/config/features.ts
@@ -18,6 +18,8 @@ export function isDevMode(): boolean {
 }
 
 const devMode = isDevMode()
+const gardenGridEnvOverride =
+  process.env.NEXT_PUBLIC_IFS_GARDEN_GRID_VIEW ?? process.env.IFS_GARDEN_GRID_VIEW
 
 // Whether to show the "Enable Dev Mode" toggle in the UI.
 // Default behavior: show in development, hide in production unless explicitly enabled.
@@ -79,4 +81,11 @@ export function statusForPath(pathname: string): { key: FeatureKey; status: Feat
   const enabled = devMode || (typeof window !== 'undefined' && clientDevOverride())
   const effective: FeatureStatus = enabled && status !== 'disabled' ? 'enabled' : status
   return { key, status: effective }
+}
+
+export function isGardenGridViewEnabled(): boolean {
+  if (devMode || (typeof window !== 'undefined' && clientDevOverride())) {
+    return true
+  }
+  return isTrue(gardenGridEnvOverride)
 }


### PR DESCRIPTION
## Summary
- add a feature flag to enable the upcoming garden grid experience
- render parts as square PartCard tiles with client-side search when the grid flag is on
- keep the existing force graph as the fallback when the flag is disabled

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8803259ec832387aa73ef76f895f9