### PR TITLE
Use config defaults for streaming text durations

### DIFF
--- a/components/ethereal/StreamingText.tsx
+++ b/components/ethereal/StreamingText.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { motion } from 'framer-motion'
 
+import { animationDefaults } from '@/config/animation'
+
 // Streams text with gentle, per-word glow, color shift, upward motion, and per-char fade for newly arrived content
 export function StreamingText({ text, onAnimationComplete }: { text: string, onAnimationComplete?: () => void }) {
   const prevCharLen = useRef(0)
@@ -20,12 +22,15 @@ export function StreamingText({ text, onAnimationComplete }: { text: string, onA
   let charSeen = 0
 
   // Read CSS variables for durations (ms)
+  const defaultWordDurationMs = animationDefaults.wordDurationMs
+  const defaultCharDurationMs = animationDefaults.charDurationMs
+
   const wordMs = typeof window !== 'undefined'
-    ? Number(getComputedStyle(document.documentElement).getPropertyValue('--eth-word-duration').trim() || 0) || 2000
-    : 2000
+    ? Number(getComputedStyle(document.documentElement).getPropertyValue('--eth-word-duration').trim() || 0) || defaultWordDurationMs
+    : defaultWordDurationMs
   const charMs = typeof window !== 'undefined'
-    ? Number(getComputedStyle(document.documentElement).getPropertyValue('--eth-char-duration').trim() || 0) || 1000
-    : 1000
+    ? Number(getComputedStyle(document.documentElement).getPropertyValue('--eth-char-duration').trim() || 0) || defaultCharDurationMs
+    : defaultCharDurationMs
 
   return (
     <span aria-live="polite">

--- a/config/animation.ts
+++ b/config/animation.ts
@@ -1,0 +1,6 @@
+export const animationDefaults = {
+  wordDurationMs: 2000,
+  charDurationMs: 1000,
+} as const
+
+export type AnimationDefaults = typeof animationDefaults

--- a/config/etherealTheme.ts
+++ b/config/etherealTheme.ts
@@ -1,3 +1,5 @@
+import { animationDefaults } from './animation'
+
 export type EtherealThemeVariant = {
   gradient?: string
 }
@@ -40,8 +42,8 @@ export const defaultEtherealTheme: EtherealTheme = {
     letterSpacingUser: '0',
   },
   animation: {
-    wordDurationMs: 2000,
-    charDurationMs: 1000,
+    wordDurationMs: animationDefaults.wordDurationMs,
+    charDurationMs: animationDefaults.charDurationMs,
     streamTickMs: 150,
     streamCharsPerTick: 8,
   },


### PR DESCRIPTION
## Summary
- add central animation defaults for word and character streaming durations
- reuse the shared defaults from the ethereal theme and StreamingText component

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8b663f1f08323963c043c1ceac8fc