### PR TITLE
Standardize parts data access via API routes

### DIFF
--- a/app/api/parts/[partId]/route.ts
+++ b/app/api/parts/[partId]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { dev } from '@/config/dev'
+import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response'
+import { getPartById } from '@/lib/data/parts-server'
+import { createClient } from '@/lib/supabase/server'
+
+type RouteContext = {
+  params: {
+    partId: string
+  }
+}
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const { partId } = context.params
+  const supabase = await createClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError) {
+    console.error('Supabase auth error while fetching part:', authError)
+  }
+
+  if (!user && !dev.enabled) {
+    return errorResponse('Unauthorized', HTTP_STATUS.UNAUTHORIZED)
+  }
+
+  try {
+    const part = await getPartById({ partId, userId: user?.id })
+
+    if (!part) {
+      return errorResponse('Part not found', HTTP_STATUS.NOT_FOUND)
+    }
+
+    return jsonResponse(part)
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const detail = error.issues.map(issue => issue.message).join(', ') || 'Invalid request parameters'
+      return errorResponse(`Invalid request: ${detail}`, HTTP_STATUS.BAD_REQUEST)
+    }
+
+    console.error(`Error fetching part ${partId}:`, error)
+    return errorResponse('Failed to fetch part', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+}

--- a/app/api/parts/relationships/route.ts
+++ b/app/api/parts/relationships/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { dev } from '@/config/dev'
+import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response'
+import { getPartRelationships } from '@/lib/data/parts-server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError) {
+    console.error('Supabase auth error while fetching part relationships:', authError)
+  }
+
+  if (!user && !dev.enabled) {
+    return errorResponse('Unauthorized', HTTP_STATUS.UNAUTHORIZED)
+  }
+
+  const params = request.nextUrl.searchParams
+  const limitParam = params.get('limit')
+  const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : undefined
+  const limit = typeof parsedLimit === 'number' && !Number.isNaN(parsedLimit) ? parsedLimit : undefined
+
+  type RelationshipsInput = Parameters<typeof getPartRelationships>[0]
+  const relationshipInput: Partial<RelationshipsInput> = {
+    userId: user?.id,
+  }
+
+  const partIdParam = params.get('partId')
+  if (partIdParam) {
+    relationshipInput.partId = partIdParam as RelationshipsInput['partId']
+  }
+
+  const relationshipTypeParam = params.get('relationshipType')
+  if (relationshipTypeParam) {
+    relationshipInput.relationshipType = relationshipTypeParam as RelationshipsInput['relationshipType']
+  }
+
+  const statusParam = params.get('status')
+  if (statusParam) {
+    relationshipInput.status = statusParam as RelationshipsInput['status']
+  }
+
+  const includePartDetailsParam = params.get('includePartDetails')
+  if (includePartDetailsParam !== null) {
+    relationshipInput.includePartDetails = (includePartDetailsParam === 'true') as RelationshipsInput['includePartDetails']
+  }
+
+  if (typeof limit === 'number') {
+    relationshipInput.limit = limit as RelationshipsInput['limit']
+  }
+
+  try {
+    const relationships = await getPartRelationships(relationshipInput as RelationshipsInput)
+    return jsonResponse(relationships)
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const detail = error.issues.map(issue => issue.message).join(', ') || 'Invalid request parameters'
+      return errorResponse(`Invalid request: ${detail}`, HTTP_STATUS.BAD_REQUEST)
+    }
+
+    console.error('Error fetching part relationships:', error)
+    return errorResponse('Failed to fetch part relationships', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+}

--- a/app/api/parts/route.ts
+++ b/app/api/parts/route.ts
@@ -1,31 +1,61 @@
-import { createClient } from '@/lib/supabase/server'
-import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response'
+import { NextRequest } from 'next/server'
+import { ZodError } from 'zod'
 
-export async function GET() {
+import { dev } from '@/config/dev'
+import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response'
+import { searchParts } from '@/lib/data/parts-server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(request: NextRequest) {
   const supabase = await createClient()
   const {
     data: { user },
+    error: authError,
   } = await supabase.auth.getUser()
 
-  if (!user) {
+  if (authError) {
+    console.error('Supabase auth error while fetching parts:', authError)
+  }
+
+  if (!user && !dev.enabled) {
     return errorResponse('Unauthorized', HTTP_STATUS.UNAUTHORIZED)
   }
 
+  const params = request.nextUrl.searchParams
+  const limitParam = params.get('limit')
+  const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : undefined
+  const limit = typeof parsedLimit === 'number' && !Number.isNaN(parsedLimit) ? parsedLimit : undefined
+
+  type SearchPartsInput = Parameters<typeof searchParts>[0]
+  const searchInput: Partial<SearchPartsInput> = {
+    query: params.get('query') ?? undefined,
+    userId: user?.id,
+  }
+
+  const statusParam = params.get('status')
+  if (statusParam) {
+    searchInput.status = statusParam as SearchPartsInput['status']
+  }
+
+  const categoryParam = params.get('category')
+  if (categoryParam) {
+    searchInput.category = categoryParam as SearchPartsInput['category']
+  }
+
+  if (typeof limit === 'number') {
+    searchInput.limit = limit as SearchPartsInput['limit']
+  }
+
   try {
-    const { data: parts, error } = await supabase
-      .from('parts')
-      .select('id, name, visualization')
-      .eq('user_id', user.id)
-      .order('last_active', { ascending: false })
-
-    if (error) {
-      console.error('Error fetching parts:', error)
-      return errorResponse('Failed to fetch parts', HTTP_STATUS.INTERNAL_SERVER_ERROR)
-    }
-
+    const parts = await searchParts(searchInput as SearchPartsInput)
     return jsonResponse(parts)
   } catch (error) {
-    console.error('Parts API error:', error)
-    return errorResponse('An unexpected error occurred', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+    if (error instanceof ZodError) {
+      const detail = error.issues.map(issue => issue.message).join(', ') || 'Invalid request parameters'
+      return errorResponse(`Invalid request: ${detail}`, HTTP_STATUS.BAD_REQUEST)
+    }
+
+    console.error('Error fetching parts:', error)
+    return errorResponse('Failed to fetch parts', HTTP_STATUS.INTERNAL_SERVER_ERROR)
   }
 }

--- a/docs/current_state/01_system_architecture.md
+++ b/docs/current_state/01_system_architecture.md
@@ -32,7 +32,7 @@ Understanding the flow of data from user input to AI response is key to understa
 - **Backend:** Implemented as server-side logic within the Next.js framework, primarily using **API Routes** and server components/actions.
 - **Database:** [PostgreSQL](https://www.postgresql.org/) hosted on [Supabase](https://supabase.com/).
 - **Authentication:** Handled entirely by Supabase Auth, using the `@supabase/ssr` library to manage user sessions seamlessly across client and server components.
-- **Data modules split:** To prevent Node-only modules from leaking into the browser bundle, client code imports from `@/lib/data/parts-lite` (browser-safe), while server code imports from `@/lib/data/parts-server` (guarded via `server-only`). Richer logic (snapshots, action logging) lives behind the server entrypoint.
+- **Data modules split:** Client code calls `/api/parts` endpoints via the thin wrappers in `@/lib/data/parts-lite`, keeping Supabase credentials off the browser bundle. Server code imports from `@/lib/data/parts-server` (guarded via `server-only`) for direct Supabase access plus richer logic (snapshots, action logging).
 - **Security:** The database schema makes extensive use of PostgreSQL's **Row Level Security (RLS)** to ensure users can only access their own data. Policies are defined for all major tables.
 
 ## AI / Agentic Layer

--- a/docs/features/parts-garden.md
+++ b/docs/features/parts-garden.md
@@ -20,7 +20,7 @@ Visual exploration interface for browsing and drilling into Parts.
 Offers a spatial/visual way to understand internal parts and relationships.
 
 ## How it works
-- Grid overview at app/garden/page.tsx (client) uses `@/lib/data/parts-lite`
+- Grid overview at app/garden/page.tsx (client) uses `@/lib/data/parts-lite` fetchers backed by `/api/parts`
 - Detail at app/garden/[partId]/page.tsx (server) uses `@/lib/data/parts-server`
 - PartActions server actions import from `@/lib/data/parts-server`
 - Mastra tools provide part querying and updates

--- a/lib/data/parts-lite.ts
+++ b/lib/data/parts-lite.ts
@@ -1,13 +1,6 @@
 import { z } from 'zod'
-import type { Database, PartRow, PartRelationshipRow } from '@/lib/types/database'
-import { createClient as createBrowserSupabase } from '@/lib/supabase/client'
+import type { PartRow } from '@/lib/types/database'
 
-function getSupabaseClient() {
-  // Always use browser client in lite (client-safe) module
-  return createBrowserSupabase()
-}
-
-// Lightweight schemas (for basic validation only where needed)
 const searchPartsSchema = z.object({
   query: z.string().optional(),
   status: z.enum(['emerging', 'acknowledged', 'active', 'integrated']).optional(),
@@ -20,7 +13,6 @@ const getPartByIdSchema = z.object({
 })
 
 const getPartRelationshipsSchema = z.object({
-  userId: z.string().uuid().optional(),
   partId: z.string().uuid().optional(),
   relationshipType: z.enum(['polarized', 'protector-exile', 'allied']).optional(),
   status: z.enum(['active', 'healing', 'resolved']).optional(),
@@ -28,134 +20,91 @@ const getPartRelationshipsSchema = z.object({
   limit: z.number().min(1).max(50).default(20),
 })
 
-export async function searchParts(input: z.infer<typeof searchPartsSchema>): Promise<PartRow[]> {
-  try {
-    const validated = searchPartsSchema.parse(input)
-    const supabase = getSupabaseClient()
+async function fetchJson<T>(path: string, params?: URLSearchParams): Promise<T> {
+  const query = params && params.toString().length > 0 ? `?${params.toString()}` : ''
+  const response = await fetch(`${path}${query}`, {
+    method: 'GET',
+    credentials: 'same-origin',
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/json',
+    },
+  })
 
-    let query = supabase
-      .from('parts')
-      .select('*')
-      .order('last_active', { ascending: false })
-      .limit(validated.limit)
+  const text = await response.text()
+  let payload: unknown = null
 
-    if (validated.query) {
-      query = query.or(`name.ilike.%${validated.query}%,role.ilike.%${validated.query}%`)
+  if (text) {
+    try {
+      payload = JSON.parse(text)
+    } catch {
+      payload = text
     }
-    if (validated.status) {
-      query = query.eq('status', validated.status)
-    }
-    if (validated.category) {
-      query = query.eq('category', validated.category)
-    }
-
-    const { data, error } = await query
-    if (error) throw new Error(`Database error: ${error.message}`)
-
-    return (data as any) || []
-  } catch (error) {
-    throw error instanceof Error ? error : new Error('Unknown error occurred')
   }
+
+  if (!response.ok) {
+    const message =
+      payload && typeof payload === 'object' && payload !== null && 'error' in payload && typeof (payload as any).error === 'string'
+        ? (payload as any).error
+        : `Request failed with status ${response.status}`
+    throw new Error(message)
+  }
+
+  return payload as T
+}
+
+export async function searchParts(input: z.infer<typeof searchPartsSchema>): Promise<PartRow[]> {
+  const validated = searchPartsSchema.parse(input)
+  const params = new URLSearchParams()
+
+  if (validated.query) {
+    params.set('query', validated.query)
+  }
+  if (validated.status) {
+    params.set('status', validated.status)
+  }
+  if (validated.category) {
+    params.set('category', validated.category)
+  }
+  if (typeof validated.limit === 'number') {
+    params.set('limit', String(validated.limit))
+  }
+
+  return fetchJson<PartRow[]>('/api/parts', params)
 }
 
 export async function getPartById(input: z.infer<typeof getPartByIdSchema>): Promise<PartRow | null> {
+  const validated = getPartByIdSchema.parse(input)
+
   try {
-    const validated = getPartByIdSchema.parse(input)
-    const supabase = getSupabaseClient()
-
-    const { data, error } = await supabase
-      .from('parts')
-      .select('*')
-      .eq('id', validated.partId)
-      .single()
-
-    if (error) {
-      if ((error as any).code === 'PGRST116') {
-        return null
-      }
-      throw new Error(`Database error: ${error.message}`)
-    }
-
-    return data as any
+    return await fetchJson<PartRow>(`/api/parts/${validated.partId}`)
   } catch (error) {
+    if (error instanceof Error && error.message === 'Part not found') {
+      return null
+    }
     throw error instanceof Error ? error : new Error('Unknown error occurred')
   }
 }
 
 export async function getPartRelationships(input: z.infer<typeof getPartRelationshipsSchema>): Promise<Array<any>> {
-  try {
-    const validated = getPartRelationshipsSchema.parse(input)
-    const supabase = getSupabaseClient()
+  const validated = getPartRelationshipsSchema.parse(input)
+  const params = new URLSearchParams()
 
-    let query = supabase
-      .from('part_relationships')
-      .select('*')
-      .order('created_at', { ascending: false })
-      .limit(validated.limit)
-
-    if (validated.relationshipType) {
-      query = query.eq('type', validated.relationshipType)
-    }
-    if (validated.status) {
-      query = query.eq('status', validated.status)
-    }
-
-    const { data, error } = await query
-    if (error) throw new Error(`Database error: ${error.message}`)
-
-    let relationships = (data || []) as any[]
-
-    if (validated.partId) {
-      const pid = validated.partId
-      relationships = relationships.filter((rel: any) => Array.isArray(rel.parts) && rel.parts.includes(pid))
-    }
-
-    // Optionally fetch basic part details
-    let partsDetails: Record<string, { name: string; status: string }> = {}
-    if (validated.includePartDetails) {
-      const allPartIds = relationships.reduce((acc, rel) => {
-        const partIds = Array.isArray(rel.parts) ? rel.parts : []
-        return [...acc, ...partIds]
-      }, [] as string[])
-      const uniquePartIds = [...new Set(allPartIds)]
-      if (uniquePartIds.length > 0) {
-        const { data: parts, error: partsError } = await supabase
-          .from('parts')
-          .select('id, name, status')
-          .in('id', uniquePartIds)
-        if (!partsError) {
-          partsDetails = (parts || []).reduce((acc, part) => {
-            acc[part.id] = { name: (part as any).name, status: (part as any).status }
-            return acc
-          }, {} as Record<string, { name: string; status: string }>)
-        }
-      }
-    }
-
-    const formatted = relationships.map(rel => {
-      const partIds = Array.isArray(rel.parts) ? rel.parts : []
-      return {
-        id: rel.id,
-        type: rel.type,
-        status: rel.status,
-        description: rel.description,
-        issue: rel.issue,
-        common_ground: rel.common_ground,
-        polarization_level: rel.polarization_level,
-        dynamics: rel.dynamics || [],
-        parts: partIds.map((partId: string) => ({
-          id: partId,
-          ...(validated.includePartDetails && partsDetails[partId] ? { name: partsDetails[partId].name, status: partsDetails[partId].status } : {})
-        })),
-        last_addressed: rel.last_addressed,
-        created_at: rel.created_at,
-        updated_at: rel.updated_at,
-      }
-    })
-
-    return formatted
-  } catch (error) {
-    throw error instanceof Error ? error : new Error('Unknown error occurred')
+  if (validated.partId) {
+    params.set('partId', validated.partId)
   }
-}
+  if (validated.relationshipType) {
+    params.set('relationshipType', validated.relationshipType)
+  }
+  if (validated.status) {
+    params.set('status', validated.status)
+  }
+  if (validated.includePartDetails) {
+    params.set('includePartDetails', 'true')
+  }
+  if (typeof validated.limit === 'number') {
+    params.set('limit', String(validated.limit))
+  }
 
+  return fetchJson<Array<any>>('/api/parts/relationships', params)
+}


### PR DESCRIPTION
## Summary
- expand `/api/parts` to proxy the server-side search helper with consistent auth and validation
- add `/api/parts/[partId]` and `/api/parts/relationships` endpoints and refactor the browser data helpers to call them
- document when to use the new API routes versus direct Supabase access for contributors

## Testing
- npm run lint
- npm run typecheck *(fails: existing repository-wide type errors with errorResponse/default status typing)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d777144c8323a5c8a95afaed1c6c