### PR TITLE
Refine daily check-in payload format

### DIFF
--- a/components/check-in/DailyCheckInForm.tsx
+++ b/components/check-in/DailyCheckInForm.tsx
@@ -266,25 +266,88 @@ export function DailyCheckInForm({ variant, className, ...divProps }: DailyCheck
     setIsSubmitting(true)
 
     try {
-      const payload =
-        variant === 'morning'
-          ? {
-              type: 'morning' as const,
-              responses: {
-                intention: morningState.intention.trim(),
-                worries: morningState.worries.trim(),
-                lookingForwardTo: morningState.lookingForwardTo.trim(),
-              },
+      let payload:
+        | {
+            type: 'morning'
+            intention: string
+            reflection: null
+            responses: {
+              intention: string
+              worries: string
+              lookingForwardTo: string
             }
-          : {
-              type: 'evening' as const,
-              gratitude: eveningState.gratitude.trim(),
-              responses: {
-                reflectionOnIntention: eveningState.reflectionOnIntention.trim(),
-                reflectionOnWorries: eveningState.reflectionOnWorries.trim(),
-                reflectionOnLookingForwardTo: eveningState.reflectionOnLookingForwardTo.trim(),
-              },
+            parts_data: {
+              daily_responses: {
+                variant: 'morning'
+                intention: string
+                worries: string
+                lookingForwardTo: string
+              }
             }
+          }
+        | {
+            type: 'evening'
+            intention: string
+            reflection: string
+            gratitude: string
+            responses: {
+              reflectionOnIntention: string
+              reflectionOnWorries: string
+              reflectionOnLookingForwardTo: string
+              gratitude: string
+            }
+            parts_data: {
+              daily_responses: {
+                variant: 'evening'
+                reflectionOnIntention: string
+                reflectionOnWorries: string
+                reflectionOnLookingForwardTo: string
+                gratitude: string
+              }
+            }
+          }
+
+      if (variant === 'morning') {
+        const morningResponses = {
+          intention: morningState.intention.trim(),
+          worries: morningState.worries.trim(),
+          lookingForwardTo: morningState.lookingForwardTo.trim(),
+        }
+
+        payload = {
+          type: 'morning',
+          intention: morningResponses.intention,
+          reflection: null,
+          responses: morningResponses,
+          parts_data: {
+            daily_responses: {
+              variant: 'morning',
+              ...morningResponses,
+            },
+          },
+        }
+      } else {
+        const eveningResponses = {
+          reflectionOnIntention: eveningState.reflectionOnIntention.trim(),
+          reflectionOnWorries: eveningState.reflectionOnWorries.trim(),
+          reflectionOnLookingForwardTo: eveningState.reflectionOnLookingForwardTo.trim(),
+          gratitude: eveningState.gratitude.trim(),
+        }
+
+        payload = {
+          type: 'evening',
+          intention: morningContext?.intention ?? '',
+          reflection: eveningResponses.reflectionOnIntention,
+          gratitude: eveningResponses.gratitude,
+          responses: eveningResponses,
+          parts_data: {
+            daily_responses: {
+              variant: 'evening',
+              ...eveningResponses,
+            },
+          },
+        }
+      }
 
       const response = await fetch('/api/check-ins', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- restructure the daily check-in form submission so intention/reflection are sent at the top level and answers are grouped under `parts_data.daily_responses`
- update the check-in API to map responses onto the core columns while storing the complete response set under the new daily responses payload

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c8976c98188323a65df9bd27c3e306