### PR TITLE
refactor: centralize time constants

### DIFF
--- a/app/api/cron/generate-insights/route.ts
+++ b/app/api/cron/generate-insights/route.ts
@@ -1,9 +1,8 @@
+import { DAY_MS, HOUR_MS, INSIGHT_COOLDOWN_HOURS } from '@/config/time'
 import { getMastra } from '@/mastra'
 import { createClient } from '@/lib/supabase/server'
 import type { Json } from '@/lib/types/database'
 import { jsonResponse, errorResponse } from '@/lib/api/response'
-
-const COOL_DOWN_HOURS = 48
 
 async function saveInsightsToDb(
   supabase: Awaited<ReturnType<typeof createClient>>,
@@ -65,14 +64,14 @@ export async function GET(request: Request) {
 
     if (lastInsight) {
       const lastInsightDate = new Date(lastInsight.created_at)
-      const coolDownDate = new Date(lastInsightDate.getTime() + COOL_DOWN_HOURS * 60 * 60 * 1000)
+      const coolDownDate = new Date(lastInsightDate.getTime() + INSIGHT_COOLDOWN_HOURS * HOUR_MS)
       if (new Date() < coolDownDate) {
         console.log(`[Cron] User ${userId} is in cool-down period. Skipping.`)
         continue
       }
     }
 
-    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+    const oneDayAgo = new Date(Date.now() - DAY_MS).toISOString()
     const { data: recentActivity } = await supabase
       .from('sessions')
       .select('id', { count: 'exact' })

--- a/app/api/cron/memory-update/route.ts
+++ b/app/api/cron/memory-update/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { DAY_MS } from '@/config/time'
 import { listActiveUsersSince, reconstructMemory, loadTodayData, generateMemoryUpdate, saveNewSnapshot, markUpdatesProcessed } from '@/lib/memory/service'
 
 function requireCronAuth(req: Request): boolean {
@@ -12,7 +13,7 @@ function requireCronAuth(req: Request): boolean {
 }
 
 async function runDailyMemoryUpdate(): Promise<Response> {
-  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+  const cutoff = new Date(Date.now() - DAY_MS).toISOString()
   const users = await listActiveUsersSince(cutoff)
 
   const results: Array<{ userId: string; version?: number; error?: string }> = []

--- a/config/time.ts
+++ b/config/time.ts
@@ -1,0 +1,3 @@
+export const HOUR_MS = 60 * 60 * 1000
+export const DAY_MS = 24 * HOUR_MS
+export const INSIGHT_COOLDOWN_HOURS = 48


### PR DESCRIPTION
## Summary
- add shared time constants for hours, days, and insight cooldowns in a new config module
- update cron insight generation and memory update routes to rely on the shared time constants instead of inline calculations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8b63877e883238f1924946ef73fe3