### PR TITLE
Route /check-in to correct variant

### DIFF
--- a/app/check-in/page.tsx
+++ b/app/check-in/page.tsx
@@ -4,6 +4,40 @@ import { statusForPath } from '@/config/features'
 import ComingSoonPage from '@/components/common/ComingSoonPage'
 import { dev } from '@/config/dev'
 
+type CheckInVariant = 'morning' | 'evening'
+type TimeOfDay = CheckInVariant | 'none'
+
+function resolveTimeOfDay(date: Date): TimeOfDay {
+  const hour = date.getHours()
+  if (hour >= 4 && hour < 12) {
+    return 'morning'
+  }
+  if (hour >= 16 && hour < 22) {
+    return 'evening'
+  }
+  return 'none'
+}
+
+function determineVariant({
+  timeOfDay,
+  hasMorning,
+  hasEvening,
+}: {
+  timeOfDay: TimeOfDay
+  hasMorning: boolean
+  hasEvening: boolean
+}): CheckInVariant {
+  if (hasMorning) {
+    return timeOfDay === 'evening' ? 'evening' : 'morning'
+  }
+
+  if (hasEvening) {
+    return 'morning'
+  }
+
+  return timeOfDay === 'evening' ? 'evening' : 'morning'
+}
+
 export default async function CheckInPage() {
   const feature = statusForPath('/check-in')
   if (feature.status === 'coming_soon') {
@@ -20,5 +54,33 @@ export default async function CheckInPage() {
     redirect('/auth/login')
   }
 
-  redirect('/check-in/morning')
+  const now = new Date()
+  const timeOfDay = resolveTimeOfDay(now)
+  let variant: CheckInVariant = timeOfDay === 'evening' ? 'evening' : 'morning'
+
+  const userId = session?.user?.id
+  if (userId) {
+    const todayString = now.toISOString().slice(0, 10)
+    try {
+      const { data, error } = await supabase
+        .from('check_ins')
+        .select('type')
+        .eq('user_id', userId)
+        .eq('check_in_date', todayString)
+
+      if (error) {
+        console.error('Failed to load today\'s check-ins', error)
+      } else {
+        const entries = (data as { type: CheckInVariant }[] | null) ?? []
+        const hasMorning = entries.some((entry) => entry.type === 'morning')
+        const hasEvening = entries.some((entry) => entry.type === 'evening')
+
+        variant = determineVariant({ timeOfDay, hasMorning, hasEvening })
+      }
+    } catch (error) {
+      console.error('Unexpected error determining check-in variant', error)
+    }
+  }
+
+  redirect(`/check-in/${variant}`)
 }

--- a/docs/current_state/02_feature_implementations.md
+++ b/docs/current_state/02_feature_implementations.md
@@ -50,7 +50,7 @@ This section provides a quick, human-readable map of shipped and in-progress fea
 - Parts Garden — Visual exploration UI for Parts. Status: shipped (enabled by default; gate environments with `ENABLE_GARDEN=false`). See docs/features/parts-garden.md
   - Key routes: /garden, /garden/[partId]. Key paths: app/garden/*, components/garden/*
 - Guided Check-ins — Morning and evening structured flows. Status: shipped. See docs/features/check-ins.md
-  - Key routes: /check-in/morning, /check-in/evening. Key paths: app/check-in/*, components/check-in/*
+  - Key routes: /check-in/morning, /check-in/evening (root /check-in auto-selects the appropriate flow). Key paths: app/check-in/*, components/check-in/*
 - Chat — Conversational interface. Status: shipped. See docs/features/chat.md
   - Key route: /chat. Key paths: app/chat/page.tsx, hooks/useChat.ts, lib/database/*
 - Authentication (Google) — OAuth via Google. Status: shipped. See docs/features/authentication-google.md

--- a/docs/features/check-ins.md
+++ b/docs/features/check-ins.md
@@ -21,6 +21,7 @@ Provides a gentle, repeatable practice to capture mood, intentions, and observat
 
 ## How it works
 - Next.js routes under /check-in/morning and /check-in/evening
+- Visiting /check-in automatically routes to the morning or evening flow depending on the current window and whether today's entries already exist
 - Form components capture responses and persist via Supabase
 - Auth middleware ensures session enforcement for protected routes
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
     "test:unit": "npm exec tsx scripts/tests/unit/scoring.test.ts && npm exec tsx scripts/tests/unit/selector.test.ts && npm exec tsx scripts/tests/unit/prompt.test.ts && npm exec tsx scripts/tests/unit/security.test.ts && npm exec tsx scripts/tests/unit/rollback.test.ts && npm exec tsx scripts/tests/unit/part-schemas.test.ts",
-    "test:integration": "tsx scripts/tests/integration/check-ins.test.ts",
+    "test:integration": "tsx scripts/tests/integration/check-ins.test.ts && tsx scripts/tests/integration/check-in-page.test.ts",
     "test:ui": "tsx scripts/tests/ui/check-in-card.test.tsx",
     "test": "npm run test:unit && npm run test:integration && npm run test:ui && tsx scripts/test-onboarding.ts",
     "dev:mastra": "mastra dev --dir mastra",

--- a/scripts/tests/integration/check-in-page.test.ts
+++ b/scripts/tests/integration/check-in-page.test.ts
@@ -1,0 +1,152 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { setServerClientOverrideForTests } from '@/lib/supabase/server'
+
+process.env.NODE_ENV = 'test'
+process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://supabase.local'
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'anon-key'
+
+type CheckInType = 'morning' | 'evening'
+
+type Session = { user: { id: string } }
+
+const state: {
+  session: Session | null
+  checkIns: { type: CheckInType }[]
+  queryError: { message: string } | null
+} = {
+  session: { user: { id: 'user-123' } },
+  checkIns: [],
+  queryError: null,
+}
+
+const supabaseStub = {
+  auth: {
+    async getSession() {
+      return { data: { session: state.session }, error: null }
+    },
+  },
+  from() {
+    const query = {
+      eq() {
+        return query
+      },
+      then(onFulfilled: any, onRejected?: any) {
+        const result =
+          state.queryError === null
+            ? { data: state.checkIns, error: null }
+            : { data: null, error: state.queryError }
+        return Promise.resolve(result).then(onFulfilled, onRejected)
+      },
+    }
+
+    return {
+      select() {
+        return query
+      },
+    }
+  },
+}
+
+setServerClientOverrideForTests(supabaseStub as any)
+
+process.on('exit', () => {
+  setServerClientOverrideForTests(null)
+})
+
+const RealDate = Date
+
+function mockDateAtHour(hour: number) {
+  const isoHour = String(hour).padStart(2, '0')
+  const isoString = `2025-01-15T${isoHour}:00:00.000Z`
+
+  class MockDate extends RealDate {
+    constructor(...args: any[]) {
+      if (args.length === 0) {
+        super(isoString)
+      } else {
+        super(...(args as [any]))
+      }
+    }
+
+    static now() {
+      return new RealDate(isoString).getTime()
+    }
+  }
+
+  ;(globalThis as any).Date = MockDate as unknown as DateConstructor
+}
+
+function restoreDate() {
+  ;(globalThis as any).Date = RealDate as unknown as DateConstructor
+}
+
+const { default: CheckInPage } = await import('@/app/check-in/page')
+
+async function expectRedirect(url: string) {
+  try {
+    await CheckInPage()
+    assert.fail('Expected redirect to throw')
+  } catch (error) {
+    assert.ok(error instanceof Error)
+    const digest = (error as Error & { digest?: string }).digest
+    assert.equal(typeof digest, 'string')
+    const parts = (digest ?? '').split(';')
+    assert.equal(parts[0], 'NEXT_REDIRECT')
+    assert.equal(parts[2], url)
+  }
+}
+
+test('redirects to the morning flow during morning hours without entries', { concurrency: false }, async (t) => {
+  state.session = { user: { id: 'user-123' } }
+  state.checkIns = []
+  state.queryError = null
+  mockDateAtHour(9)
+
+  t.after(() => {
+    restoreDate()
+  })
+
+  await expectRedirect('/check-in/morning')
+})
+
+test('redirects to evening when the morning check-in exists and it is evening hours', { concurrency: false }, async (t) => {
+  state.session = { user: { id: 'user-123' } }
+  state.checkIns = [{ type: 'morning' }]
+  state.queryError = null
+  mockDateAtHour(18)
+
+  t.after(() => {
+    restoreDate()
+  })
+
+  await expectRedirect('/check-in/evening')
+})
+
+test('falls back to the morning form outside check-in windows', { concurrency: false }, async (t) => {
+  state.session = { user: { id: 'user-123' } }
+  state.checkIns = [{ type: 'morning' }]
+  state.queryError = null
+  mockDateAtHour(13)
+
+  t.after(() => {
+    restoreDate()
+  })
+
+  await expectRedirect('/check-in/morning')
+})
+
+test('uses time-of-day when Supabase returns an error', { concurrency: false }, async (t) => {
+  state.session = { user: { id: 'user-123' } }
+  state.checkIns = []
+  state.queryError = { message: 'boom' }
+  mockDateAtHour(18)
+
+  t.after(() => {
+    restoreDate()
+    state.queryError = null
+  })
+
+  await expectRedirect('/check-in/evening')
+})


### PR DESCRIPTION
## Summary
- determine the check-in variant server-side using time of day and whether today's entries exist before redirecting
- add integration coverage for /check-in routing decisions and supabase error fallback
- document the automatic morning/evening routing in the check-in feature notes

## Testing
- npm run test:integration

------
https://chatgpt.com/codex/tasks/task_e_68c8977099e883238c54a856078bdb8b