### PR TITLE
Configure Supabase Google auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 # Supabase (required for persistence)
 NEXT_PUBLIC_SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=your-google-oauth-client-id
+SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET=your-google-oauth-client-secret
+# Production: https://<PROJECT_REF>.supabase.co/auth/v1/callback
+# Local CLI:  http://127.0.0.1:54321/auth/v1/callback
+SUPABASE_AUTH_EXTERNAL_GOOGLE_REDIRECT_URI=https://YOUR_PROJECT_REF.supabase.co/auth/v1/callback
 
 # Google Authentication (required for native Google Sign-In)
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-client-id

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -45,6 +45,11 @@ In code, prefer using `isDevMode()` from `config/features` to check whether deve
 
 - `NEXT_PUBLIC_SUPABASE_URL` - Your Supabase project URL
 - `SUPABASE_SERVICE_ROLE_KEY` - Supabase service role key for Storage adapter
+- `SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID` - OAuth client ID configured in the Google Cloud Console for Supabase Auth
+- `SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET` - OAuth client secret paired with the above client ID
+- `SUPABASE_AUTH_EXTERNAL_GOOGLE_REDIRECT_URI` - Redirect URI registered with Google for Supabase (e.g. `https://<PROJECT_REF>.supabase.co/auth/v1/callback` in production or `http://127.0.0.1:54321/auth/v1/callback` when running the Supabase CLI locally)
+
+Ensure the redirect URIs listed above are also added to the allowed redirect list in your Supabase project (`[auth] site_url` and `additional_redirect_urls`) so the Google flow can complete successfully.
 
 ### Agent API Keys
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -273,6 +273,16 @@ url = ""
 # If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
 skip_nonce_check = false
 
+[auth.external.google]
+enabled = true
+client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_REDIRECT_URI)"
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth without nonce support.
+skip_nonce_check = false
+
 # Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
 # You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
 [auth.web3.solana]


### PR DESCRIPTION
## Summary
- enable the Supabase Google OAuth provider with environment-driven client credentials and redirect URI
- document the new Google auth environment variables and required redirect configuration for deployments
- expand the example env file with placeholders for the Google OAuth credentials and callback URL

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9dcf751088323ad30afec74e9c19e