### PR TITLE
Refactor session APIs to use ChatSessionService

### DIFF
--- a/app/api/session/end/route.ts
+++ b/app/api/session/end/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server'
 import { withSupabaseOrDev } from '@/lib/api/supabaseGuard'
 import { jsonResponse, errorResponse } from '@/lib/api/response'
+import { resolveUserId } from '@/config/dev'
 
 export async function POST(req: NextRequest) {
   try {
@@ -15,38 +16,21 @@ export async function POST(req: NextRequest) {
         return jsonResponse({ ok: true, ended: false })
       }
 
+      const { createChatSessionService } = await import('@/lib/session-service')
+
       if (ctx.type === 'authed') {
-        const { chatSessionService } = await import('@/lib/session-service')
-        await chatSessionService.endSession(sessionId)
+        const sessionService = createChatSessionService({ supabaseClient: ctx.supabase })
+        await sessionService.endSession(sessionId)
         return jsonResponse({ ok: true, ended: true })
       }
 
       if (ctx.type === 'admin') {
-        const { data: row, error: fetchError } = await ctx.admin
-          .from('sessions')
-          .select('start_time')
-          .eq('id', sessionId)
-          .single()
-
-        if (fetchError) throw fetchError
-
-        const endTime = new Date().toISOString()
-        let duration: number | null = null
-        try {
-          if (row?.start_time) {
-            const startMs = new Date(row.start_time as unknown as string).getTime()
-            const endMs = new Date(endTime).getTime()
-            duration = Math.max(0, Math.floor((endMs - startMs) / 1000))
-          }
-        } catch {}
-
-        const { error: updateError } = await ctx.admin
-          .from('sessions')
-          .update({ end_time: endTime, duration, updated_at: endTime })
-          .eq('id', sessionId)
-
-        if (updateError) throw updateError
-
+        const personaUserId = resolveUserId()
+        const sessionService = createChatSessionService({
+          supabaseClient: ctx.admin,
+          defaultUserId: personaUserId,
+        })
+        await sessionService.endSession(sessionId)
         return jsonResponse({ ok: true, ended: true })
       }
 


### PR DESCRIPTION
## Summary
- allow `ChatSessionService` to accept injected Supabase clients/action loggers and resolve a default user id for dev contexts
- add a configurable `createActionLogger` helper and use the session service for admin/dev and authed flows in the session API routes

## Testing
- npm run typecheck *(fails: existing type errors across unrelated API/onboarding files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d72bf0048323a1c3e1576c51173e