### PR TITLE
Refactor cron auth into shared helper

### DIFF
--- a/app/api/cron/generate-insights/route.ts
+++ b/app/api/cron/generate-insights/route.ts
@@ -1,7 +1,8 @@
 import { getMastra } from '@/mastra'
+import { requireCronAuth } from '@/lib/api/cron-auth'
+import { jsonResponse, errorResponse } from '@/lib/api/response'
 import { createClient } from '@/lib/supabase/server'
 import type { Json } from '@/lib/types/database'
-import { jsonResponse, errorResponse } from '@/lib/api/response'
 
 const COOL_DOWN_HOURS = 48
 
@@ -34,8 +35,7 @@ async function saveInsightsToDb(
 }
 
 export async function GET(request: Request) {
-  const authHeader = request.headers.get('authorization')
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!requireCronAuth(request)) {
     return errorResponse('Unauthorized', 401)
   }
 

--- a/app/api/cron/memory-update/route.ts
+++ b/app/api/cron/memory-update/route.ts
@@ -1,15 +1,6 @@
 import { NextResponse } from 'next/server'
+import { requireCronAuth } from '@/lib/api/cron-auth'
 import { listActiveUsersSince, reconstructMemory, loadTodayData, generateMemoryUpdate, saveNewSnapshot, markUpdatesProcessed } from '@/lib/memory/service'
-
-function requireCronAuth(req: Request): boolean {
-  const secret = process.env.CRON_SECRET
-  if (!secret) {
-    // In dev, allow if not configured; in prod, CI should set CRON_SECRET
-    return process.env.NODE_ENV !== 'production'
-  }
-  const authHeader = req.headers.get('authorization')
-  return authHeader === `Bearer ${secret}`
-}
 
 async function runDailyMemoryUpdate(): Promise<Response> {
   const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()

--- a/app/api/cron/update-digest/route.ts
+++ b/app/api/cron/update-digest/route.ts
@@ -1,15 +1,7 @@
 import { NextResponse } from 'next/server'
+import { requireCronAuth } from '@/lib/api/cron-auth'
 import { listUsersWithPendingUpdates } from '@/lib/memory/updates'
 import { summarizePendingUpdatesForUser, type UpdateSummarizerResult } from '@/lib/memory/update-runner'
-
-function requireCronAuth(req: Request): boolean {
-  const secret = process.env.CRON_SECRET
-  if (!secret) {
-    return process.env.NODE_ENV !== 'production'
-  }
-  const authHeader = req.headers.get('authorization')
-  return authHeader === `Bearer ${secret}`
-}
 
 async function runUpdateDigest(): Promise<Response> {
   const users = await listUsersWithPendingUpdates()

--- a/lib/api/cron-auth.ts
+++ b/lib/api/cron-auth.ts
@@ -1,0 +1,9 @@
+export function requireCronAuth(req: Request): boolean {
+  const secret = process.env.CRON_SECRET
+  if (!secret) {
+    // In development, allow requests when CRON_SECRET is not configured
+    return process.env.NODE_ENV !== 'production'
+  }
+  const authHeader = req.headers.get('authorization')
+  return authHeader === `Bearer ${secret}`
+}


### PR DESCRIPTION
## Summary
- add a shared cron authentication helper for API routes
- update cron API routes to use the shared helper instead of duplicated logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8b637800083239023c7732895eab4