### PR TITLE
feat(nav): switch bottom nav to Today/Chat/Journey

### DIFF
--- a/components/nav/BottomTabs.tsx
+++ b/components/nav/BottomTabs.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Plus, CalendarDays, Lightbulb, Sprout, Map } from 'lucide-react'
+import { CalendarDays, MessageCircle, Map } from 'lucide-react'
 import { GuardedLink } from '@/components/common/GuardedLink'
 import * as React from 'react'
 
@@ -24,7 +24,7 @@ export function BottomTabs() {
       aria-label="Primary tabs"
     >
       <div className="mx-auto max-w-md">
-        <div className="grid grid-cols-4 text-center text-muted-foreground">
+        <div className="grid grid-cols-3 text-center text-muted-foreground">
           {/* Today */}
           <Link
             href="/"
@@ -39,41 +39,27 @@ export function BottomTabs() {
             <span>Today</span>
           </Link>
 
-          {/* Insights */}
-          <GuardedLink
-            href="/insights"
+          {/* Chat */}
+          <Link
+            href="/chat"
             className={
-              baseItem + ' ' + (isActive('/insights') ? 'text-foreground' : 'text-muted-foreground')
+              baseItem + ' ' + (isActive('/chat') ? 'text-foreground' : 'text-muted-foreground')
             }
-            aria-current={isActive('/insights') ? 'page' : undefined}
-            aria-label="Insights"
-            data-testid="nav-insights"
+            aria-current={isActive('/chat') ? 'page' : undefined}
+            aria-label="Chat"
+            data-testid="nav-chat"
           >
-            <Lightbulb className="w-5 h-5" />
-            <span>Insights</span>
-          </GuardedLink>
+            <MessageCircle className="w-5 h-5" />
+            <span>Chat</span>
+          </Link>
 
-          {/* Garden */}
+          {/* Journey */}
           <GuardedLink
             href="/garden"
             className={
               baseItem + ' ' + (isActive('/garden') ? 'text-foreground' : 'text-muted-foreground')
             }
             aria-current={isActive('/garden') ? 'page' : undefined}
-            aria-label="Garden"
-            data-testid="nav-garden"
-          >
-            <Sprout className="w-5 h-5" />
-            <span>Garden</span>
-          </GuardedLink>
-
-          {/* Journey */}
-          <GuardedLink
-            href="/journey"
-            className={
-              baseItem + ' ' + (isActive('/journey') ? 'text-foreground' : 'text-muted-foreground')
-            }
-            aria-current={isActive('/journey') ? 'page' : undefined}
             aria-label="Journey"
             data-testid="nav-journey"
           >
@@ -81,15 +67,6 @@ export function BottomTabs() {
             <span>Journey</span>
           </GuardedLink>
         </div>
-      </div>
-
-      {/* Floating + button */}
-      <div className="absolute inset-x-0 -top-6 flex justify-center pointer-events-none">
-        <Link href="/chat" aria-label="Start a new chat" className="pointer-events-auto">
-          <div className="size-14 rounded-full bg-primary text-primary-foreground shadow-xl grid place-items-center">
-            <Plus className="w-7 h-7" />
-          </div>
-        </Link>
       </div>
     </nav>
   )


### PR DESCRIPTION
## Summary
Replaces 4-tab layout + floating action button with streamlined 3-tab navigation.

## Changes Made
- **Today** tab (unchanged): Routes to  with CalendarDays icon
- **Chat** tab (new): Routes to  with MessageCircle icon, replaces floating + button
- **Journey** tab (updated): Routes to  (Parts Garden) with Map icon

## Removed
- **Insights** tab: Now accessible through Today Inbox
- **Garden** tab: Consolidated into Journey  
- **Floating + button**: Replaced by dedicated Chat tab

## Agent Context (Rich History)
### Why This Feature
User requested simplified navigation with Today/Chat/Journey tabs. Insights functionality moved to Today Inbox reduces cognitive overhead and improves flow.

### Technical Decisions & Rationale  
- Kept GuardedLink for Journey (garden access requires auth like before)
- Used regular Link for Chat (mirrors floating + button behavior)
- Preserved all visual styling: backdrop blur, spacing, theme variables
- Updated grid from grid-cols-4 to grid-cols-3
- Maintained accessibility with proper aria-labels and data-testids

### Code Architecture
- Clean icon imports (CalendarDays, MessageCircle, Map only)
- Preserved isActive logic and aria-current behavior
- No changes to ethereal theme integration or reduced-motion support
- Removed absolute positioned floating button container entirely

### Verification Completed
- ✅ No grid-cols-4 references remain  
- ✅ No nav-insights selectors remain
- ✅ No href="/journey" references in component
- ✅ No floating button container remains
- ✅ MessageCircle properly imported and used
- ✅ TypeScript passes (no new errors from navigation changes)
- ✅ No tests required updates (no navigation test references found)

### Future Considerations
- Journey routing to /garden provides seamless access to Parts Garden
- Chat tab placement (middle) provides balanced visual hierarchy
- Preserved GuardedLink pattern allows future auth requirements for Chat if needed