### PR TITLE
refactor: extract shared task list component

### DIFF
--- a/components/chat/TaskList.tsx
+++ b/components/chat/TaskList.tsx
@@ -1,78 +1,12 @@
 "use client"
 
-import React from 'react'
-import type { TaskEvent } from '@/types/chat'
-import { Task as TaskBase, TaskTrigger, TaskContent, TaskItem, TaskItemFile } from '@/components/ai-elements/task'
-
-function getProgressData(progress?: number): { value?: number; label?: string } {
-  if (typeof progress !== 'number' || !Number.isFinite(progress)) {
-    return { value: undefined, label: undefined }
-  }
-  const value = Math.min(100, Math.max(0, progress))
-  return { value, label: `${Math.round(value)}%` }
-}
+import type { TaskEvent } from "@/types/chat"
+import { TaskList as TaskListBase } from "@/components/tasks/TaskList"
 
 interface TaskListProps {
   tasks: TaskEvent[] | undefined
 }
 
 export function TaskList({ tasks }: TaskListProps) {
-  if (!tasks || tasks.length === 0) return null
-
-  return (
-    <div className="space-y-2" data-testid="task-list">
-      {tasks.map((t) => {
-        const { value: progressValue, label: progressLabel } = getProgressData(t.progress)
-        const statusLabel = t.status ?? 'working'
-        const triggerPieces = [t.title ?? 'Task']
-        if (progressLabel) triggerPieces.push(`· ${progressLabel}`)
-        const triggerTitle = `${triggerPieces.join(' ')} (${statusLabel})`
-        const hasDetails = Array.isArray(t.details) ? t.details.length > 0 : Boolean(t.details)
-        const hasFiles = Array.isArray(t.meta?.files) && t.meta.files.length > 0
-        const showContent = hasDetails || hasFiles || progressValue !== undefined
-
-        return (
-          <TaskBase key={t.id} defaultOpen={t.status !== 'completed'}>
-            <TaskTrigger title={triggerTitle} />
-            {showContent ? (
-              <TaskContent>
-                {progressValue !== undefined ? (
-                  <div className="space-y-1">
-                    <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      <span>Progress</span>
-                      <span>{progressLabel}</span>
-                    </div>
-                    <div
-                      className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
-                      role="progressbar"
-                      aria-valuenow={Math.round(progressValue)}
-                      aria-valuemin={0}
-                      aria-valuemax={100}
-                    >
-                      <div
-                        className="h-full bg-primary transition-[width] duration-300"
-                        style={{ width: `${progressValue}%` }}
-                      />
-                    </div>
-                  </div>
-                ) : null}
-                {Array.isArray(t.details)
-                  ? t.details.map((d, i) => <TaskItem key={i}>{d}</TaskItem>)
-                  : t.details
-                  ? <TaskItem>{t.details}</TaskItem>
-                  : null}
-                {hasFiles ? (
-                  <div className="pt-2 flex flex-wrap gap-2">
-                    {t.meta?.files?.map((f, i) => (
-                      <TaskItemFile key={i}>{f?.name ?? 'file'}</TaskItemFile>
-                    ))}
-                  </div>
-                ) : null}
-              </TaskContent>
-            ) : null}
-          </TaskBase>
-        )
-      })}
-    </div>
-  )
+  return <TaskListBase tasks={tasks} data-testid="task-list" />
 }

--- a/components/ethereal/ActiveTaskOverlay.tsx
+++ b/components/ethereal/ActiveTaskOverlay.tsx
@@ -1,78 +1,19 @@
 "use client"
 
 import type { TaskEvent } from "@/types/chat"
-import { Task as TaskBase, TaskTrigger, TaskContent, TaskItem, TaskItemFile } from "@/components/ai-elements/task"
-
-function getProgressData(progress?: number): { value?: number; label?: string } {
-  if (typeof progress !== "number" || !Number.isFinite(progress)) {
-    return { value: undefined, label: undefined }
-  }
-  const value = Math.min(100, Math.max(0, progress))
-  return { value, label: `${Math.round(value)}%` }
-}
+import { TaskList as TaskListBase } from "@/components/tasks/TaskList"
 
 interface ActiveTaskOverlayProps {
   tasks: TaskEvent[] | undefined
 }
 
 export function ActiveTaskOverlay({ tasks }: ActiveTaskOverlayProps) {
-  if (!tasks || tasks.length === 0) return null
-
   return (
-    <div className="space-y-2 rounded-2xl border border-white/15 bg-white/10 p-4 backdrop-blur-xl shadow-[0_8px_40px_rgba(0,0,0,0.25)]">
-      {tasks.map((t) => {
-        const { value: progressValue, label: progressLabel } = getProgressData(t.progress)
-        const statusLabel = t.status ?? "working"
-        const triggerPieces = [t.title ?? "Task"]
-        if (progressLabel) triggerPieces.push(`· ${progressLabel}`)
-        const triggerTitle = `${triggerPieces.join(" ")} (${statusLabel})`
-        const hasDetails = Array.isArray(t.details) ? t.details.length > 0 : Boolean(t.details)
-        const hasFiles = Array.isArray(t.meta?.files) && t.meta.files.length > 0
-        const showContent = hasDetails || hasFiles || progressValue !== undefined
-
-        return (
-          <TaskBase key={t.id} defaultOpen={t.status !== "completed"}>
-            <TaskTrigger title={triggerTitle} />
-            {showContent ? (
-              <TaskContent>
-                {progressValue !== undefined ? (
-                  <div className="space-y-1">
-                    <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      <span>Progress</span>
-                      <span>{progressLabel}</span>
-                    </div>
-                    <div
-                      className="h-1.5 w-full overflow-hidden rounded-full bg-white/20"
-                      role="progressbar"
-                      aria-valuenow={Math.round(progressValue)}
-                      aria-valuemin={0}
-                      aria-valuemax={100}
-                    >
-                      <div
-                        className="h-full bg-white transition-[width] duration-300"
-                        style={{ width: `${progressValue}%` }}
-                      />
-                    </div>
-                  </div>
-                ) : null}
-                {Array.isArray(t.details)
-                  ? t.details.map((d, i) => <TaskItem key={i}>{d}</TaskItem>)
-                  : t.details
-                  ? <TaskItem>{t.details}</TaskItem>
-                  : null}
-                {hasFiles ? (
-                  <div className="pt-2 flex flex-wrap gap-2">
-                    {t.meta?.files?.map((f, i) => (
-                      <TaskItemFile key={i}>{f?.name ?? "file"}</TaskItemFile>
-                    ))}
-                  </div>
-                ) : null}
-              </TaskContent>
-            ) : null}
-          </TaskBase>
-        )
-      })}
-    </div>
+    <TaskListBase
+      tasks={tasks}
+      className="space-y-2 rounded-2xl border border-white/15 bg-white/10 p-4 backdrop-blur-xl shadow-[0_8px_40px_rgba(0,0,0,0.25)]"
+      progressTrackClassName="bg-white/20"
+      progressBarClassName="bg-white"
+    />
   )
 }
-

--- a/components/tasks/TaskList.tsx
+++ b/components/tasks/TaskList.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import type { HTMLAttributes } from "react"
+
+import { Task as TaskBase, TaskTrigger, TaskContent, TaskItem, TaskItemFile } from "@/components/ai-elements/task"
+import { cn } from "@/lib/utils"
+import type { TaskEvent } from "@/types/chat"
+
+function getProgressData(progress?: number): { value?: number; label?: string } {
+  if (typeof progress !== "number" || !Number.isFinite(progress)) {
+    return { value: undefined, label: undefined }
+  }
+
+  const value = Math.min(100, Math.max(0, progress))
+  return { value, label: `${Math.round(value)}%` }
+}
+
+export interface TaskListProps extends HTMLAttributes<HTMLDivElement> {
+  tasks: TaskEvent[] | undefined
+  progressTrackClassName?: string
+  progressBarClassName?: string
+}
+
+export function TaskList({
+  tasks,
+  progressTrackClassName = "bg-muted",
+  progressBarClassName = "bg-primary",
+  className,
+  ...props
+}: TaskListProps) {
+  if (!tasks || tasks.length === 0) return null
+
+  return (
+    <div className={cn("space-y-2", className)} {...props}>
+      {tasks.map((t) => {
+        const { value: progressValue, label: progressLabel } = getProgressData(t.progress)
+        const statusLabel = t.status ?? "working"
+        const triggerPieces = [t.title ?? "Task"]
+
+        if (progressLabel) triggerPieces.push(`· ${progressLabel}`)
+
+        const triggerTitle = `${triggerPieces.join(" ")} (${statusLabel})`
+        const hasDetails = Array.isArray(t.details) ? t.details.length > 0 : Boolean(t.details)
+        const hasFiles = Array.isArray(t.meta?.files) && t.meta.files.length > 0
+        const showContent = hasDetails || hasFiles || progressValue !== undefined
+
+        return (
+          <TaskBase key={t.id} defaultOpen={t.status !== "completed"}>
+            <TaskTrigger title={triggerTitle} />
+            {showContent ? (
+              <TaskContent>
+                {progressValue !== undefined ? (
+                  <div className="space-y-1">
+                    <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      <span>Progress</span>
+                      <span>{progressLabel}</span>
+                    </div>
+                    <div
+                      className={cn(
+                        "h-1.5 w-full overflow-hidden rounded-full",
+                        progressTrackClassName,
+                      )}
+                      role="progressbar"
+                      aria-valuenow={Math.round(progressValue)}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                    >
+                      <div
+                        className={cn("h-full transition-[width] duration-300", progressBarClassName)}
+                        style={{ width: `${progressValue}%` }}
+                      />
+                    </div>
+                  </div>
+                ) : null}
+                {Array.isArray(t.details)
+                  ? t.details.map((d, i) => <TaskItem key={i}>{d}</TaskItem>)
+                  : t.details
+                  ? <TaskItem>{t.details}</TaskItem>
+                  : null}
+                {hasFiles ? (
+                  <div className="pt-2 flex flex-wrap gap-2">
+                    {t.meta?.files?.map((f, i) => (
+                      <TaskItemFile key={i}>{f?.name ?? "file"}</TaskItemFile>
+                    ))}
+                  </div>
+                ) : null}
+              </TaskContent>
+            ) : null}
+          </TaskBase>
+        )
+      })}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- create a shared TaskList component with reusable progress and task detail rendering
- update ActiveTaskOverlay to use the shared component with overlay styling
- simplify the chat TaskList to reuse the shared component while retaining test hooks

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8b656325c8323a12e0a2e39c16e03