### PR TITLE
Normalize Supabase configuration handling and fallbacks

### DIFF
--- a/app/api/chat/logic.ts
+++ b/app/api/chat/logic.ts
@@ -1,8 +1,9 @@
 import { createClient } from '@/lib/supabase/server'
+import { getSupabaseKey, getSupabaseUrl } from '@/lib/supabase/config'
 
 export async function getUserIdFromSupabase(): Promise<string | undefined> {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const supabaseAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  const supabaseUrl = getSupabaseUrl()
+  const supabaseAnon = getSupabaseKey()
   const hasSupabase =
     typeof supabaseUrl === 'string' && /^https?:\/\//.test(supabaseUrl) &&
     typeof supabaseAnon === 'string' && supabaseAnon.length > 20

--- a/lib/database/action-logger.ts
+++ b/lib/database/action-logger.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { createClient } from '../supabase/client'
+import { getSupabaseKey, getSupabaseUrl } from '../supabase/config'
 import { logEvent } from '@/lib/memory/events-logger'
 import type { Database } from '@/lib/types/database'
 
@@ -335,11 +336,13 @@ case 'add_part_evidence':
 }
 
 // Export singleton instance
+const supabaseUrl = getSupabaseUrl()
+const supabaseKey = getSupabaseKey()
 const hasSupabase =
-  typeof process.env.NEXT_PUBLIC_SUPABASE_URL === 'string' &&
-  /^https?:\/\//.test(process.env.NEXT_PUBLIC_SUPABASE_URL) &&
-  typeof process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY === 'string' &&
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY.length > 20
+  typeof supabaseUrl === 'string' &&
+  /^https?:\/\//.test(supabaseUrl) &&
+  typeof supabaseKey === 'string' &&
+  supabaseKey.length > 20
 
 export class NoopActionLogger {
   async loggedInsert<T extends DataObject>(_table: string, data: Partial<T>): Promise<T> {

--- a/lib/memory/storage/supabase-storage-adapter.ts
+++ b/lib/memory/storage/supabase-storage-adapter.ts
@@ -1,10 +1,11 @@
 import { createClient } from '@supabase/supabase-js'
 import type { StorageAdapter } from './adapter'
 import { MEMORY_SNAPSHOTS_BUCKET } from '../config'
+import { getSupabaseServiceRoleKey, getSupabaseUrl } from '@/lib/supabase/config'
 
 function getSb() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const service = process.env.SUPABASE_SERVICE_ROLE_KEY
+  const url = getSupabaseUrl()
+  const service = getSupabaseServiceRoleKey()
   if (!url || !service) throw new Error('Supabase Storage adapter requires URL and service role key')
   return createClient(url, service)
 }

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,5 +1,6 @@
 import { createClient as createSupabaseClient } from '@supabase/supabase-js'
 import { createNoopSupabaseClient, isSupabaseConfigured } from './noop-client'
+import { getSupabaseServiceRoleKey, getSupabaseUrl } from './config'
 
 let adminClientOverride: unknown | null = null
 
@@ -16,8 +17,8 @@ export function createAdminClient() {
   if (!isSupabaseConfigured()) {
     return createNoopSupabaseClient()
   }
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  const url = getSupabaseUrl()
+  const serviceKey = getSupabaseServiceRoleKey()
   if (!url || !serviceKey) {
     return createNoopSupabaseClient()
   }

--- a/lib/supabase/config.ts
+++ b/lib/supabase/config.ts
@@ -1,11 +1,72 @@
-export function getSupabaseUrl() {
-  return process.env.NEXT_PUBLIC_SUPABASE_URL
+const URL_ENV_KEYS = [
+  'NEXT_PUBLIC_SUPABASE_URL',
+  'VITE_SUPABASE_URL',
+  'SUPABASE_URL',
+] as const
+
+const ANON_KEY_ENV_KEYS = [
+  'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY',
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY',
+  'VITE_SUPABASE_ANON_KEY',
+  'SUPABASE_ANON_KEY',
+] as const
+
+const SERVICE_ROLE_KEY_ENV_KEYS = ['SUPABASE_SERVICE_ROLE_KEY'] as const
+
+const PROTOCOL_REGEX = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//
+
+function readEnv(keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key]
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim()
+    }
+  }
+  return undefined
 }
 
-export function getSupabaseKey() {
-  return (
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY ||
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY
-  )
+function normalizeUrl(raw?: string): string | undefined {
+  if (!raw) return undefined
+  const trimmed = raw.trim()
+  if (!trimmed) return undefined
+
+  const hasProtocol = PROTOCOL_REGEX.test(trimmed)
+  const value = hasProtocol ? trimmed : buildUrlWithDefaultProtocol(trimmed)
+
+  try {
+    const parsed = new URL(value)
+    return parsed.origin
+  } catch {
+    return undefined
+  }
+}
+
+function buildUrlWithDefaultProtocol(value: string): string {
+  const host = value.split('/')[0]
+  const hostWithoutPort = host.split(':')[0]
+  const isLocalhost =
+    /^localhost$/i.test(hostWithoutPort) ||
+    hostWithoutPort === '0.0.0.0' ||
+    /^127(?:\.\d{1,3}){3}$/.test(hostWithoutPort)
+  const defaultProtocol = isLocalhost ? 'http://' : 'https://'
+  return `${defaultProtocol}${value}`
+}
+
+function normalizeKey(raw?: string): string | undefined {
+  if (!raw) return undefined
+  const trimmed = raw.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+export function getSupabaseUrl(): string | undefined {
+  return normalizeUrl(readEnv(URL_ENV_KEYS))
+}
+
+export function getSupabaseKey(): string | undefined {
+  return normalizeKey(readEnv(ANON_KEY_ENV_KEYS))
+}
+
+export function getSupabaseServiceRoleKey(): string | undefined {
+  return normalizeKey(readEnv(SERVICE_ROLE_KEY_ENV_KEYS))
 }

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 import { dev } from '@/config/dev'
+import { getSupabaseKey, getSupabaseUrl } from './config'
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
@@ -9,11 +10,8 @@ export async function updateSession(request: NextRequest) {
 
   // With Fluid compute, don't put this client in a global environment
   // variable. Always create a new one on each request.
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const key =
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY ||
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY
+  const url = getSupabaseUrl()
+  const key = getSupabaseKey()
 
   // Dev fallback: if Supabase env is not configured, allow request to pass through
   if (!url || !key) {

--- a/lib/supabase/noop-client.ts
+++ b/lib/supabase/noop-client.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '../types/database'
+import { getSupabaseKey, getSupabaseUrl } from './config'
 
 const missingConfigMessage =
   'Supabase environment variables are not configured. Falling back to a no-op client. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to enable Supabase features.'
@@ -15,7 +16,7 @@ function warnOnce() {
   }
 }
 
-function createNoopQueryBuilder(): any {
+function createNoopQueryBuilder(): unknown {
   const handler: ProxyHandler<Record<string, unknown>> = {
     get(_target, prop) {
       if (prop === 'then') {
@@ -132,11 +133,8 @@ export function createNoopSupabaseClient(): SupabaseClient<Database> {
 }
 
 export function isSupabaseConfigured(): boolean {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const anonKey =
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY ??
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY
+  const url = getSupabaseUrl()
+  const anonKey = getSupabaseKey()
   return typeof url === 'string' && url.length > 0 && typeof anonKey === 'string' && anonKey.length > 0
 }
 


### PR DESCRIPTION
## Summary
- normalize Supabase URL and key env values to trim whitespace, infer protocol, and expose a service-role getter
- route all runtime Supabase clients through the sanitized helpers to avoid malformed URLs and missing keys
- update storage adapters, middleware, and data utilities to use the shared helpers for consistent configuration detection

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c9e381302c8323bf51829a1a203e28