### PR TITLE
Track onboarding completion analytics

### DIFF
--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -13,6 +13,7 @@ import questionsConfig from '@/config/onboarding-questions.json';
 import { ensureOverviewExists } from '@/lib/memory/snapshots/scaffold';
 import { userOverviewPath } from '@/lib/memory/snapshots/fs-helpers';
 import { editMarkdownSection } from '@/lib/memory/markdown/editor';
+import { track } from '@/lib/analytics';
 
 /**
  * POST /api/onboarding/complete
@@ -117,8 +118,7 @@ export async function POST(request: NextRequest) {
       // Don't fail the completion for memory synthesis issues
     }
 
-    // TODO: Track analytics event
-    // await trackEvent('onboarding_completed', { userId: user.id, duration: ... });
+    track('onboarding_completed', { userId: user.id });
 
     const response: CompletionResponse = {
       ok: true,


### PR DESCRIPTION
## Summary
- import the analytics helper in the onboarding completion API route
- send an `onboarding_completed` analytics event when the flow finishes successfully

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c897783edc8323a3f47529d4e4a094