### PR TITLE
Refactor ethereal chat and dev flow layout

### DIFF
--- a/app/dev/flow/page.tsx
+++ b/app/dev/flow/page.tsx
@@ -1,27 +1,24 @@
-'use client';
+'use client'
 
-import { useState, useEffect } from 'react';
-import { isDevMode } from '@/config/features';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Progress } from '@/components/ui/progress';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import type { OnboardingQuestion, QuestionResponse } from '@/lib/onboarding/types';
-import { DEV_STAGE_2_QUESTION_BANK, ANSWER_PRESETS } from '@/lib/dev/fixtures';
-import { AlertTriangle, CheckCircle } from 'lucide-react';
+import { useEffect, useState, type ReactNode } from 'react'
 
-// Dev mode guard
-function DevModeGuard({ children }: { children: React.ReactNode }) {
-    const [devEnabled, setDevEnabled] = useState(false);
+import { AlertTriangle, CheckCircle } from 'lucide-react'
 
-    useEffect(() => {
-      setDevEnabled(isDevMode());
-    }, []);
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Progress } from '@/components/ui/progress'
+import { isDevMode } from '@/config/features'
+import { useDevOnboardingFlow } from '@/hooks/useDevOnboardingFlow'
 
-    if (!devEnabled) {
+function DevModeGuard({ children }: { children: ReactNode }) {
+  const [devEnabled, setDevEnabled] = useState(false)
+
+  useEffect(() => {
+    setDevEnabled(isDevMode())
+  }, [])
+
+  if (!devEnabled) {
     return (
       <div className="min-h-screen flex items-center justify-center p-4">
         <Card className="max-w-md">
@@ -33,216 +30,27 @@ function DevModeGuard({ children }: { children: React.ReactNode }) {
           </CardContent>
         </Card>
       </div>
-    );
+    )
   }
 
-  return <>{children}</>;
+  return <>{children}</>
 }
 
-// Mock Stage 1 questions (using the actual structure)
-const STAGE_1_QUESTIONS: OnboardingQuestion[] = [
-  {
-    id: 'S1_Q1',
-    stage: 1,
-    type: 'single_choice',
-    prompt: 'When you share your work publicly, what typically comes up for you first?',
-    helper: 'Think about the immediate feelings or thoughts that arise',
-    options: [
-      { value: 'surge_energy', label: 'A surge of energy and excitement about reaching people' },
-      { value: 'methodical_checking', label: 'Methodical checking and rechecking before posting' },
-      { value: 'wondering_reception', label: 'Wondering how it will be received by others' },
-      { value: 'noticing_improvement', label: 'Noticing everything that could be improved' },
-    ],
-    active: true,
-    locale: 'en',
-    order_hint: 1,
-    theme_weights: {},
-  },
-  {
-    id: 'S1_Q2', 
-    stage: 1,
-    type: 'single_choice',
-    prompt: 'When your plans get disrupted unexpectedly, what happens inside you?',
-    helper: 'Consider your inner response to sudden changes',
-    options: [
-      { value: 'energized_possibilities', label: 'I feel energized by new possibilities opening up' },
-      { value: 'protect_secure', label: 'I need to protect what feels secure and familiar' },
-      { value: 'check_affected', label: 'I check on others who might be affected by the change' },
-      { value: 'analyze_wrong', label: 'I analyze what went wrong and how to prevent it next time' },
-    ],
-    active: true,
-    locale: 'en',
-    order_hint: 2,
-    theme_weights: {},
-  },
-  {
-    id: 'S1_Q3',
-    stage: 1,
-    type: 'single_choice', 
-    prompt: 'When someone you care about seems upset with you, what do you find yourself doing?',
-    helper: 'Think about your automatic response pattern',
-    options: [
-      { value: 'give_space', label: 'Give them space and wait for them to come to me' },
-      { value: 'directly_ask', label: 'Ask directly what\'s wrong and how to fix it' },
-      { value: 'review_actions', label: 'Review all my recent actions to see what I might have done' },
-      { value: 'focus_elsewhere', label: 'Focus my attention elsewhere until things settle' },
-    ],
-    active: true,
-    locale: 'en',
-    order_hint: 3,
-    theme_weights: {},
-  },
-];
-
-// Stage 3 questions with free text responses
-const STAGE_3_QUESTIONS: OnboardingQuestion[] = [
-  {
-    id: 'S3_Q1',
-    stage: 3,
-    type: 'free_text',
-    prompt: 'When you think about the parts of yourself that get activated under stress, what do you notice they are trying to protect you from?',
-    helper: 'Take a moment to reflect on what your protective parts are guarding against',
-    options: [],
-    active: true,
-    locale: 'en',
-    order_hint: 1,
-    theme_weights: {},
-  },
-  {
-    id: 'S3_Q2',
-    stage: 3,
-    type: 'free_text',
-    prompt: 'What beliefs do you carry about yourself that might have formed during difficult times in your life?',
-    helper: 'These might be thoughts like "I\'m not good enough" or "I have to be perfect"',
-    options: [],
-    active: true,
-    locale: 'en',
-    order_hint: 2,
-    theme_weights: {},
-  },
-  {
-    id: 'S3_Q3',
-    stage: 3,
-    type: 'free_text',
-    prompt: 'Where in your body do you tend to feel stress, tension, or difficult emotions?',
-    helper: 'This could be your shoulders, stomach, chest, or anywhere else you notice sensations',
-    options: [],
-    active: true,
-    locale: 'en',
-    order_hint: 3,
-    theme_weights: {},
-  },
-  {
-    id: 'S3_Q4',
-    stage: 3,
-    type: 'free_text',
-    prompt: 'If you could offer a compassionate message to the parts of yourself that struggle, what would you say?',
-    helper: 'Imagine speaking to these parts like you would to a good friend who is going through a hard time',
-    options: [],
-    active: true,
-    locale: 'en',
-    order_hint: 4,
-    theme_weights: {},
-  },
-];
-
 export default function OnboardingFlowPage() {
-  const [currentStage, setCurrentStage] = useState(1);
-  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-  const [answers, setAnswers] = useState<Record<string, QuestionResponse>>({});
-  const [questions, setQuestions] = useState<OnboardingQuestion[]>([]);
-  const [isComplete, setIsComplete] = useState(false);
+  const {
+    currentStage,
+    currentQuestionIndex,
+    currentQuestion,
+    totalQuestions,
+    questionContent,
+    answers,
+    isComplete,
+    progress,
+    totalStages,
+    actions: { resetFlow, loadPreset },
+  } = useDevOnboardingFlow()
 
-  // Initialize questions based on stage
-  useEffect(() => {
-    if (currentStage === 1) {
-      setQuestions(STAGE_1_QUESTIONS);
-      setCurrentQuestionIndex(0);
-    } else if (currentStage === 2) {
-      // Use fixture data for Stage 2 
-      setQuestions(DEV_STAGE_2_QUESTION_BANK.slice(0, 4));
-      setCurrentQuestionIndex(0);
-    } else if (currentStage === 3) {
-      // Stage 3 with free text questions
-      setQuestions(STAGE_3_QUESTIONS);
-      setCurrentQuestionIndex(0);
-    }
-  }, [currentStage]);
-
-  const currentQuestion = questions[currentQuestionIndex];
-  const totalQuestions = questions.length;
-  
-  // Progress calculation: 3 Stage 1 + 4 Stage 2 + 4 Stage 3 = 11 total
-  const totalQuestionCount = 11;
-  let completedQuestions = 0;
-  
-  if (currentStage === 1) {
-    completedQuestions = currentQuestionIndex;
-  } else if (currentStage === 2) {
-    completedQuestions = 3 + currentQuestionIndex;
-  } else if (currentStage === 3) {
-    completedQuestions = 7 + currentQuestionIndex;
-  }
-  
-  const progress = (completedQuestions / totalQuestionCount) * 100;
-
-  const handleAnswer = (response: QuestionResponse) => {
-    if (!currentQuestion) return;
-
-    const newAnswers = {
-      ...answers,
-      [currentQuestion.id]: response,
-    };
-    setAnswers(newAnswers);
-
-    // Auto-advance to next question
-    setTimeout(() => {
-      if (currentQuestionIndex < questions.length - 1) {
-        setCurrentQuestionIndex(currentQuestionIndex + 1);
-      } else if (currentStage === 1) {
-        // Move to Stage 2
-        setCurrentStage(2);
-      } else if (currentStage === 2) {
-        // Move to Stage 3
-        setCurrentStage(3);
-      } else {
-        // Complete onboarding
-        setIsComplete(true);
-      }
-    }, 500); // Small delay for UX
-  };
-
-  const handleSingleChoice = (value: string) => {
-    handleAnswer({
-      type: 'single_choice',
-      value,
-    });
-  };
-
-  const handleTextResponse = (text: string) => {
-    if (text.trim().length === 0) return;
-    
-    handleAnswer({
-      type: 'free_text', 
-      text: text.trim(),
-    });
-  };
-
-  const resetFlow = () => {
-    setCurrentStage(1);
-    setCurrentQuestionIndex(0);
-    setAnswers({});
-    setIsComplete(false);
-  };
-
-  const loadPreset = (presetKey: string) => {
-    const preset = ANSWER_PRESETS[presetKey as keyof typeof ANSWER_PRESETS];
-    if (preset) {
-      setAnswers(preset.answers);
-      setCurrentStage(2);
-      setCurrentQuestionIndex(0);
-    }
-  };
+  const answersCount = Object.keys(answers).length
 
   if (isComplete) {
     return (
@@ -267,7 +75,7 @@ export default function OnboardingFlowPage() {
                 <Button onClick={resetFlow} variant="outline" className="flex-1">
                   Start Over
                 </Button>
-                <Button onClick={() => window.location.href = '/'} className="flex-1">
+                <Button onClick={() => (window.location.href = '/')} className="flex-1">
                   Continue to App
                 </Button>
               </div>
@@ -275,13 +83,12 @@ export default function OnboardingFlowPage() {
           </Card>
         </div>
       </DevModeGuard>
-    );
+    )
   }
 
   return (
     <DevModeGuard>
       <div className="min-h-screen bg-gradient-to-b from-background to-muted/50 p-4">
-        {/* Header */}
         <div className="max-w-2xl mx-auto mb-6">
           <Alert>
             <AlertTriangle className="h-4 w-4" />
@@ -291,94 +98,39 @@ export default function OnboardingFlowPage() {
           </Alert>
         </div>
 
-        {/* Progress */}
         <div className="max-w-2xl mx-auto mb-8">
           <div className="flex items-center justify-between text-sm text-muted-foreground mb-2">
-            <span>Stage {currentStage} of 3</span>
+            <span>Stage {currentStage} of {totalStages}</span>
             <span>{Math.round(progress)}% Complete</span>
           </div>
           <Progress value={progress} className="h-2" />
           <div className="flex justify-center space-x-2 mt-3">
-            <div className={`w-3 h-3 rounded-full ${currentStage >= 1 ? 'bg-primary' : 'bg-muted'}`} />
-            <div className={`w-3 h-3 rounded-full ${currentStage >= 2 ? 'bg-primary' : 'bg-muted'}`} />
-            <div className={`w-3 h-3 rounded-full ${currentStage >= 3 ? 'bg-primary' : 'bg-muted'}`} />
+            {Array.from({ length: totalStages }).map((_, index) => (
+              <div
+                key={index}
+                className={`w-3 h-3 rounded-full ${currentStage >= index + 1 ? 'bg-primary' : 'bg-muted'}`}
+              />
+            ))}
           </div>
         </div>
 
-        {/* Question Card */}
         <div className="max-w-2xl mx-auto">
           <Card>
             <CardHeader>
               <CardTitle className="text-xl">
-                Question {currentQuestionIndex + 1} of {totalQuestions}
+                Question {totalQuestions > 0 ? currentQuestionIndex + 1 : 0} of {totalQuestions}
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-6">
               {currentQuestion ? (
                 <>
                   <div>
-                    <h2 className="text-lg font-medium mb-2">
-                      {currentQuestion.prompt}
-                    </h2>
+                    <h2 className="text-lg font-medium mb-2">{currentQuestion.prompt}</h2>
                     {currentQuestion.helper && (
-                      <p className="text-sm text-muted-foreground">
-                        {currentQuestion.helper}
-                      </p>
+                      <p className="text-sm text-muted-foreground">{currentQuestion.helper}</p>
                     )}
                   </div>
-
-                  {/* Single Choice Questions */}
-                  {currentQuestion.type === 'single_choice' && (
-<RadioGroup
-                      onValueChange={handleSingleChoice}
-                      value={((): string => {
-                        const sel = answers[currentQuestion.id];
-                        return sel && sel.type === 'single_choice' ? sel.value : ''
-                      })()}
-                    >
-                      <div className="space-y-3">
-                        {currentQuestion.options.map((option) => (
-                          <div key={option.value} className="flex items-start space-x-3 p-3 border rounded-lg hover:bg-muted/50 cursor-pointer">
-                            <RadioGroupItem value={option.value} id={option.value} />
-                            <Label htmlFor={option.value} className="cursor-pointer flex-1 leading-relaxed">
-                              {option.label}
-                            </Label>
-                          </div>
-                        ))}
-                      </div>
-                    </RadioGroup>
-                  )}
-
-                  {/* Free Text Questions */}
-                  {currentQuestion.type === 'free_text' && (
-                    <div className="space-y-4">
-                      <Textarea
-                        placeholder="Take your time to reflect and share your thoughts..."
-                        className="min-h-40 text-base leading-relaxed"
-defaultValue={((): string => {
-                          const sel = answers[currentQuestion.id];
-                          return sel && sel.type === 'free_text' ? sel.text : ''
-                        })()}
-                        id={`textarea-${currentQuestion.id}`}
-                      />
-                      <div className="flex justify-between items-center">
-                        <p className="text-xs text-muted-foreground">
-                          Take as much time as you need. There are no right or wrong answers.
-                        </p>
-                        <Button
-                          onClick={() => {
-                            const textarea = document.getElementById(`textarea-${currentQuestion.id}`) as HTMLTextAreaElement;
-                            if (textarea?.value.trim()) {
-                              handleTextResponse(textarea.value);
-                            }
-                          }}
-                          className="ml-4"
-                        >
-                          Continue
-                        </Button>
-                      </div>
-                    </div>
-                  )}
+                  {questionContent}
                 </>
               ) : (
                 <div className="text-center py-8">
@@ -389,7 +141,6 @@ defaultValue={((): string => {
           </Card>
         </div>
 
-        {/* Dev Controls */}
         <div className="max-w-2xl mx-auto mt-8">
           <Card>
             <CardHeader>
@@ -408,12 +159,12 @@ defaultValue={((): string => {
                 </Button>
               </div>
               <div className="text-xs text-muted-foreground">
-                Current answers: {Object.keys(answers).length} collected
+                Current answers: {answersCount} collected
               </div>
             </CardContent>
           </Card>
         </div>
       </div>
     </DevModeGuard>
-  );
+  )
 }

--- a/components/ethereal/ChatMessage.tsx
+++ b/components/ethereal/ChatMessage.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { useMemo, type CSSProperties } from "react"
+import { motion } from "framer-motion"
+
+import { TaskList } from "@/components/chat/TaskList"
+import { StreamingText } from "./StreamingText"
+import type { Message as ChatMessageType, TaskEvent } from "@/types/chat"
+
+interface ChatMessageProps {
+  message: ChatMessageType
+  isActive: boolean
+  tasks?: TaskEvent[]
+  taskListStyles: CSSProperties
+}
+
+export function ChatMessage({ message, isActive, tasks, taskListStyles }: ChatMessageProps) {
+  const isAssistant = message.role === "assistant"
+
+  const userOpacity = useMemo(() => {
+    if (typeof window === "undefined") return 0.8
+    const value = Number(
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--eth-user-opacity")
+        .trim() || 0
+    )
+    return value || 0.8
+  }, [])
+
+  const textStyles: CSSProperties = {
+    letterSpacing: isAssistant
+      ? "var(--eth-letter-spacing-assistant)"
+      : "var(--eth-letter-spacing-user)",
+    color: isAssistant
+      ? isActive
+        ? "rgba(255,255,255,1)"
+        : "rgba(255,255,255,var(--eth-assistant-opacity))"
+      : "rgba(255,255,255,var(--eth-assistant-opacity))",
+    ...(isAssistant ? {} : { opacity: userOpacity }),
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: "easeOut" }}
+      className={`flex ${isAssistant ? "justify-start" : "justify-end"}`}
+    >
+      <div
+        className={[
+          "max-w-[84%] whitespace-pre-wrap leading-7",
+          isAssistant
+            ? "text-3xl sm:text-4xl leading-snug lowercase font-thin italic drop-shadow-[0_1px_1px_rgba(0,0,0,0.7)]"
+            : "text-[15px] sm:text-[16px] font-thin lowercase drop-shadow-[0_1px_1px_rgba(0,0,0,0.6)]",
+        ].join(" ")}
+        style={textStyles}
+      >
+        {message.id === "ethereal-welcome" && (
+          <p className="mb-2 text-sm text-white/60">dive back in.</p>
+        )}
+        {isAssistant && (
+          <div className="mb-2 text-base" style={taskListStyles}>
+            <TaskList tasks={tasks} />
+          </div>
+        )}
+        <StreamingText text={message.content} />
+      </div>
+    </motion.div>
+  )
+}
+

--- a/components/ethereal/EtherealChat.tsx
+++ b/components/ethereal/EtherealChat.tsx
@@ -2,14 +2,15 @@
 
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react"
 import { motion } from "framer-motion"
+import { useRouter } from "next/navigation"
+
 import { useChat } from "@/hooks/useChat"
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog"
-import type { Message as ChatMessage } from "@/types/chat"
-import { useRouter } from "next/navigation"
-import { StreamingText } from "./StreamingText"
-import { TaskList } from "@/components/chat/TaskList"
+import type { Message as ChatMessageType } from "@/types/chat"
+
+import { ChatMessage } from "./ChatMessage"
 import { ActiveTaskOverlay } from "./ActiveTaskOverlay"
 
 // Minimal, bubble-less chat presentation
@@ -123,42 +124,14 @@ export function EtherealChat() {
       {/* Messages area */}
       <div className="relative z-10 flex-1 overflow-y-auto px-4 pb-[120px] pt-[calc(env(safe-area-inset-top)+16px)]">
         <div className="mx-auto flex max-w-[820px] flex-col gap-6">
-          {(messages as ChatMessage[]).map((m) => (
-            <motion.div
-              key={m.id}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.4, ease: "easeOut" }}
-              className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}
-            >
-              <div
-                className={[
-                  "max-w-[84%] whitespace-pre-wrap leading-7",
-                  m.role === "assistant"
-                    ? "text-3xl sm:text-4xl leading-snug lowercase font-thin italic drop-shadow-[0_1px_1px_rgba(0,0,0,0.7)]"
-                    : "text-[15px] sm:text-[16px] font-thin lowercase drop-shadow-[0_1px_1px_rgba(0,0,0,0.6)]",
-                ].join(" ")}
-                style={{
-                  letterSpacing: m.role === 'assistant' ? 'var(--eth-letter-spacing-assistant)' : 'var(--eth-letter-spacing-user)',
-                  color: m.role === 'assistant'
-                    ? (m.id === currentStreamingId
-                      ? 'rgba(255,255,255,1)'
-                      : 'rgba(255,255,255,var(--eth-assistant-opacity))')
-                    : 'rgba(255,255,255,var(--eth-assistant-opacity))',
-                  opacity: m.role === 'assistant' ? undefined : (Number(getComputedStyle(document.documentElement).getPropertyValue('--eth-user-opacity').trim()) || 0.8),
-                }}
-              >
-                {m.id === "ethereal-welcome" && (
-                  <p className="mb-2 text-sm text-white/60">dive back in.</p>
-                )}
-                {m.role === 'assistant' && (
-                  <div className="mb-2 text-base" style={taskListStyles}>
-                    <TaskList tasks={tasksByMessage?.[m.id]} />
-                  </div>
-                )}
-                <StreamingText text={m.content} />
-              </div>
-            </motion.div>
+          {(messages as ChatMessageType[]).map((message) => (
+            <ChatMessage
+              key={message.id}
+              message={message}
+              isActive={message.id === currentStreamingId}
+              tasks={tasksByMessage?.[message.id]}
+              taskListStyles={taskListStyles}
+            />
           ))}
           <div ref={messagesEndRef} />
         </div>

--- a/hooks/useDevOnboardingFlow.tsx
+++ b/hooks/useDevOnboardingFlow.tsx
@@ -1,0 +1,368 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
+
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import type { OnboardingQuestion, QuestionResponse } from "@/lib/onboarding/types"
+import { ANSWER_PRESETS, DEV_STAGE_2_QUESTION_BANK } from "@/lib/dev/fixtures"
+
+const STAGE_1_QUESTIONS: OnboardingQuestion[] = [
+  {
+    id: "S1_Q1",
+    stage: 1,
+    type: "single_choice",
+    prompt: "When you share your work publicly, what typically comes up for you first?",
+    helper: "Think about the immediate feelings or thoughts that arise",
+    options: [
+      { value: "surge_energy", label: "A surge of energy and excitement about reaching people" },
+      { value: "methodical_checking", label: "Methodical checking and rechecking before posting" },
+      { value: "wondering_reception", label: "Wondering how it will be received by others" },
+      { value: "noticing_improvement", label: "Noticing everything that could be improved" },
+    ],
+    active: true,
+    locale: "en",
+    order_hint: 1,
+    theme_weights: {},
+  },
+  {
+    id: "S1_Q2",
+    stage: 1,
+    type: "single_choice",
+    prompt: "When your plans get disrupted unexpectedly, what happens inside you?",
+    helper: "Consider your inner response to sudden changes",
+    options: [
+      { value: "energized_possibilities", label: "I feel energized by new possibilities opening up" },
+      { value: "protect_secure", label: "I need to protect what feels secure and familiar" },
+      { value: "check_affected", label: "I check on others who might be affected by the change" },
+      { value: "analyze_wrong", label: "I analyze what went wrong and how to prevent it next time" },
+    ],
+    active: true,
+    locale: "en",
+    order_hint: 2,
+    theme_weights: {},
+  },
+  {
+    id: "S1_Q3",
+    stage: 1,
+    type: "single_choice",
+    prompt: "When someone you care about seems upset with you, what do you find yourself doing?",
+    helper: "Think about your automatic response pattern",
+    options: [
+      { value: "give_space", label: "Give them space and wait for them to come to me" },
+      { value: "directly_ask", label: "Ask directly what's wrong and how to fix it" },
+      { value: "review_actions", label: "Review all my recent actions to see what I might have done" },
+      { value: "focus_elsewhere", label: "Focus my attention elsewhere until things settle" },
+    ],
+    active: true,
+    locale: "en",
+    order_hint: 3,
+    theme_weights: {},
+  },
+]
+
+const STAGE_2_QUESTIONS = DEV_STAGE_2_QUESTION_BANK.slice(0, 4)
+
+const STAGE_3_QUESTIONS: OnboardingQuestion[] = [
+  {
+    id: "S3_Q1",
+    stage: 3,
+    type: "free_text",
+    prompt:
+      "When you think about the parts of yourself that get activated under stress, what do you notice they are trying to protect you from?",
+    helper: "Take a moment to reflect on what your protective parts are guarding against",
+    options: [],
+    active: true,
+    locale: "en",
+    order_hint: 1,
+    theme_weights: {},
+  },
+  {
+    id: "S3_Q2",
+    stage: 3,
+    type: "free_text",
+    prompt: "What beliefs do you carry about yourself that might have formed during difficult times in your life?",
+    helper: "These might be thoughts like \"I'm not good enough\" or \"I have to be perfect\"",
+    options: [],
+    active: true,
+    locale: "en",
+    order_hint: 2,
+    theme_weights: {},
+  },
+  {
+    id: "S3_Q3",
+    stage: 3,
+    type: "free_text",
+    prompt: "Where in your body do you tend to feel stress, tension, or difficult emotions?",
+    helper: "This could be your shoulders, stomach, chest, or anywhere else you notice sensations",
+    options: [],
+    active: true,
+    locale: "en",
+    order_hint: 3,
+    theme_weights: {},
+  },
+  {
+    id: "S3_Q4",
+    stage: 3,
+    type: "free_text",
+    prompt: "If you could offer a compassionate message to the parts of yourself that struggle, what would you say?",
+    helper: "Imagine speaking to these parts like you would to a good friend who is going through a hard time",
+    options: [],
+    active: true,
+    locale: "en",
+    order_hint: 4,
+    theme_weights: {},
+  },
+]
+
+const TOTAL_QUESTION_COUNT =
+  STAGE_1_QUESTIONS.length + STAGE_2_QUESTIONS.length + STAGE_3_QUESTIONS.length
+
+interface StageConfig {
+  questions: OnboardingQuestion[]
+  renderQuestion: (question: OnboardingQuestion) => ReactNode
+}
+
+type RecordAnswerFn = (
+  question: OnboardingQuestion,
+  response: QuestionResponse,
+  questionCount: number
+) => void
+
+export function useDevOnboardingFlow() {
+  const [currentStage, setCurrentStage] = useState(1)
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0)
+  const [answers, setAnswers] = useState<Record<string, QuestionResponse>>({})
+  const [isComplete, setIsComplete] = useState(false)
+
+  const recordAnswer = useCallback<RecordAnswerFn>(
+    (question, response, questionCount) => {
+      setAnswers((prev) => ({ ...prev, [question.id]: response }))
+
+      setTimeout(() => {
+        setCurrentQuestionIndex((prevIndex) => {
+          if (prevIndex < questionCount - 1) {
+            return prevIndex + 1
+          }
+
+          if (currentStage === 1) {
+            setCurrentStage(2)
+            return 0
+          }
+
+          if (currentStage === 2) {
+            setCurrentStage(3)
+            return 0
+          }
+
+          setIsComplete(true)
+          return prevIndex
+        })
+      }, 500)
+    },
+    [currentStage]
+  )
+
+  const stageOne = useSingleChoiceStage(STAGE_1_QUESTIONS, answers, recordAnswer)
+  const stageTwo = useSingleChoiceStage(STAGE_2_QUESTIONS, answers, recordAnswer)
+  const stageThree = useFreeTextStage(STAGE_3_QUESTIONS, answers, recordAnswer)
+
+  const stageConfig = useMemo(
+    () => ({
+      1: stageOne,
+      2: stageTwo,
+      3: stageThree,
+    }),
+    [stageOne, stageTwo, stageThree]
+  )
+
+  const stage = stageConfig[currentStage as keyof typeof stageConfig]
+  const currentQuestion = stage?.questions[currentQuestionIndex]
+  const totalQuestions = stage?.questions.length ?? 0
+  const questionContent = currentQuestion ? stage.renderQuestion(currentQuestion) : null
+
+  const answeredCount = Object.keys(answers).length
+  const progress = isComplete ? 100 : Math.min((answeredCount / TOTAL_QUESTION_COUNT) * 100, 100)
+
+  const resetFlow = useCallback(() => {
+    setAnswers({})
+    setCurrentStage(1)
+    setCurrentQuestionIndex(0)
+    setIsComplete(false)
+  }, [])
+
+  const loadPreset = useCallback((presetKey: string) => {
+    const preset = ANSWER_PRESETS[presetKey as keyof typeof ANSWER_PRESETS]
+    if (!preset) return
+
+    setAnswers(preset.answers)
+    setCurrentStage(2)
+    setCurrentQuestionIndex(0)
+    setIsComplete(false)
+  }, [])
+
+  useEffect(() => {
+    if (!isComplete || totalQuestions === 0) return
+    setCurrentQuestionIndex((index) => Math.max(0, Math.min(index, totalQuestions - 1)))
+  }, [isComplete, totalQuestions])
+
+  return {
+    currentStage,
+    currentQuestionIndex,
+    currentQuestion,
+    totalQuestions,
+    questionContent,
+    answers,
+    isComplete,
+    progress,
+    totalStages: 3,
+    actions: {
+      resetFlow,
+      loadPreset,
+    },
+  }
+}
+
+function useSingleChoiceStage(
+  questions: OnboardingQuestion[],
+  answers: Record<string, QuestionResponse>,
+  recordAnswer: RecordAnswerFn
+): StageConfig {
+  const handleSelect = useCallback(
+    (question: OnboardingQuestion, value: string) => {
+      recordAnswer(question, { type: "single_choice", value }, questions.length)
+    },
+    [questions.length, recordAnswer]
+  )
+
+  const renderQuestion = useCallback<StageConfig["renderQuestion"]>(
+    (question) => (
+      <SingleChoiceQuestion
+        key={question.id}
+        question={question}
+        selectedValue={getSelectedValue(answers, question.id)}
+        onSelect={(value) => handleSelect(question, value)}
+      />
+    ),
+    [answers, handleSelect]
+  )
+
+  return useMemo(
+    () => ({
+      questions,
+      renderQuestion,
+    }),
+    [questions, renderQuestion]
+  )
+}
+
+function useFreeTextStage(
+  questions: OnboardingQuestion[],
+  answers: Record<string, QuestionResponse>,
+  recordAnswer: RecordAnswerFn
+): StageConfig {
+  const handleSubmit = useCallback(
+    (question: OnboardingQuestion, text: string) => {
+      recordAnswer(question, { type: "free_text", text: text.trim() }, questions.length)
+    },
+    [questions.length, recordAnswer]
+  )
+
+  const renderQuestion = useCallback<StageConfig["renderQuestion"]>(
+    (question) => (
+      <FreeTextQuestion
+        key={question.id}
+        question={question}
+        existingValue={getFreeTextValue(answers, question.id)}
+        onSubmit={(text) => handleSubmit(question, text)}
+      />
+    ),
+    [answers, handleSubmit]
+  )
+
+  return useMemo(
+    () => ({
+      questions,
+      renderQuestion,
+    }),
+    [questions, renderQuestion]
+  )
+}
+
+interface SingleChoiceQuestionProps {
+  question: OnboardingQuestion
+  selectedValue: string
+  onSelect: (value: string) => void
+}
+
+function SingleChoiceQuestion({ question, selectedValue, onSelect }: SingleChoiceQuestionProps) {
+  return (
+    <RadioGroup value={selectedValue} onValueChange={onSelect}>
+      <div className="space-y-3">
+        {question.options.map((option) => (
+          <div
+            key={option.value}
+            className="flex items-start space-x-3 p-3 border rounded-lg hover:bg-muted/50 cursor-pointer"
+          >
+            <RadioGroupItem value={option.value} id={`${question.id}-${option.value}`} />
+            <Label htmlFor={`${question.id}-${option.value}`} className="cursor-pointer flex-1 leading-relaxed">
+              {option.label}
+            </Label>
+          </div>
+        ))}
+      </div>
+    </RadioGroup>
+  )
+}
+
+interface FreeTextQuestionProps {
+  question: OnboardingQuestion
+  existingValue: string
+  onSubmit: (text: string) => void
+}
+
+function FreeTextQuestion({ question, existingValue, onSubmit }: FreeTextQuestionProps) {
+  const [value, setValue] = useState(existingValue)
+
+  useEffect(() => {
+    setValue(existingValue)
+  }, [existingValue])
+
+  return (
+    <div className="space-y-4">
+      <Textarea
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        placeholder="Take your time to reflect and share your thoughts..."
+        className="min-h-40 text-base leading-relaxed"
+      />
+      <div className="flex justify-between items-center">
+        <p className="text-xs text-muted-foreground">
+          Take as much time as you need. There are no right or wrong answers.
+        </p>
+        <Button
+          onClick={() => {
+            if (!value.trim()) return
+            onSubmit(value)
+          }}
+          className="ml-4"
+        >
+          Continue
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function getSelectedValue(answers: Record<string, QuestionResponse>, questionId: string) {
+  const entry = answers[questionId]
+  return entry && entry.type === "single_choice" ? entry.value : ""
+}
+
+function getFreeTextValue(answers: Record<string, QuestionResponse>, questionId: string) {
+  const entry = answers[questionId]
+  return entry && entry.type === "free_text" ? entry.text : ""
+}
+

--- a/hooks/useStreamingBuffer.ts
+++ b/hooks/useStreamingBuffer.ts
@@ -1,0 +1,81 @@
+"use client"
+
+import { useEffect, useMemo, useRef } from "react"
+
+interface StreamingChar {
+  char: string
+  isNew: boolean
+}
+
+export interface StreamingToken {
+  value: string
+  isWhitespace: boolean
+  isNewWord: boolean
+  chars: StreamingChar[]
+}
+
+/**
+ * Tracks the streaming state of a chat message. Given the full text content,
+ * the hook returns tokens annotated with whether each word/character is new
+ * compared to the previous render. This allows presentation components to
+ * animate only the incremental pieces of the response.
+ */
+export function useStreamingBuffer(text: string) {
+  const prevCharLen = useRef(0)
+  const prevWordCount = useRef(0)
+
+  const tokens = useMemo<StreamingToken[]>(() => {
+    const rawTokens = (text ?? "").split(/(\s+)/)
+
+    let wordIndex = 0
+    let charSeen = 0
+
+    return rawTokens.map((value) => {
+      const isWhitespace = /^\s+$/.test(value)
+
+      if (isWhitespace) {
+        charSeen += value.length
+        return {
+          value,
+          isWhitespace,
+          isNewWord: false,
+          chars: Array.from(value).map((char) => ({ char, isNew: false })),
+        }
+      }
+
+      const isNewWord = wordIndex >= prevWordCount.current
+      const startCharIndex = charSeen
+      const chars = Array.from(value).map((char, charIndex) => {
+        const globalIndex = startCharIndex + charIndex
+        return {
+          char,
+          isNew: globalIndex >= prevCharLen.current,
+        }
+      })
+
+      wordIndex += 1
+      charSeen += value.length
+
+      return {
+        value,
+        isWhitespace,
+        isNewWord,
+        chars,
+      }
+    })
+  }, [text])
+
+  const wordsOnlyCount = useMemo(
+    () => tokens.filter((token) => !token.isWhitespace).length,
+    [tokens]
+  )
+
+  useEffect(() => {
+    const nextLength = (text ?? "").length
+    prevCharLen.current = Math.max(prevCharLen.current, nextLength)
+    prevWordCount.current = Math.max(prevWordCount.current, wordsOnlyCount)
+  }, [text, wordsOnlyCount])
+
+  return tokens
+}
+


### PR DESCRIPTION
## Summary
- refactor EtherealChat to delegate message rendering to a new ChatMessage component and drive animations via a useStreamingBuffer hook
- update StreamingText to consume the streaming buffer metadata and keep EtherealChat focused on layout/orchestration
- add a dedicated useDevOnboardingFlow hook and simplify the dev onboarding flow page to defer stage logic and input rendering to the hook

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: repository already reports numerous HTTP status typing errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d74b0b9c83238da697c5e9ee0df1