### PR TITLE
Use JWT-scoped Supabase clients for chat sessions

### DIFF
--- a/app/api/session/end/route.ts
+++ b/app/api/session/end/route.ts
@@ -16,8 +16,12 @@ export async function POST(req: NextRequest) {
       }
 
       if (ctx.type === 'authed') {
-        const { chatSessionService } = await import('@/lib/session-service')
-        await chatSessionService.endSession(sessionId)
+        const { createChatSessionService } = await import('@/lib/session-service')
+        const sessionService = createChatSessionService({
+          accessToken: ctx.accessToken,
+          userId: ctx.userId,
+        })
+        await sessionService.endSession(sessionId)
         return jsonResponse({ ok: true, ended: true })
       }
 

--- a/app/api/session/message/route.ts
+++ b/app/api/session/message/route.ts
@@ -16,8 +16,12 @@ export async function POST(req: NextRequest) {
       }
 
       if (ctx.type === 'authed') {
-        const { chatSessionService } = await import('@/lib/session-service')
-        await chatSessionService.addMessage(sessionId, { role, content })
+        const { createChatSessionService } = await import('@/lib/session-service')
+        const sessionService = createChatSessionService({
+          accessToken: ctx.accessToken,
+          userId: ctx.userId,
+        })
+        await sessionService.addMessage(sessionId, { role, content })
         return jsonResponse({ ok: true, stored: true })
       }
 

--- a/app/api/session/start/route.ts
+++ b/app/api/session/start/route.ts
@@ -15,8 +15,12 @@ export async function POST(req: NextRequest) {
       }
 
       if (ctx.type === 'authed') {
-        const { chatSessionService } = await import('../../../../lib/session-service')
-        const sessionId = await chatSessionService.startSession(ctx.userId)
+        const { createChatSessionService } = await import('../../../../lib/session-service')
+        const sessionService = createChatSessionService({
+          accessToken: ctx.accessToken,
+          userId: ctx.userId,
+        })
+        const sessionId = await sessionService.startSession()
         return jsonResponse({ sessionId })
       }
 

--- a/lib/database/action-logger.ts
+++ b/lib/database/action-logger.ts
@@ -1,3 +1,5 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '../types/database'
 import { createClient } from '../supabase/client'
 import { logEvent } from '@/lib/memory/events-logger'
 
@@ -62,7 +64,11 @@ export interface ActionSummary {
 }
 
 export class DatabaseActionLogger {
-  private supabase = createClient()
+  private supabase: SupabaseClient<Database>
+
+  constructor(supabase?: SupabaseClient<Database>) {
+    this.supabase = supabase ?? (createClient() as SupabaseClient<Database>)
+  }
 
   /**
    * Log and execute an INSERT operation with rollback capability

--- a/lib/session-service.ts
+++ b/lib/session-service.ts
@@ -1,17 +1,46 @@
-import { createClient } from './supabase/client'
-import { actionLogger } from './database/action-logger'
-import type { SessionMessage, SessionRow, SessionInsert, SessionUpdate } from './types/database'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { createClientWithAccessToken } from './supabase/server'
+import { DatabaseActionLogger } from './database/action-logger'
+import type {
+  Database,
+  SessionInsert,
+  SessionMessage,
+  SessionRow,
+  SessionUpdate,
+} from './types/database'
 import { getStorageAdapter, sessionTranscriptPath } from './memory/snapshots/fs-helpers'
 
+export interface ChatSessionServiceOptions {
+  accessToken?: string
+  supabase?: SupabaseClient<Database>
+  userId: string
+}
+
 export class ChatSessionService {
-  private supabase = createClient()
+  private readonly supabase: SupabaseClient<Database>
+  private readonly actionLogger: DatabaseActionLogger
+  private readonly userId: string
+
+  constructor(options: ChatSessionServiceOptions) {
+    this.userId = options.userId
+
+    if (options.supabase) {
+      this.supabase = options.supabase
+    } else if (options.accessToken) {
+      this.supabase = createClientWithAccessToken(options.accessToken)
+    } else {
+      throw new Error('Supabase client or access token is required to use ChatSessionService')
+    }
+
+    this.actionLogger = new DatabaseActionLogger(this.supabase)
+  }
 
   /**
-   * Start a new chat session
+   * Start a new chat session for the current user
    */
-  async startSession(userId: string): Promise<string> {
+  async startSession(): Promise<string> {
     const session: SessionInsert = {
-      user_id: userId,
+      user_id: this.userId,
       start_time: new Date().toISOString(),
       messages: [],
       parts_involved: {},
@@ -20,34 +49,34 @@ export class ChatSessionService {
       emotional_arc: {
         start: { valence: 0, arousal: 0 },
         peak: { valence: 0, arousal: 0 },
-        end: { valence: 0, arousal: 0 }
+        end: { valence: 0, arousal: 0 },
       },
-      processed: false
+      processed: false,
     }
 
-    // Use action logger for session creation
-    const data = await actionLogger.loggedInsert<{ id: string }>(
+    const data = await this.actionLogger.loggedInsert<{ id: string }>(
       'sessions',
       session,
-      userId,
+      this.userId,
       'create_session',
       {
         changeDescription: 'Started new chat session',
-        sessionId: undefined // Will be set after creation
-      }
+        sessionId: undefined,
+      },
     )
+
     const storage = await getStorageAdapter()
-    const transcriptPath = sessionTranscriptPath(userId, data.id)
+    const transcriptPath = sessionTranscriptPath(this.userId, data.id)
     const transcript = {
       id: data.id,
-      user_id: userId,
+      user_id: this.userId,
       start_time: session.start_time,
       end_time: null as string | null,
       duration: null as number | null,
-      messages: [] as SessionMessage[]
+      messages: [] as SessionMessage[],
     }
     await storage.putText(transcriptPath, JSON.stringify(transcript), {
-      contentType: 'application/json'
+      contentType: 'application/json',
     })
 
     return data.id
@@ -58,9 +87,8 @@ export class ChatSessionService {
    */
   async addMessage(
     sessionId: string,
-    message: Omit<SessionMessage, 'timestamp'>
+    message: Omit<SessionMessage, 'timestamp'>,
   ): Promise<void> {
-    // First get the current session
     const { data: session, error: fetchError } = await this.supabase
       .from('sessions')
       .select('messages, user_id, start_time, end_time, duration')
@@ -71,20 +99,17 @@ export class ChatSessionService {
       throw new Error(`Failed to fetch session: ${fetchError.message}`)
     }
 
-    // Add the new message with timestamp
     const newMessage: SessionMessage = {
       ...message,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     }
-
     const updatedMessages = [...(session.messages || []), newMessage]
 
-    // Update the session with new messages
     const { error: updateError } = await this.supabase
       .from('sessions')
-      .update({ 
+      .update({
         messages: updatedMessages,
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       })
       .eq('id', sessionId)
 
@@ -93,31 +118,35 @@ export class ChatSessionService {
     }
 
     const storage = await getStorageAdapter()
-    const transcriptPath = sessionTranscriptPath(session.user_id, sessionId)
+    const transcriptUserId = session.user_id || this.userId
+    const transcriptPath = sessionTranscriptPath(transcriptUserId, sessionId)
     let transcript
     try {
       const existing = await storage.getText(transcriptPath)
-      transcript = existing ? JSON.parse(existing) : {
-        id: sessionId,
-        user_id: session.user_id,
-        start_time: session.start_time,
-        end_time: session.end_time,
-        duration: session.duration,
-        messages: [] as SessionMessage[]
-      }
+      transcript = existing
+        ? JSON.parse(existing)
+        : {
+            id: sessionId,
+            user_id: transcriptUserId,
+            start_time: session.start_time,
+            end_time: session.end_time,
+            duration: session.duration,
+            messages: [] as SessionMessage[],
+          }
     } catch {
       transcript = {
         id: sessionId,
-        user_id: session.user_id,
+        user_id: transcriptUserId,
         start_time: session.start_time,
         end_time: session.end_time,
         duration: session.duration,
-        messages: [] as SessionMessage[]
+        messages: [] as SessionMessage[],
       }
     }
+
     transcript.messages = updatedMessages
     await storage.putText(transcriptPath, JSON.stringify(transcript), {
-      contentType: 'application/json'
+      contentType: 'application/json',
     })
   }
 
@@ -126,8 +155,7 @@ export class ChatSessionService {
    */
   async endSession(sessionId: string): Promise<void> {
     const endTime = new Date().toISOString()
-    
-    // Get session start time to calculate duration
+
     const { data: session, error: fetchError } = await this.supabase
       .from('sessions')
       .select('start_time, user_id, end_time, duration, messages')
@@ -145,8 +173,8 @@ export class ChatSessionService {
       .from('sessions')
       .update({
         end_time: endTime,
-        duration: duration,
-        updated_at: endTime
+        duration,
+        updated_at: endTime,
       })
       .eq('id', sessionId)
 
@@ -155,32 +183,36 @@ export class ChatSessionService {
     }
 
     const storage = await getStorageAdapter()
-    const transcriptPath = sessionTranscriptPath(session.user_id, sessionId)
+    const transcriptUserId = session.user_id || this.userId
+    const transcriptPath = sessionTranscriptPath(transcriptUserId, sessionId)
     let transcript
     try {
       const existing = await storage.getText(transcriptPath)
-      transcript = existing ? JSON.parse(existing) : {
-        id: sessionId,
-        user_id: session.user_id,
-        start_time: session.start_time,
-        end_time: null as string | null,
-        duration: null as number | null,
-        messages: session.messages || []
-      }
+      transcript = existing
+        ? JSON.parse(existing)
+        : {
+            id: sessionId,
+            user_id: transcriptUserId,
+            start_time: session.start_time,
+            end_time: null as string | null,
+            duration: null as number | null,
+            messages: session.messages || [],
+          }
     } catch {
       transcript = {
         id: sessionId,
-        user_id: session.user_id,
+        user_id: transcriptUserId,
         start_time: session.start_time,
         end_time: null as string | null,
         duration: null as number | null,
-        messages: session.messages || []
+        messages: session.messages || [],
       }
     }
+
     transcript.end_time = endTime
     transcript.duration = duration
     await storage.putText(transcriptPath, JSON.stringify(transcript), {
-      contentType: 'application/json'
+      contentType: 'application/json',
     })
   }
 
@@ -195,8 +227,8 @@ export class ChatSessionService {
       .single()
 
     if (error) {
-      if (error.code === 'PGRST116') {
-        return null // Session not found
+      if ((error as { code?: string }).code === 'PGRST116') {
+        return null
       }
       throw new Error(`Failed to get session: ${error.message}`)
     }
@@ -205,13 +237,13 @@ export class ChatSessionService {
   }
 
   /**
-   * Get recent sessions for a user
+   * Get recent sessions for the current user
    */
-  async getUserSessions(userId: string, limit: number = 10): Promise<SessionRow[]> {
+  async getUserSessions(limit: number = 10): Promise<SessionRow[]> {
     const { data, error } = await this.supabase
       .from('sessions')
       .select('*')
-      .eq('user_id', userId)
+      .eq('user_id', this.userId)
       .order('start_time', { ascending: false })
       .limit(limit)
 
@@ -233,8 +265,8 @@ export class ChatSessionService {
       .single()
 
     if (error) {
-      if (error.code === 'PGRST116') {
-        return [] // Session not found
+      if ((error as { code?: string }).code === 'PGRST116') {
+        return []
       }
       throw new Error(`Failed to get session messages: ${error.message}`)
     }
@@ -250,7 +282,7 @@ export class ChatSessionService {
       .from('sessions')
       .update({
         ...updates,
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       })
       .eq('id', sessionId)
 
@@ -260,5 +292,6 @@ export class ChatSessionService {
   }
 }
 
-// Export singleton instance
-export const chatSessionService = new ChatSessionService()
+export function createChatSessionService(options: ChatSessionServiceOptions): ChatSessionService {
+  return new ChatSessionService(options)
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,6 +1,8 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 import { getSupabaseKey, getSupabaseUrl } from './config'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '../types/database'
 
 let serverClientOverride: unknown | null = null
 
@@ -45,4 +47,29 @@ export async function createClient() {
       },
     }
   )
+}
+
+export function createClientWithAccessToken(accessToken: string): SupabaseClient<Database> {
+  const url = getSupabaseUrl()
+  const key = getSupabaseKey()
+
+  if (!url || !key) {
+    throw new Error('Supabase URL and key must be configured to create a server client')
+  }
+
+  return createServerClient<Database>(url, key, {
+    cookies: {
+      getAll() {
+        return []
+      },
+      setAll() {
+        /* no-op: JWT auth handles session */
+      },
+    },
+    global: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  })
 }

--- a/supabase/migrations/018_sessions_auth_context.sql
+++ b/supabase/migrations/018_sessions_auth_context.sql
@@ -1,0 +1,27 @@
+-- Ensure sessions automatically scope to the authenticated user
+ALTER TABLE sessions
+  ALTER COLUMN user_id SET DEFAULT auth.uid();
+
+CREATE OR REPLACE FUNCTION set_session_user_id()
+RETURNS trigger AS $$
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'auth.uid() must be set to insert into sessions';
+  END IF;
+  NEW.user_id := auth.uid();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS set_session_user_id ON sessions;
+
+CREATE TRIGGER set_session_user_id
+BEFORE INSERT ON sessions
+FOR EACH ROW
+EXECUTE FUNCTION set_session_user_id();
+
+DROP POLICY IF EXISTS "Users can insert own sessions" ON sessions;
+
+CREATE POLICY "Authenticated users can insert sessions"
+  ON sessions FOR INSERT
+  WITH CHECK (auth.role() = 'authenticated');


### PR DESCRIPTION
## Summary
- create a helper for building Supabase server clients from a user's JWT and pass the token through the guard to per-request chat session services
- refactor chat session routes/services to instantiate user-scoped clients and loggers and ensure the chat session APIs operate with the authenticated context
- add a migration that sets session.user_id from auth.uid() and replaces the insert policy to rely on authenticated users

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8d76949808323b6b89b79dc0ba449