### PR TITLE
Centralize BASE_URL configuration

### DIFF
--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { BASE_URL } from '@/config/app';
 import { createClient } from '@/lib/supabase/server';
 import {
   CompletionRequest,
@@ -65,7 +66,7 @@ export async function POST(request: NextRequest) {
     if (userState.status === 'completed') {
       const response: CompletionResponse = {
         ok: true,
-        redirect: `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/`,
+        redirect: `${BASE_URL}/`,
         completed_at: userState.completed_at!
       };
       return NextResponse.json(response);
@@ -122,7 +123,7 @@ export async function POST(request: NextRequest) {
 
     const response: CompletionResponse = {
       ok: true,
-      redirect: `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/`,
+      redirect: `${BASE_URL}/`,
       completed_at: now
     };
 

--- a/config/app.ts
+++ b/config/app.ts
@@ -1,0 +1,10 @@
+const DEFAULT_BASE_URL = 'http://localhost:3000';
+
+const configuredBaseUrl =
+  process.env.BASE_URL ||
+  process.env.APP_BASE_URL ||
+  process.env.NEXT_PUBLIC_APP_URL ||
+  process.env.API_BASE_URL ||
+  '';
+
+export const BASE_URL = configuredBaseUrl.trim() || DEFAULT_BASE_URL;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@playwright/test';
+import { BASE_URL } from './config/app';
 
 // Playwright will build and then start the Next.js server for the tests.
 // It will wait until the port responds, then run tests, and finally tear down the server.
@@ -8,14 +9,14 @@ export default defineConfig({
   fullyParallel: true,
   reporter: [['list']],
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    baseURL: BASE_URL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
   },
   webServer: {
     command: 'bash -c "npm run build && npm run start"',
-    url: process.env.BASE_URL || 'http://localhost:3000',
+    url: BASE_URL,
     timeout: 120_000,
     reuseExistingServer: true,
   },

--- a/scripts/smoke-test-insights.ts
+++ b/scripts/smoke-test-insights.ts
@@ -1,10 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
+import { BASE_URL } from '../config/app';
 import type { Database } from '../lib/types/database';
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const CRON_SECRET = process.env.CRON_SECRET;
-const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3000';
 
 if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY || !CRON_SECRET) {
   console.error('Missing required environment variables.');
@@ -30,7 +30,7 @@ async function testOnDemand() {
   const initialCount = await getInsightCount(TEST_USER_ID);
   console.log(`Initial insight count: ${initialCount}`);
 
-  const response = await fetch(`${API_BASE_URL}/api/insights/request`, {
+  const response = await fetch(`${BASE_URL}/api/insights/request`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ userId: TEST_USER_ID }),
@@ -61,7 +61,7 @@ async function testCronJob() {
   // For a real test suite, you'd want to seed the DB with a known state first.
 
   console.log('Simulating cron job trigger...');
-  const response = await fetch(`${API_BASE_URL}/api/cron/generate-insights`, {
+  const response = await fetch(`${BASE_URL}/api/cron/generate-insights`, {
     method: 'GET',
     headers: { Authorization: `Bearer ${CRON_SECRET}` },
   });


### PR DESCRIPTION
## Summary
- add a shared BASE_URL constant that falls back to http://localhost:3000
- refactor onboarding API redirect, Playwright config, and smoke test script to reuse BASE_URL

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8b651a6c88323bd026c2c73fa8360