### PR TITLE
Use response helpers across API routes

### DIFF
--- a/app/api/cron/memory-update/route.ts
+++ b/app/api/cron/memory-update/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { listActiveUsersSince, reconstructMemory, loadTodayData, generateMemoryUpdate, saveNewSnapshot, markUpdatesProcessed } from '@/lib/memory/service'
+import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response'
 
 function requireCronAuth(req: Request): boolean {
   const secret = process.env.CRON_SECRET
@@ -36,26 +36,26 @@ async function runDailyMemoryUpdate(): Promise<Response> {
     }
   }
 
-  return NextResponse.json({ cutoff, processed: users.length, results })
+  return jsonResponse({ cutoff, processed: users.length, results })
 }
 
 export async function GET(req: Request) {
-  if (!requireCronAuth(req)) return new NextResponse('Unauthorized', { status: 401 })
+  if (!requireCronAuth(req)) return errorResponse('Unauthorized', HTTP_STATUS.UNAUTHORIZED)
   try {
     return await runDailyMemoryUpdate()
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'Internal Error'
-    return new NextResponse(message, { status: 500 })
+    return errorResponse(message, HTTP_STATUS.INTERNAL_SERVER_ERROR)
   }
 }
 
 export async function POST(req: Request) {
-  if (!requireCronAuth(req)) return new NextResponse('Unauthorized', { status: 401 })
+  if (!requireCronAuth(req)) return errorResponse('Unauthorized', HTTP_STATUS.UNAUTHORIZED)
   try {
     return await runDailyMemoryUpdate()
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : 'Internal Error'
-    return new NextResponse(message, { status: 500 })
+    return errorResponse(message, HTTP_STATUS.INTERNAL_SERVER_ERROR)
   }
 }
 

--- a/app/api/cron/update-digest/route.ts
+++ b/app/api/cron/update-digest/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from 'next/server'
 import { listUsersWithPendingUpdates } from '@/lib/memory/updates'
 import { summarizePendingUpdatesForUser, type UpdateSummarizerResult } from '@/lib/memory/update-runner'
+import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response'
 
 function requireCronAuth(req: Request): boolean {
   const secret = process.env.CRON_SECRET
@@ -25,26 +25,26 @@ async function runUpdateDigest(): Promise<Response> {
     }
   }
 
-  return NextResponse.json({ processed: users.length, results })
+  return jsonResponse({ processed: users.length, results })
 }
 
 export async function GET(req: Request) {
-  if (!requireCronAuth(req)) return new NextResponse('Unauthorized', { status: 401 })
+  if (!requireCronAuth(req)) return errorResponse('Unauthorized', HTTP_STATUS.UNAUTHORIZED)
   try {
     return await runUpdateDigest()
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Internal Error'
-    return new NextResponse(message, { status: 500 })
+    return errorResponse(message, HTTP_STATUS.INTERNAL_SERVER_ERROR)
   }
 }
 
 export async function POST(req: Request) {
-  if (!requireCronAuth(req)) return new NextResponse('Unauthorized', { status: 401 })
+  if (!requireCronAuth(req)) return errorResponse('Unauthorized', HTTP_STATUS.UNAUTHORIZED)
   try {
     return await runUpdateDigest()
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Internal Error'
-    return new NextResponse(message, { status: 500 })
+    return errorResponse(message, HTTP_STATUS.INTERNAL_SERVER_ERROR)
   }
 }
 

--- a/app/api/insights/request/route.ts
+++ b/app/api/insights/request/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from 'next/server';
 import { getMastra } from '@/mastra';
 import { createClient } from '@/lib/supabase/server';
 import { resolveUserId } from '@/config/dev';
 import type { Json } from '@/lib/types/database';
+import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response';
 
 async function saveInsightsToDb(
   supabase: Awaited<ReturnType<typeof createClient>>,
@@ -69,11 +69,11 @@ export async function POST(req: Request) {
     if (generatedInsights.length > 0) {
       const saved = await saveInsightsToDb(supabase, userId, generatedInsights);
       if (!saved) {
-        return NextResponse.json({ error: 'Failed to save generated insights.' }, { status: 500 });
+        return errorResponse('Failed to save generated insights.', HTTP_STATUS.INTERNAL_SERVER_ERROR);
       }
     }
 
-    return NextResponse.json({
+    return jsonResponse({
       message: 'Insight generation process completed.',
       insightsGenerated: generatedInsights.length,
     });
@@ -81,6 +81,6 @@ export async function POST(req: Request) {
   } catch (error) {
     console.error('Error in insight request route:', error);
     const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.';
-    return NextResponse.json({ error: errorMessage }, { status: 500 });
+    return errorResponse(errorMessage, HTTP_STATUS.INTERNAL_SERVER_ERROR);
   }
 }

--- a/app/api/onboarding/state/route.ts
+++ b/app/api/onboarding/state/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response';
 
 /**
  * GET /api/onboarding/state
@@ -17,7 +17,7 @@ export async function GET() {
     const { data: { user } } = await supabase.auth.getUser();
     
     if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return errorResponse('Unauthorized', HTTP_STATUS.UNAUTHORIZED);
     }
 
     // Get user's onboarding state
@@ -43,13 +43,13 @@ export async function GET() {
 
       if (createError) {
         console.error('Error creating initial onboarding state:', createError);
-        return NextResponse.json({ error: 'Failed to initialize onboarding' }, { status: 500 });
+        return errorResponse('Failed to initialize onboarding', HTTP_STATUS.INTERNAL_SERVER_ERROR);
       }
 
       userState = newState;
     } else if (stateError) {
       console.error('Error fetching onboarding state:', stateError);
-      return NextResponse.json({ error: 'Failed to fetch onboarding state' }, { status: 500 });
+      return errorResponse('Failed to fetch onboarding state', HTTP_STATUS.INTERNAL_SERVER_ERROR);
     }
 
     // Return minimal state for privacy and performance
@@ -63,10 +63,10 @@ export async function GET() {
       needs_onboarding: userState!.status !== 'completed'
     };
 
-    return NextResponse.json(response);
+    return jsonResponse(response);
 
   } catch (error) {
     console.error('Unexpected error in state route:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return errorResponse('Internal server error', HTTP_STATUS.INTERNAL_SERVER_ERROR);
   }
 }

--- a/app/api/parts/route.ts
+++ b/app/api/parts/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response'
 
 export async function GET() {
   const supabase = await createClient()
@@ -8,7 +8,7 @@ export async function GET() {
   } = await supabase.auth.getUser()
 
   if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    return errorResponse('Unauthorized', HTTP_STATUS.UNAUTHORIZED)
   }
 
   try {
@@ -20,12 +20,12 @@ export async function GET() {
 
     if (error) {
       console.error('Error fetching parts:', error)
-      return NextResponse.json({ error: 'Failed to fetch parts' }, { status: 500 })
+      return errorResponse('Failed to fetch parts', HTTP_STATUS.INTERNAL_SERVER_ERROR)
     }
 
-    return NextResponse.json(parts, { status: 200 })
+    return jsonResponse(parts)
   } catch (error) {
     console.error('Parts API error:', error)
-    return NextResponse.json({ error: 'An unexpected error occurred' }, { status: 500 })
+    return errorResponse('An unexpected error occurred', HTTP_STATUS.INTERNAL_SERVER_ERROR)
   }
 }

--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -1,9 +1,26 @@
-export function jsonResponse(data: unknown, status = 200, init: ResponseInit = {}) {
+import { NextResponse } from 'next/server'
+
+export const HTTP_STATUS = {
+  OK: 200,
+  CREATED: 201,
+  NO_CONTENT: 204,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  UNPROCESSABLE_ENTITY: 422,
+  TOO_MANY_REQUESTS: 429,
+  INTERNAL_SERVER_ERROR: 500,
+  SERVICE_UNAVAILABLE: 503,
+} as const
+
+export function jsonResponse(data: unknown, status = HTTP_STATUS.OK, init: ResponseInit = {}) {
   const headers = new Headers(init.headers)
   headers.set('Content-Type', 'application/json')
-  return new Response(JSON.stringify(data), { ...init, status, headers })
+  return new NextResponse(JSON.stringify(data), { ...init, status, headers })
 }
 
-export function errorResponse(message: string, status = 500, init?: ResponseInit) {
+export function errorResponse(message: string, status = HTTP_STATUS.INTERNAL_SERVER_ERROR, init?: ResponseInit) {
   return jsonResponse({ error: message }, status, init)
 }


### PR DESCRIPTION
## Summary
- extend the shared response helpers with HTTP status constants and NextResponse support
- replace direct NextResponse.json usage in API routes with jsonResponse/errorResponse for consistent payloads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8b65b7a44832386754e51cdcacaa8