### PR TITLE
Add part clarification notes support

### DIFF
--- a/components/garden/PartActions.tsx
+++ b/components/garden/PartActions.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from 'react'
 import Link from 'next/link'
 import type { PartRow } from '@/lib/types/database'
-import { updatePartDetails } from '@/app/garden/actions'
+import { addPartNote, updatePartDetails } from '@/app/garden/actions'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
 import { useToast } from '@/hooks/use-toast'
 
 interface PartActionsProps {
@@ -25,14 +26,16 @@ interface PartActionsProps {
 
 export function PartActions({ part }: PartActionsProps) {
   const { toast } = useToast()
-  const [isPending, startTransition] = useTransition()
+  const [isUpdatePending, startUpdate] = useTransition()
+  const [isNotePending, startAddNote] = useTransition()
   const [isOpen, setIsOpen] = useState(false)
   const [name, setName] = useState(part.name)
   const initialEmoji = (part.visualization as { emoji?: string })?.emoji || '🤗'
   const [emoji, setEmoji] = useState(initialEmoji)
+  const [clarificationNote, setClarificationNote] = useState('')
 
   const handleSave = () => {
-    startTransition(async () => {
+    startUpdate(async () => {
       const formData = new FormData()
       formData.append('partId', part.id)
       formData.append('name', name)
@@ -51,6 +54,46 @@ export function PartActions({ part }: PartActionsProps) {
         const errorMessage = typeof result.error === 'string'
           ? result.error
           : 'Validation failed. Please check your input.'
+        toast({
+          title: 'Error',
+          description: errorMessage,
+          variant: 'destructive',
+        })
+      }
+    })
+  }
+
+  const handleAddNote = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const noteContent = clarificationNote.trim()
+
+    if (!noteContent) {
+      toast({
+        title: 'Note is empty',
+        description: 'Add some details before saving a clarification.',
+        variant: 'destructive',
+      })
+      return
+    }
+
+    startAddNote(async () => {
+      const formData = new FormData()
+      formData.append('partId', part.id)
+      formData.append('content', noteContent)
+
+      const result = await addPartNote(formData)
+
+      if (result.success) {
+        toast({
+          title: 'Note added',
+          description: 'Clarification saved for this part.',
+        })
+        setClarificationNote('')
+      } else {
+        const errorMessage = typeof result.error === 'string'
+          ? result.error
+          : 'Could not save your note. Please try again.'
+
         toast({
           title: 'Error',
           description: errorMessage,
@@ -104,8 +147,8 @@ export function PartActions({ part }: PartActionsProps) {
                 </div>
               </div>
               <DialogFooter>
-                <Button onClick={handleSave} disabled={isPending}>
-                  {isPending ? 'Saving...' : 'Save Changes'}
+                <Button onClick={handleSave} disabled={isUpdatePending}>
+                  {isUpdatePending ? 'Saving...' : 'Save Changes'}
                 </Button>
               </DialogFooter>
             </DialogContent>
@@ -114,6 +157,28 @@ export function PartActions({ part }: PartActionsProps) {
           <Button asChild className="w-full">
             <Link href={`/chat?partId=${part.id}`}>Chat about this Part</Link>
           </Button>
+
+          <div className="space-y-3 rounded-lg border p-4">
+            <form onSubmit={handleAddNote} className="space-y-3">
+              <div className="space-y-2">
+                <Label htmlFor="clarification-note">Clarification Note</Label>
+                <Textarea
+                  id="clarification-note"
+                  value={clarificationNote}
+                  onChange={(event) => setClarificationNote(event.target.value)}
+                  placeholder="Capture context, requests, or insights you want to remember about this part."
+                  rows={4}
+                />
+              </div>
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={isNotePending || clarificationNote.trim().length === 0}
+              >
+                {isNotePending ? 'Saving Note...' : 'Save Clarification'}
+              </Button>
+            </form>
+          </div>
         </CardContent>
       </Card>
     </>

--- a/lib/data/parts-server.ts
+++ b/lib/data/parts-server.ts
@@ -7,6 +7,7 @@ export {
   createEmergingPart,
   updatePart,
   getPartRelationships,
+  getPartNotes,
   logRelationship,
 } from './parts'
 

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -87,7 +87,20 @@ export interface Database {
           }
         ]
       }
-      ,
+      part_notes: {
+        Row: PartNoteRow
+        Insert: PartNoteInsert
+        Update: PartNoteUpdate
+        Relationships: [
+          {
+            foreignKeyName: "part_notes_part_id_fkey"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
       insights: {
         Row: InsightRow
         Insert: InsightInsert
@@ -306,6 +319,29 @@ export interface PartUpdate {
   last_charge_intensity?: number | null
   created_at?: string
   updated_at?: string
+}
+
+// Part Note Types
+export interface PartNoteRow {
+  id: string;
+  [key: string]: unknown;
+  part_id: string
+  content: string
+  created_at: string
+}
+
+export interface PartNoteInsert {
+  id?: string
+  part_id: string
+  content: string
+  created_at?: string
+}
+
+export interface PartNoteUpdate {
+  id?: string
+  part_id?: string
+  content?: string
+  created_at?: string
 }
 
 // Session Types

--- a/supabase/migrations/017_part_notes.sql
+++ b/supabase/migrations/017_part_notes.sql
@@ -1,0 +1,33 @@
+-- Clarification notes for user parts
+CREATE TABLE IF NOT EXISTS part_notes (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  part_id uuid NOT NULL REFERENCES parts(id) ON DELETE CASCADE,
+  content text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_part_notes_part_id ON part_notes(part_id);
+
+ALTER TABLE part_notes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view notes for own parts"
+  ON part_notes FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM parts
+      WHERE parts.id = part_notes.part_id
+        AND parts.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can add notes for own parts"
+  ON part_notes FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM parts
+      WHERE parts.id = part_notes.part_id
+        AND parts.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- add a `part_notes` table with RLS policies to store clarification notes per part
- expose a server action and data helper to add and fetch notes, wiring up UI controls to capture new notes
- surface saved notes on the part details page in newest-first order

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8803735088323897ff1e028e6cdae