### PR TITLE
fix(auth): allow google nonce debug in production

### DIFF
--- a/docs/features/authentication-google.md
+++ b/docs/features/authentication-google.md
@@ -41,7 +41,7 @@ Lower-friction sign-in and account creation with secure provider flows.
 - Verify redirect URIs and provider credentials across environments
 
 ## Debugging tips
-- Use the built-in console logs from `useGoogleAuth` (enabled when `NODE_ENV !== 'production'`) to confirm the nonce lifecycle. You should see whether a nonce is generated, reused, and the redacted value supplied to Supabase. A nonce mismatch will surface as `Supabase sign-in failed` with `AuthApiError` details containing `Nonce not valid`.
+- Use the built-in console logs from `useGoogleAuth`. In production builds, enable them by running `localStorage.setItem('IFS_GOOGLE_AUTH_DEBUG', 'true')` (or append `?debugGoogleAuth=1` to the URL) and refresh. You should then see whether a nonce is generated, reused, and the redacted value supplied to Supabase. A nonce mismatch will surface as `Supabase sign-in failed` with `AuthApiError` details containing `Nonce not valid`.
 - Check the environment diagnostics log on first render; it redacts `NEXT_PUBLIC_GOOGLE_CLIENT_ID`, `NEXT_PUBLIC_SUPABASE_URL`, and `NEXT_PUBLIC_SUPABASE_ANON_KEY`. Missing or unexpected values typically mean the wrong `.env` file is loaded or build-time envs differ from runtime.
 - If you suspect Supabase configuration, temporarily set `skip_nonce_check = true` under `[auth.external.google]` in `supabase/config.toml`, restart Supabase, and retry sign-in. If sign-in succeeds with the skip in place, the issue is almost certainly nonce-related. Remember to revert this flag after testing.
 - Supabase credential issues (bad client ID/secret) usually return HTTP 400 with `invalid_client` or `unauthorized_client` errors. Capture the full `authError` object from the console log to distinguish these from nonce problems.

--- a/lib/hooks/use-google-auth.ts
+++ b/lib/hooks/use-google-auth.ts
@@ -41,15 +41,27 @@ type GoogleIdentity = NonNullable<Window['google']>
 const textEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null
 
 const DEBUG_PREFIX = '[useGoogleAuth]'
-const shouldLogDebug = process.env.NODE_ENV !== 'production'
+
+function isDebugEnabled() {
+  if (process.env.NODE_ENV !== 'production') return true
+  if (typeof window === 'undefined') return false
+  try {
+    if (window.localStorage.getItem('IFS_GOOGLE_AUTH_DEBUG') === 'true') return true
+  } catch {}
+  try {
+    const params = new URLSearchParams(window.location.search)
+    if (params.has('debugGoogleAuth')) return true
+  } catch {}
+  return false
+}
 
 function debugLog(...args: unknown[]) {
-  if (!shouldLogDebug) return
+  if (!isDebugEnabled()) return
   console.info(DEBUG_PREFIX, ...args)
 }
 
 function debugWarn(...args: unknown[]) {
-  if (!shouldLogDebug) return
+  if (!isDebugEnabled()) return
   console.warn(DEBUG_PREFIX, ...args)
 }
 
@@ -117,7 +129,7 @@ export function useGoogleAuth() {
   const redirectPathRef = useRef('/')
   const envReportedRef = useRef(false)
 
-  if (shouldLogDebug && !envReportedRef.current) {
+  if (isDebugEnabled() && !envReportedRef.current) {
     envReportedRef.current = true
     debugLog('Environment diagnostics', {
       NEXT_PUBLIC_GOOGLE_CLIENT_ID: redact(process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID),


### PR DESCRIPTION
## Summary
- allow enabling Google auth debug logs in production via localStorage or query param
- keep existing nonce instrumentation but ensure logs emit on demand
- document how to toggle the debug flag for support

## Testing
- npm run lint -- lib/hooks/use-google-auth.ts *(fails: Next CLI couldn't find any  or  directory in this sandbox)*