### PR TITLE
Refactor onboarding completion flow modules

### DIFF
--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -1,18 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import {
-  CompletionRequest,
-  CompletionResponse,
-  QuestionResponse,
-  OnboardingQuestion,
-  QuestionOption,
-  OnboardingResponseRecord,
-} from '@/lib/onboarding/types';
-import { computeStage1Scores, getTopThemes } from '@/lib/onboarding/scoring';
-import questionsConfig from '@/config/onboarding-questions.json';
-import { ensureOverviewExists } from '@/lib/memory/snapshots/scaffold';
-import { userOverviewPath } from '@/lib/memory/snapshots/fs-helpers';
-import { editMarkdownSection } from '@/lib/memory/markdown/editor';
+import { validateCompletionRequest } from '@/lib/onboarding/validate-completion-request';
+import { completeOnboardingState } from '@/lib/onboarding/complete-state';
+import { synthesizeOnboardingMemories } from '@/lib/onboarding/synthesize-memories';
+import { buildCompletionResponse } from '@/lib/onboarding/build-completion-response';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/lib/types/database';
 
 /**
  * POST /api/onboarding/complete
@@ -36,16 +29,16 @@ export async function POST(request: NextRequest) {
 
     // Parse and validate request
     const body = await request.json();
-    const validation = CompletionRequest.safeParse(body);
-    
-    if (!validation.success) {
-      return NextResponse.json({ 
-        error: 'Invalid request', 
-        details: validation.error.issues 
+    const validationResult = validateCompletionRequest(body);
+
+    if (!validationResult.success) {
+      return NextResponse.json({
+        error: 'Invalid request',
+        details: validationResult.issues,
       }, { status: 400 });
     }
 
-    const { version } = validation.data;
+    const { version } = validationResult.data;
 
     // Get user's onboarding state
     const { data: userState, error: stateError } = await supabase
@@ -63,12 +56,8 @@ export async function POST(request: NextRequest) {
 
     // Check if already completed
     if (userState.status === 'completed') {
-      const response: CompletionResponse = {
-        ok: true,
-        redirect: `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/`,
-        completed_at: userState.completed_at!
-      };
-      return NextResponse.json(response);
+      const completedAt = userState.completed_at ?? new Date().toISOString();
+      return buildCompletionResponse(completedAt, { setCompletionCookie: false });
     }
 
     // Version conflict check
@@ -80,36 +69,25 @@ export async function POST(request: NextRequest) {
     }
 
     // Validate completion requirements
-    const validationResult = await validateOnboardingCompletion(supabase, user.id);
-    if (!validationResult.valid) {
-      return NextResponse.json({ 
-        error: 'Onboarding not complete', 
-        missing: validationResult.missing 
+    const completionValidation = await validateOnboardingCompletion(supabase, user.id);
+    if (!completionValidation.valid) {
+      return NextResponse.json({
+        error: 'Onboarding not complete',
+        missing: completionValidation.missing
       }, { status: 400 });
     }
 
     // Mark as completed
-    const now = new Date().toISOString();
-    const { error: updateError } = await supabase
-      .from('user_onboarding')
-      .update({
-        status: 'completed',
-        stage: 'complete',
-        completed_at: now
-      })
-      .eq('user_id', user.id)
-      .eq('version', version)
-      .select()
-      .single();
+    const completionResult = await completeOnboardingState(supabase, user.id, version);
 
-    if (updateError) {
-      console.error('Error completing onboarding:', updateError);
+    if (!completionResult.success) {
+      console.error('Error completing onboarding:', completionResult.error);
       return NextResponse.json({ error: 'Failed to complete onboarding' }, { status: 500 });
     }
 
     // Trigger user memory synthesis
     try {
-      const { success: _memSuccess, didEdit: _memDidEdit } = await synthesizeOnboardingMemories(user.id);
+      const { success: _memSuccess, didEdit: _memDidEdit } = await synthesizeOnboardingMemories(supabase, user.id);
       void _memSuccess;
       void _memDidEdit;
     } catch (memoryError) {
@@ -120,24 +98,7 @@ export async function POST(request: NextRequest) {
     // TODO: Track analytics event
     // await trackEvent('onboarding_completed', { userId: user.id, duration: ... });
 
-    const response: CompletionResponse = {
-      ok: true,
-      redirect: `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/`,
-      completed_at: now
-    };
-
-    // Also set a lightweight cookie hint so middleware/UX can skip the DB check
-    const res = NextResponse.json(response)
-    try {
-      res.cookies.set('ifs_onb', '0', {
-        path: '/',
-        httpOnly: false,
-        sameSite: 'lax',
-        secure: true,
-      })
-    } catch {}
-
-    return res;
+    return buildCompletionResponse(completionResult.completedAt);
 
   } catch (error) {
     console.error('Unexpected error in completion route:', error);
@@ -148,9 +109,6 @@ export async function POST(request: NextRequest) {
 /**
  * Validates that all required onboarding responses are present
  */
-import type { SupabaseClient } from '@supabase/supabase-js'
-import type { Database } from '@/lib/types/database'
-
 async function validateOnboardingCompletion(
   supabase: SupabaseClient<Database>, 
   userId: string
@@ -217,112 +175,3 @@ async function validateOnboardingCompletion(
   };
 }
 
-/**
- * Synthesizes onboarding responses into user memory entries
- */
-async function synthesizeOnboardingMemories(userId: string): Promise<{ success: boolean; didEdit: boolean }> {
-  try {
-    const supabase = await createClient();
-    const { data: responses, error } = await supabase
-      .from('onboarding_responses')
-      .select('question_id, stage, response')
-      .eq('user_id', userId)
-      .in('stage', [1, 2, 3]);
-
-    if (error || !responses) {
-      console.warn('Failed to fetch onboarding responses:', error);
-      return { success: false, didEdit: false };
-    }
-
-    const stage1Snapshot: Record<string, QuestionResponse> = {};
-    const stage2: OnboardingResponseRecord[] = [];
-    const stage3: OnboardingResponseRecord[] = [];
-
-    for (const responseRecord of responses) {
-      if (responseRecord.stage === 1) {
-        stage1Snapshot[responseRecord.question_id] = responseRecord.response as QuestionResponse;
-      } else if (responseRecord.stage === 2) {
-        stage2.push(responseRecord);
-      } else if (responseRecord.stage === 3) {
-        stage3.push(responseRecord);
-      }
-    }
-
-    const scores = computeStage1Scores(stage1Snapshot);
-    const topThemes = getTopThemes(scores);
-    const themesMd = topThemes
-      .map(theme => `- ${theme}: ${(scores[theme] * 100).toFixed(0)}%`)
-      .join('\n');
-
-    const questionMap = new Map<string, OnboardingQuestion>(
-      (questionsConfig.questions as OnboardingQuestion[]).map((q: OnboardingQuestion) => [q.id, q])
-    );
-
-    const protectionsMd = stage2
-      .map((row): string | null => {
-        const question = questionMap.get(row.question_id);
-        if (!question || row.response.type !== 'single_choice') return null;
-        const response = row.response;
-        const option = question.options.find((opt: QuestionOption) => opt.value === response.value);
-        return `- ${question.prompt} ${option ? option.label : response.value}`;
-      })
-      .filter((line): line is string => Boolean(line))
-      .join('\n');
-
-    let somaticMd = '';
-    const somatic = stage3.find(row => row.question_id === 'S3_Q1');
-    if (somatic && somatic.response.type === 'multi_select') {
-      const q = questionMap.get('S3_Q1');
-      somaticMd = somatic.response.values
-        .map((value: string) => q?.options.find((opt: QuestionOption) => opt.value === value)?.label || value)
-        .join(', ');
-    }
-
-    let beliefsMd = '';
-    const belief = stage3.find(row => row.question_id === 'S3_Q2');
-    if (belief && belief.response.type === 'free_text') beliefsMd = belief.response.text;
-
-    let selfCompMd = '';
-    const selfComp = stage3.find(row => row.question_id === 'S3_Q3');
-    if (selfComp && selfComp.response.type === 'free_text') selfCompMd = selfComp.response.text;
-
-    let emotionsMd = '';
-    const emotion = stage3.find(row => row.question_id === 'S3_Q4');
-    if (emotion && emotion.response.type === 'single_choice') {
-      const q = questionMap.get('S3_Q4');
-      const response = emotion.response;
-      emotionsMd =
-        q?.options.find((o: QuestionOption) => o.value === response.value)?.label ||
-        response.value;
-    }
-
-    await ensureOverviewExists(userId);
-    const path = userOverviewPath(userId);
-
-    let didEdit = false;
-    let success = true;
-    const sections = [
-      { anchor: 'onboarding:v1:themes', text: themesMd },
-      { anchor: 'onboarding:v1:somatic', text: somaticMd },
-      { anchor: 'onboarding:v1:protections', text: protectionsMd },
-      { anchor: 'onboarding:v1:beliefs', text: beliefsMd },
-      { anchor: 'onboarding:v1:self_compassion', text: selfCompMd },
-      { anchor: 'onboarding:v1:emotions', text: emotionsMd },
-    ];
-
-    for (const { anchor, text } of sections) {
-      try {
-        const result = await editMarkdownSection(path, anchor, { replace: text });
-        if (result.beforeHash !== result.afterHash) didEdit = true;
-      } catch (err) {
-        success = false;
-        console.warn('Failed to edit markdown section', anchor, err);
-      }
-    }
-
-    return { success, didEdit };
-  } catch (err) {
-    console.error('synthesizeOnboardingMemories error', err);
-    return { success: false, didEdit: false };
-  }
-}

--- a/lib/onboarding/build-completion-response.ts
+++ b/lib/onboarding/build-completion-response.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import type { CompletionResponse } from './types';
+
+interface BuildCompletionResponseOptions {
+  setCompletionCookie?: boolean;
+}
+
+export function buildCompletionResponse(
+  completedAt: string,
+  options: BuildCompletionResponseOptions = {}
+): NextResponse<CompletionResponse> {
+  const redirectBase = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+
+  const response: CompletionResponse = {
+    ok: true,
+    redirect: `${redirectBase}/`,
+    completed_at: completedAt,
+  };
+
+  const res = NextResponse.json(response);
+
+  if (options.setCompletionCookie ?? true) {
+    try {
+      res.cookies.set('ifs_onb', '0', {
+        path: '/',
+        httpOnly: false,
+        sameSite: 'lax',
+        secure: true,
+      });
+    } catch {}
+  }
+
+  return res;
+}

--- a/lib/onboarding/complete-state.ts
+++ b/lib/onboarding/complete-state.ts
@@ -1,0 +1,32 @@
+import type { PostgrestError, SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/lib/types/database';
+
+export type CompleteOnboardingStateResult =
+  | { success: true; completedAt: string }
+  | { success: false; error: PostgrestError };
+
+export async function completeOnboardingState(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  version: number
+): Promise<CompleteOnboardingStateResult> {
+  const completedAt = new Date().toISOString();
+
+  const { error } = await supabase
+    .from('user_onboarding')
+    .update({
+      status: 'completed',
+      stage: 'complete',
+      completed_at: completedAt,
+    })
+    .eq('user_id', userId)
+    .eq('version', version)
+    .select()
+    .single();
+
+  if (error) {
+    return { success: false, error };
+  }
+
+  return { success: true, completedAt };
+}

--- a/lib/onboarding/synthesize-memories.ts
+++ b/lib/onboarding/synthesize-memories.ts
@@ -1,0 +1,122 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { computeStage1Scores, getTopThemes } from './scoring';
+import type {
+  QuestionResponse,
+  OnboardingResponseRecord,
+  OnboardingQuestion,
+  QuestionOption,
+} from './types';
+import questionsConfig from '@/config/onboarding-questions.json';
+import { ensureOverviewExists } from '@/lib/memory/snapshots/scaffold';
+import { userOverviewPath } from '@/lib/memory/snapshots/fs-helpers';
+import { editMarkdownSection } from '@/lib/memory/markdown/editor';
+import type { Database } from '@/lib/types/database';
+
+export async function synthesizeOnboardingMemories(
+  supabase: SupabaseClient<Database>,
+  userId: string
+): Promise<{ success: boolean; didEdit: boolean }> {
+  try {
+    const { data: responses, error } = await supabase
+      .from('onboarding_responses')
+      .select('question_id, stage, response')
+      .eq('user_id', userId)
+      .in('stage', [1, 2, 3]);
+
+    if (error || !responses) {
+      console.warn('Failed to fetch onboarding responses:', error);
+      return { success: false, didEdit: false };
+    }
+
+    const stage1Snapshot: Record<string, QuestionResponse> = {};
+    const stage2: OnboardingResponseRecord[] = [];
+    const stage3: OnboardingResponseRecord[] = [];
+
+    for (const responseRecord of responses) {
+      if (responseRecord.stage === 1) {
+        stage1Snapshot[responseRecord.question_id] = responseRecord.response as QuestionResponse;
+      } else if (responseRecord.stage === 2) {
+        stage2.push(responseRecord as OnboardingResponseRecord);
+      } else if (responseRecord.stage === 3) {
+        stage3.push(responseRecord as OnboardingResponseRecord);
+      }
+    }
+
+    const scores = computeStage1Scores(stage1Snapshot);
+    const topThemes = getTopThemes(scores);
+    const themesMd = topThemes
+      .map(theme => `- ${theme}: ${(scores[theme] * 100).toFixed(0)}%`)
+      .join('\n');
+
+    const questionMap = new Map<string, OnboardingQuestion>(
+      (questionsConfig.questions as OnboardingQuestion[]).map((q: OnboardingQuestion) => [q.id, q])
+    );
+
+    const protectionsMd = stage2
+      .map((row): string | null => {
+        const question = questionMap.get(row.question_id);
+        if (!question || row.response.type !== 'single_choice') return null;
+        const response = row.response;
+        const option = question.options.find((opt: QuestionOption) => opt.value === response.value);
+        return `- ${question.prompt} ${option ? option.label : response.value}`;
+      })
+      .filter((line): line is string => Boolean(line))
+      .join('\n');
+
+    let somaticMd = '';
+    const somatic = stage3.find(row => row.question_id === 'S3_Q1');
+    if (somatic && somatic.response.type === 'multi_select') {
+      const q = questionMap.get('S3_Q1');
+      somaticMd = somatic.response.values
+        .map((value: string) => q?.options.find((opt: QuestionOption) => opt.value === value)?.label || value)
+        .join(', ');
+    }
+
+    let beliefsMd = '';
+    const belief = stage3.find(row => row.question_id === 'S3_Q2');
+    if (belief && belief.response.type === 'free_text') beliefsMd = belief.response.text;
+
+    let selfCompMd = '';
+    const selfComp = stage3.find(row => row.question_id === 'S3_Q3');
+    if (selfComp && selfComp.response.type === 'free_text') selfCompMd = selfComp.response.text;
+
+    let emotionsMd = '';
+    const emotion = stage3.find(row => row.question_id === 'S3_Q4');
+    if (emotion && emotion.response.type === 'single_choice') {
+      const q = questionMap.get('S3_Q4');
+      const response = emotion.response;
+      emotionsMd =
+        q?.options.find((o: QuestionOption) => o.value === response.value)?.label ||
+        response.value;
+    }
+
+    await ensureOverviewExists(userId);
+    const path = userOverviewPath(userId);
+
+    let didEdit = false;
+    let success = true;
+    const sections = [
+      { anchor: 'onboarding:v1:themes', text: themesMd },
+      { anchor: 'onboarding:v1:somatic', text: somaticMd },
+      { anchor: 'onboarding:v1:protections', text: protectionsMd },
+      { anchor: 'onboarding:v1:beliefs', text: beliefsMd },
+      { anchor: 'onboarding:v1:self_compassion', text: selfCompMd },
+      { anchor: 'onboarding:v1:emotions', text: emotionsMd },
+    ];
+
+    for (const { anchor, text } of sections) {
+      try {
+        const result = await editMarkdownSection(path, anchor, { replace: text });
+        if (result.beforeHash !== result.afterHash) didEdit = true;
+      } catch (err) {
+        success = false;
+        console.warn('Failed to edit markdown section', anchor, err);
+      }
+    }
+
+    return { success, didEdit };
+  } catch (err) {
+    console.error('synthesizeOnboardingMemories error', err);
+    return { success: false, didEdit: false };
+  }
+}

--- a/lib/onboarding/validate-completion-request.ts
+++ b/lib/onboarding/validate-completion-request.ts
@@ -1,0 +1,23 @@
+import type { ZodIssue } from 'zod';
+import { CompletionRequest as CompletionRequestSchema } from './types';
+import type { CompletionRequest } from './types';
+
+export type CompletionRequestValidationResult =
+  | { success: true; data: CompletionRequest }
+  | { success: false; issues: ZodIssue[] };
+
+export function validateCompletionRequest(body: unknown): CompletionRequestValidationResult {
+  const parsed = CompletionRequestSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      issues: parsed.error.issues,
+    };
+  }
+
+  return {
+    success: true,
+    data: parsed.data,
+  };
+}


### PR DESCRIPTION
## Summary
- extract onboarding completion request validation, completion state mutation, memory synthesis, and response building into dedicated helpers
- refactor the onboarding completion API route to use the new helpers and clarify the flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8b64c08208323a4480847e10f0cc2