### PR TITLE
Refactor parts queries to share helper

### DIFF
--- a/lib/data/parts-query.ts
+++ b/lib/data/parts-query.ts
@@ -1,0 +1,49 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { PartRow } from '@/lib/types/database'
+
+export interface PartQueryFilters {
+  /**
+   * Partial match against part name. The same term is also applied to the role field
+   * to preserve existing fuzzy search behaviour.
+   */
+  name?: string
+  status?: PartRow['status']
+  category?: PartRow['category']
+  limit?: number
+  /**
+   * Columns to select from the parts table. Defaults to `*`.
+   */
+  columns?: string
+}
+
+type PartsQueryClient = Pick<SupabaseClient<any>, 'from'>
+
+function escapeOrSearchTerm(term: string) {
+  return term.replace(/,/g, '\\,')
+}
+
+export function buildPartsQuery(
+  supabase: PartsQueryClient,
+  { name, status, category, limit, columns = '*' }: PartQueryFilters = {}
+): any {
+  let query = supabase.from('parts').select(columns).order('last_active', { ascending: false })
+
+  if (typeof limit === 'number') {
+    query = query.limit(limit)
+  }
+
+  if (name) {
+    const searchTerm = escapeOrSearchTerm(name)
+    query = query.or(`name.ilike.%${searchTerm}%,role.ilike.%${searchTerm}%`)
+  }
+
+  if (status) {
+    query = query.eq('status', status)
+  }
+
+  if (category) {
+    query = query.eq('category', category)
+  }
+
+  return query
+}


### PR DESCRIPTION
## Summary
- add a shared `buildPartsQuery` helper and `PartQueryFilters` interface to centralize base filters
- update the lite and server `searchParts` implementations to use the helper while layering module-specific constraints

## Testing
- npm run lint
- npm run typecheck *(fails due to pre-existing type errors in the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d728bf1883238e4b744718fc108a