### PR TITLE
Enable Garden feature flag and update documentation

### DIFF
--- a/config/features.ts
+++ b/config/features.ts
@@ -19,6 +19,10 @@ export function isDevMode(): boolean {
 
 const devMode = isDevMode()
 
+const gardenFlag = process.env.ENABLE_GARDEN ?? process.env.NEXT_PUBLIC_ENABLE_GARDEN
+const gardenStatus: FeatureStatus =
+  gardenFlag === undefined ? 'enabled' : isTrue(gardenFlag) ? 'enabled' : 'disabled'
+
 // Whether to show the "Enable Dev Mode" toggle in the UI.
 // Default behavior: show in development, hide in production unless explicitly enabled.
 export const showDevToggle =
@@ -41,7 +45,7 @@ export const features: Record<FeatureKey, FeatureStatus> = {
   chat: 'enabled',
   home: 'enabled',
   insights: 'coming_soon',
-  garden: 'coming_soon',
+  garden: gardenStatus,
   journey: 'coming_soon',
   settings: 'coming_soon',
   profile: 'enabled',

--- a/docs/current_state/02_feature_implementations.md
+++ b/docs/current_state/02_feature_implementations.md
@@ -47,7 +47,7 @@ The main user-facing feature is the chat interface. The agent's capabilities wit
 
 This section provides a quick, human-readable map of shipped and in-progress features. Each entry links to a canonical feature page with full details and code anchors.
 
-- Parts Garden — Visual exploration UI for Parts. Status: shipped. See docs/features/parts-garden.md
+- Parts Garden — Visual exploration UI for Parts. Status: shipped (enabled by default; gate environments with `ENABLE_GARDEN=false`). See docs/features/parts-garden.md
   - Key routes: /garden, /garden/[partId]. Key paths: app/garden/*, components/garden/*
 - Guided Check-ins — Morning and evening structured flows. Status: shipped. See docs/features/check-ins.md
   - Key routes: /check-in/morning, /check-in/evening. Key paths: app/check-in/*, components/check-in/*

--- a/docs/features/parts-garden.md
+++ b/docs/features/parts-garden.md
@@ -2,7 +2,7 @@
 title: Feature: Parts Garden
 owner: @brandongalang
 status: shipped
-last_updated: 2025-08-31
+last_updated: 2025-09-02
 feature_flag: ENABLE_GARDEN
 code_paths:
   - app/garden/page.tsx
@@ -29,7 +29,7 @@ Offers a spatial/visual way to understand internal parts and relationships.
 - parts, part_relationships (read/derived views)
 
 ## Configuration
-- ENABLE_GARDEN feature flag (default off in prod; document your env)
+- Enabled by default via `config/features.ts`. Environments that need to hide the Garden must set `ENABLE_GARDEN` to a falsey value (`false`, `0`, or `off`). The feature flag is read during build, with optional support for mirroring via `NEXT_PUBLIC_ENABLE_GARDEN` when client overrides are required.
 
 ## Testing
 - Unit tests for helper logic; Playwright for navigation (overview → detail)


### PR DESCRIPTION
## Summary
- enable the Garden feature by default while honoring the ENABLE_GARDEN flag for gated environments
- document the flag behavior in the Parts Garden feature page and current state index

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c880399fb883239ebf97a729e134c6