### PR TITLE
feat: refresh guided check-ins with emoji quick scan

### DIFF
--- a/app/api/check-ins/route.ts
+++ b/app/api/check-ins/route.ts
@@ -1,22 +1,149 @@
 import { NextRequest } from 'next/server'
+import { z } from 'zod'
+import { createOpenRouter } from '@openrouter/ai-sdk-provider'
+import { generateObject } from 'ai'
 import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { dev, resolveUserId } from '@/config/dev'
 import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response'
 
+const DEFAULT_EVENING_PROMPT = 'What stood out for you today?'
+
+interface EmojiOption {
+  id: string
+  emoji: string
+  label: string
+  score: number
+}
+
+const MOOD_OPTIONS: EmojiOption[] = [
+  { id: 'depleted', emoji: '😔', label: 'Running on empty', score: 1 },
+  { id: 'soft', emoji: '😕', label: 'Tender but okay', score: 2 },
+  { id: 'steady', emoji: '🙂', label: 'Steady and present', score: 3 },
+  { id: 'bright', emoji: '😄', label: 'Bright and open', score: 4 },
+  { id: 'glowing', emoji: '🤩', label: 'Glowing with joy', score: 5 },
+]
+
+const ENERGY_OPTIONS: EmojiOption[] = [
+  { id: 'drained', emoji: '😴', label: 'Running on fumes', score: 1 },
+  { id: 'low', emoji: '😌', label: 'Soft but tired', score: 2 },
+  { id: 'steady', emoji: '🙂', label: 'Steady and grounded', score: 3 },
+  { id: 'spark', emoji: '⚡️', label: 'Spark of momentum', score: 4 },
+  { id: 'soaring', emoji: '🚀', label: 'Soaring with energy', score: 5 },
+]
+
+const INTENTION_FOCUS_OPTIONS: EmojiOption[] = [
+  { id: 'scattered', emoji: '😵‍💫', label: 'Still finding focus', score: 1 },
+  { id: 'curious', emoji: '🤔', label: 'Curious and exploring', score: 2 },
+  { id: 'aimed', emoji: '🎯', label: 'Clear on my aim', score: 3 },
+  { id: 'committed', emoji: '💪', label: 'Committed to follow-through', score: 4 },
+  { id: 'grounded', emoji: '🧘', label: 'Grounded and embodied', score: 5 },
+]
+
+const emojiGroups = {
+  mood: MOOD_OPTIONS,
+  energy: ENERGY_OPTIONS,
+  intentionFocus: INTENTION_FOCUS_OPTIONS,
+}
+
+type EmojiGroupKey = keyof typeof emojiGroups
+
+const morningSchema = z.object({
+  type: z.literal('morning'),
+  mood: z.string(),
+  energy: z.string(),
+  intentionFocus: z.string(),
+  mindForToday: z.string().optional(),
+  intention: z.string().min(1, 'Intention is required'),
+  parts: z.array(z.string()).optional(),
+})
+
+const eveningSchema = z.object({
+  type: z.literal('evening'),
+  mood: z.string(),
+  energy: z.string(),
+  intentionFocus: z.string(),
+  reflectionPrompt: z.string().min(1),
+  reflection: z.string().min(1),
+  gratitude: z.string().optional(),
+  moreNotes: z.string().optional(),
+  parts: z.array(z.string()).optional(),
+})
+
+function findEmojiOption(group: EmojiGroupKey, id: string): EmojiOption {
+  const options = emojiGroups[group]
+  return options.find((option) => option.id === id) ?? options[Math.floor(options.length / 2)]
+}
+
+function buildEmojiSnapshot(payload: {
+  mood: EmojiOption
+  energy: EmojiOption
+  intentionFocus: EmojiOption
+}) {
+  return {
+    mood: payload.mood,
+    energy: payload.energy,
+    intentionFocus: payload.intentionFocus,
+  }
+}
+
+async function generateEveningPrompt(params: {
+  intention: string
+  mindForToday: string
+  mood: EmojiOption
+  energy: EmojiOption
+  intentionFocus: EmojiOption
+}): Promise<{ text: string; model?: string }> {
+  const apiKey = process.env.OPENROUTER_API_KEY
+  if (!apiKey) {
+    return { text: DEFAULT_EVENING_PROMPT }
+  }
+
+  try {
+    const provider = createOpenRouter({ apiKey })
+    const schema = z.object({ prompt: z.string().min(1).max(180) })
+
+    const system = `You are a gentle IFS-inspired companion helping the user reflect in the evening.
+Craft a short, supportive, curiosity-driven reflection prompt (1-2 sentences maximum) that references the user's morning check-in.
+Keep it grounded, avoid clinical language, and never promise outcomes.`
+
+    const promptLines = [
+      `Morning intention: ${params.intention || 'Not specified.'}`,
+      `Morning mindshare: ${params.mindForToday || 'Not specified.'}`,
+      `Mood: ${params.mood.label}.`,
+      `Energy: ${params.energy.label}.`,
+      `Intention focus: ${params.intentionFocus.label}.`,
+    ]
+
+    const { object } = await generateObject({
+      model: provider('openai/gpt-4o-mini'),
+      system,
+      schema,
+      prompt: promptLines.join('\n'),
+    })
+
+    const text = object.prompt.trim()
+    if (!text) {
+      return { text: DEFAULT_EVENING_PROMPT }
+    }
+
+    return { text, model: 'openai/gpt-4o-mini' }
+  } catch (error) {
+    console.error('Failed to generate evening prompt', error)
+    return { text: DEFAULT_EVENING_PROMPT }
+  }
+}
+
 export async function POST(req: NextRequest) {
-  // In dev mode, if a service role key is available, use admin client and a dev user id
   const useAdmin = dev.enabled && !!process.env.SUPABASE_SERVICE_ROLE_KEY
   const supabase = useAdmin ? createAdminClient() : await createClient()
 
   let effectiveUserId: string | null = null
 
   if (useAdmin) {
-    // Resolve a deterministic dev user ID (persona or default)
     try {
       effectiveUserId = resolveUserId()
     } catch {
-      // Fall back to rejecting if no dev user can be resolved
       return errorResponse(
         'Dev user not configured. Set IFS_TEST_PERSONA or IFS_DEFAULT_USER_ID.',
         HTTP_STATUS.BAD_REQUEST,
@@ -34,37 +161,182 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const body = await req.json()
+    const json = await req.json()
 
-    // Basic validation
-    if (!body.type || (body.type !== 'morning' && body.type !== 'evening')) {
+    if (!json?.type || (json.type !== 'morning' && json.type !== 'evening')) {
       return errorResponse('Invalid check-in type', HTTP_STATUS.BAD_REQUEST)
     }
 
-    const { error, data } = await supabase.from('check_ins').insert({
-      user_id: effectiveUserId,
-      type: body.type,
-      mood: body.mood,
-      energy_level: body.energy_level,
-      intention: body.intention,
-      reflection: body.reflection,
-      gratitude: body.gratitude,
-      parts_data: body.parts_data,
-      somatic_markers: body.somatic_markers,
-      processed: false,
-    }).select()
+    if (json.type === 'morning') {
+      const parsed = morningSchema.safeParse(json)
+      if (!parsed.success) {
+        return errorResponse('Invalid check-in payload', HTTP_STATUS.BAD_REQUEST)
+      }
+
+      const payload = parsed.data
+      const mood = findEmojiOption('mood', payload.mood)
+      const energy = findEmojiOption('energy', payload.energy)
+      const intentionFocus = findEmojiOption('intentionFocus', payload.intentionFocus)
+
+      const prompt = await generateEveningPrompt({
+        intention: payload.intention,
+        mindForToday: payload.mindForToday ?? '',
+        mood,
+        energy,
+        intentionFocus,
+      })
+
+      const createdAt = new Date().toISOString()
+      const selectedParts = payload.parts ?? []
+
+      const partsData: Record<string, unknown> = {
+        selected_part_ids: selectedParts,
+        daily_responses: {
+          variant: 'morning',
+          emoji: buildEmojiSnapshot({ mood, energy, intentionFocus }),
+          mindForToday: payload.mindForToday ?? '',
+          intention: payload.intention,
+          selectedPartIds: selectedParts,
+          generatedEveningPrompt: {
+            text: prompt.text,
+            created_at: createdAt,
+            ...(prompt.model ? { model: prompt.model } : {}),
+          },
+        },
+      }
+
+      const { error, data } = await supabase
+        .from('check_ins')
+        .insert({
+          user_id: effectiveUserId,
+          type: 'morning',
+          mood: mood.score,
+          energy_level: energy.score,
+          intention: payload.intention,
+          parts_data: partsData,
+          somatic_markers: null,
+          gratitude: null,
+          reflection: null,
+          processed: false,
+        })
+        .select()
+
+      if (error) {
+        console.error('Error inserting morning check-in:', error)
+        const pgCode = (error as { code?: string } | null)?.code
+        if (pgCode === '23505') {
+          return errorResponse('A check-in of this type already exists for this date.', HTTP_STATUS.CONFLICT)
+        }
+        return errorResponse('Failed to save check-in', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+      }
+
+      return jsonResponse(data ?? [], HTTP_STATUS.CREATED)
+    }
+
+    const parsed = eveningSchema.safeParse(json)
+    if (!parsed.success) {
+      return errorResponse('Invalid check-in payload', HTTP_STATUS.BAD_REQUEST)
+    }
+
+    const payload = parsed.data
+    const mood = findEmojiOption('mood', payload.mood)
+    const energy = findEmojiOption('energy', payload.energy)
+    const intentionFocus = findEmojiOption('intentionFocus', payload.intentionFocus)
+    const reflectionPrompt = payload.reflectionPrompt.trim() || DEFAULT_EVENING_PROMPT
+    const selectedParts = payload.parts ?? []
+    const gratitude = payload.gratitude?.trim() ?? ''
+    const moreNotes = payload.moreNotes?.trim() ?? ''
+
+    const today = new Date().toISOString().slice(0, 10)
+
+    const { data: morningRows } = await supabase
+      .from('check_ins')
+      .select('id, parts_data')
+      .eq('user_id', effectiveUserId)
+      .eq('type', 'morning')
+      .eq('check_in_date', today)
+      .order('created_at', { ascending: false })
+      .limit(1)
+
+    const morningRecord = morningRows && morningRows.length > 0 ? morningRows[0] : null
+
+    const partsData: Record<string, unknown> = {
+      selected_part_ids: selectedParts,
+      daily_responses: {
+        variant: 'evening',
+        emoji: buildEmojiSnapshot({ mood, energy, intentionFocus }),
+        reflectionPrompt: { text: reflectionPrompt },
+        reflection: payload.reflection.trim(),
+        gratitude,
+        moreNotes,
+        selectedPartIds: selectedParts,
+        ...(morningRecord?.id ? { links: { morning_check_in_id: morningRecord.id } } : {}),
+      },
+    }
+
+    const { error, data } = await supabase
+      .from('check_ins')
+      .insert({
+        user_id: effectiveUserId,
+        type: 'evening',
+        mood: mood.score,
+        energy_level: energy.score,
+        reflection: payload.reflection.trim(),
+        gratitude: gratitude.length > 0 ? gratitude : null,
+        intention: null,
+        parts_data: partsData,
+        somatic_markers: null,
+        processed: false,
+      })
+      .select()
 
     if (error) {
-      console.error('Error inserting check-in:', error)
-      // Handle unique constraint violation
+      console.error('Error inserting evening check-in:', error)
       const pgCode = (error as { code?: string } | null)?.code
-      if (pgCode === '23505') { // unique_violation
+      if (pgCode === '23505') {
         return errorResponse('A check-in of this type already exists for this date.', HTTP_STATUS.CONFLICT)
       }
       return errorResponse('Failed to save check-in', HTTP_STATUS.INTERNAL_SERVER_ERROR)
     }
 
-    return jsonResponse(data, HTTP_STATUS.CREATED)
+    if (morningRecord) {
+      try {
+        const existingPartsData = (morningRecord.parts_data as Record<string, unknown> | null) ?? {}
+        const existingDaily =
+          existingPartsData && typeof existingPartsData === 'object'
+            ? ((existingPartsData as { daily_responses?: unknown }).daily_responses as
+                | Record<string, unknown>
+                | undefined)
+            : undefined
+
+        const existingPrompt =
+          existingDaily && typeof existingDaily === 'object' && existingDaily !== null
+            ? ((existingDaily as { generatedEveningPrompt?: unknown }).generatedEveningPrompt as
+                | Record<string, unknown>
+                | undefined)
+            : undefined
+
+        const updatedMorningPartsData = {
+          ...existingPartsData,
+          daily_responses: {
+            ...(existingDaily ?? {}),
+            generatedEveningPrompt: {
+              ...(existingPrompt ?? {}),
+              responded_at: new Date().toISOString(),
+            },
+          },
+        }
+
+        await supabase
+          .from('check_ins')
+          .update({ parts_data: updatedMorningPartsData })
+          .eq('id', morningRecord.id as string)
+      } catch (updateError) {
+        console.error('Failed to update morning check-in with evening status', updateError)
+      }
+    }
+
+    return jsonResponse(data ?? [], HTTP_STATUS.CREATED)
   } catch (error) {
     console.error('Check-in API error:', error)
     return errorResponse('An unexpected error occurred', HTTP_STATUS.INTERNAL_SERVER_ERROR)

--- a/components/check-in/CheckInTemplate.tsx
+++ b/components/check-in/CheckInTemplate.tsx
@@ -25,13 +25,14 @@ export interface FormField {
 interface CheckInTemplateProps {
   title: string
   description: string
-  fields: FormField[]
+  fields?: FormField[]
   onSubmit: React.FormEventHandler<HTMLFormElement>
   isLoading: boolean
   submitText: string
   submitDisabled?: boolean
   error: string | null
   preFieldsContent?: React.ReactNode
+  children?: React.ReactNode
   className?: string
 }
 
@@ -45,6 +46,7 @@ export function CheckInTemplate({
   submitDisabled = false,
   error,
   preFieldsContent,
+  children,
   className,
 }: CheckInTemplateProps & Omit<React.ComponentPropsWithoutRef<'div'>, 'onSubmit'>) {
   return (
@@ -58,18 +60,20 @@ export function CheckInTemplate({
           <form onSubmit={onSubmit}>
             <div className="flex flex-col gap-6">
               {preFieldsContent}
-              {fields.map((field) => (
-                <div className="grid gap-2" key={field.id}>
-                  <Label htmlFor={field.id}>{field.label}</Label>
-                  <Textarea
-                    id={field.id}
-                    placeholder={field.placeholder}
-                    required={field.required}
-                    value={field.value}
-                    onChange={field.onChange}
-                  />
-                </div>
-              ))}
+              {children
+                ? children
+                : fields?.map((field) => (
+                  <div className="grid gap-2" key={field.id}>
+                    <Label htmlFor={field.id}>{field.label}</Label>
+                    <Textarea
+                      id={field.id}
+                      placeholder={field.placeholder}
+                      required={field.required}
+                      value={field.value}
+                      onChange={field.onChange}
+                    />
+                  </div>
+                ))}
               {error && <p className="text-sm text-red-500">{error}</p>}
               <Button type="submit" className="w-full" disabled={isLoading || submitDisabled}>
                 {isLoading ? 'Saving...' : submitText}

--- a/components/check-in/DailyCheckInForm.tsx
+++ b/components/check-in/DailyCheckInForm.tsx
@@ -1,57 +1,163 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import type { ChangeEvent, ComponentPropsWithoutRef, FormEvent } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import type { ComponentPropsWithoutRef, FormEvent } from 'react'
 import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
 import { cn } from '@/lib/utils'
-import { CheckInTemplate, type FormField } from './CheckInTemplate'
+import { CheckInTemplate } from './CheckInTemplate'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+
+const DEFAULT_EVENING_PROMPT = "What stood out for you today?"
+
+type EmojiOption = {
+  id: string
+  emoji: string
+  label: string
+  score: number
+}
+
+const MOOD_OPTIONS: EmojiOption[] = [
+  { id: 'depleted', emoji: '😔', label: 'Running on empty', score: 1 },
+  { id: 'soft', emoji: '😕', label: 'Tender but okay', score: 2 },
+  { id: 'steady', emoji: '🙂', label: 'Steady and present', score: 3 },
+  { id: 'bright', emoji: '😄', label: 'Bright and open', score: 4 },
+  { id: 'glowing', emoji: '🤩', label: 'Glowing with joy', score: 5 },
+]
+
+const ENERGY_OPTIONS: EmojiOption[] = [
+  { id: 'drained', emoji: '😴', label: 'Running on fumes', score: 1 },
+  { id: 'low', emoji: '😌', label: 'Soft but tired', score: 2 },
+  { id: 'steady', emoji: '🙂', label: 'Steady and grounded', score: 3 },
+  { id: 'spark', emoji: '⚡️', label: 'Spark of momentum', score: 4 },
+  { id: 'soaring', emoji: '🚀', label: 'Soaring with energy', score: 5 },
+]
+
+const INTENTION_FOCUS_OPTIONS: EmojiOption[] = [
+  { id: 'scattered', emoji: '😵‍💫', label: 'Still finding focus', score: 1 },
+  { id: 'curious', emoji: '🤔', label: 'Curious and exploring', score: 2 },
+  { id: 'aimed', emoji: '🎯', label: 'Clear on my aim', score: 3 },
+  { id: 'committed', emoji: '💪', label: 'Committed to follow-through', score: 4 },
+  { id: 'grounded', emoji: '🧘', label: 'Grounded and embodied', score: 5 },
+]
+
+const DEFAULT_MOOD_ID = MOOD_OPTIONS[2].id
+const DEFAULT_ENERGY_ID = ENERGY_OPTIONS[2].id
+const DEFAULT_INTENTION_FOCUS_ID = INTENTION_FOCUS_OPTIONS[2].id
+
+type EmojiSelections = {
+  mood: string
+  energy: string
+  intentionFocus: string
+}
+
+type MorningState = EmojiSelections & {
+  mindForToday: string
+  intention: string
+  parts: string[]
+}
+
+type EveningState = EmojiSelections & {
+  reflection: string
+  gratitude: string
+  moreNotes: string
+  parts: string[]
+}
+
+type MorningContext = {
+  id: string
+  intention: string
+  mindForToday: string
+  parts: string[]
+  emoji: EmojiSelections
+  generatedPrompt: string
+}
+
+type PartOption = {
+  id: string
+  name: string
+  emoji?: string | null
+}
+
+const createMorningState = (): MorningState => ({
+  mood: DEFAULT_MOOD_ID,
+  energy: DEFAULT_ENERGY_ID,
+  intentionFocus: DEFAULT_INTENTION_FOCUS_ID,
+  mindForToday: '',
+  intention: '',
+  parts: [],
+})
+
+const createEveningState = (defaults?: Partial<EveningState>): EveningState => ({
+  mood: defaults?.mood ?? DEFAULT_MOOD_ID,
+  energy: defaults?.energy ?? DEFAULT_ENERGY_ID,
+  intentionFocus: defaults?.intentionFocus ?? DEFAULT_INTENTION_FOCUS_ID,
+  reflection: defaults?.reflection ?? '',
+  gratitude: defaults?.gratitude ?? '',
+  moreNotes: defaults?.moreNotes ?? '',
+  parts: defaults?.parts ?? [],
+})
+
+interface EmojiScaleInputProps {
+  label: string
+  options: EmojiOption[]
+  value: string
+  onChange: (value: string) => void
+}
+
+function EmojiScaleInput({ label, options, value, onChange }: EmojiScaleInputProps) {
+  return (
+    <fieldset className="grid gap-3">
+      <legend className="text-sm font-medium text-foreground">{label}</legend>
+      <div className="grid grid-cols-5 gap-2">
+        {options.map((option) => {
+          const selected = option.id === value
+          return (
+            <button
+              type="button"
+              key={option.id}
+              onClick={() => onChange(option.id)}
+              className={cn(
+                'flex flex-col items-center gap-1 rounded-lg border bg-background px-3 py-2 text-2xl transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                selected
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-border text-foreground hover:border-primary/40 hover:bg-primary/5',
+              )}
+              aria-pressed={selected}
+            >
+              <span aria-hidden>{option.emoji}</span>
+              <span className="text-xs text-muted-foreground">{option.label}</span>
+            </button>
+          )
+        })}
+      </div>
+    </fieldset>
+  )
+}
+
+function getEmojiOption(options: EmojiOption[], id: string): EmojiOption {
+  return options.find((option) => option.id === id) ?? options[0]
+}
+
+function toEmojiSummary(options: EmojiOption[], id: string) {
+  const option = getEmojiOption(options, id)
+  return { id: option.id, emoji: option.emoji, label: option.label, score: option.score }
+}
 
 interface DailyCheckInFormProps extends Omit<ComponentPropsWithoutRef<'div'>, 'onSubmit'> {
   variant: 'morning' | 'evening'
 }
-
-type MorningState = {
-  intention: string
-  worries: string
-  lookingForwardTo: string
-}
-
-type EveningState = {
-  reflectionOnIntention: string
-  reflectionOnWorries: string
-  reflectionOnLookingForwardTo: string
-  gratitude: string
-}
-
-type MorningContext = {
-  intention: string
-  worries: string
-  lookingForwardTo: string
-}
-
-const createMorningState = (): MorningState => ({
-  intention: '',
-  worries: '',
-  lookingForwardTo: '',
-})
-
-const createEveningState = (): EveningState => ({
-  reflectionOnIntention: '',
-  reflectionOnWorries: '',
-  reflectionOnLookingForwardTo: '',
-  gratitude: '',
-})
 
 export function DailyCheckInForm({ variant, className, ...divProps }: DailyCheckInFormProps) {
   const router = useRouter()
   const [morningState, setMorningState] = useState<MorningState>(() => createMorningState())
   const [eveningState, setEveningState] = useState<EveningState>(() => createEveningState())
   const [morningContext, setMorningContext] = useState<MorningContext | null>(null)
+  const [availableParts, setAvailableParts] = useState<PartOption[]>([])
   const [isFetchingContext, setIsFetchingContext] = useState(variant === 'evening')
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [formError, setFormError] = useState<string | null>(null)
@@ -63,12 +169,53 @@ export function DailyCheckInForm({ variant, className, ...divProps }: DailyCheck
       setMorningContext(null)
       setFetchError(null)
       setIsFetchingContext(false)
+      setEveningState(createEveningState())
     } else {
       setEveningState(createEveningState())
       setIsFetchingContext(true)
     }
     setFormError(null)
   }, [variant])
+
+  useEffect(() => {
+    const fetchParts = async () => {
+      const supabase = createClient()
+
+      try {
+        const {
+          data: { user },
+          error: userError,
+        } = await supabase.auth.getUser()
+
+        if (userError) throw userError
+        if (!user) return
+
+        const { data, error } = await supabase
+          .from('parts')
+          .select('id, name, visualization')
+          .eq('user_id', user.id)
+          .order('name', { ascending: true })
+
+        if (error) throw error
+
+        const parsed = (data ?? []).map((row) => {
+          const visualization = (row.visualization as Record<string, unknown> | null) ?? null
+          const emoji =
+            visualization && typeof visualization === 'object' && typeof visualization.emoji === 'string'
+              ? (visualization.emoji as string)
+              : null
+          return { id: row.id as string, name: row.name as string, emoji }
+        })
+
+        setAvailableParts(parsed)
+      } catch (error) {
+        console.error('Failed to load parts for check-in', error)
+        setAvailableParts([])
+      }
+    }
+
+    fetchParts()
+  }, [])
 
   useEffect(() => {
     if (variant !== 'evening') return
@@ -90,11 +237,14 @@ export function DailyCheckInForm({ variant, className, ...divProps }: DailyCheck
           throw new Error('User not found')
         }
 
+        const today = new Date().toISOString().slice(0, 10)
+
         const { data, error } = await supabase
           .from('check_ins')
           .select('id, intention, parts_data, created_at')
           .eq('user_id', user.id)
           .eq('type', 'morning')
+          .eq('check_in_date', today)
           .order('created_at', { ascending: false })
           .limit(1)
 
@@ -117,29 +267,78 @@ export function DailyCheckInForm({ variant, className, ...divProps }: DailyCheck
           rawResponses && typeof rawResponses === 'object'
             ? (rawResponses as Record<string, unknown> & { variant?: 'morning' | 'evening' })
             : undefined
-        const morningResponses =
+        const responses =
           storedResponses && (!storedResponses.variant || storedResponses.variant === 'morning')
             ? storedResponses
             : undefined
 
+        const emojiRecord =
+          responses && typeof responses.emoji === 'object' && responses.emoji !== null
+            ? (responses.emoji as Record<string, unknown>)
+            : undefined
+
         const intention =
-          typeof morningResponses?.intention === 'string'
-            ? morningResponses.intention
+          typeof responses?.intention === 'string'
+            ? responses.intention
             : typeof record.intention === 'string'
             ? record.intention
             : ''
-        const worries = typeof morningResponses?.worries === 'string' ? morningResponses.worries : ''
-        const lookingForwardTo =
-          typeof morningResponses?.lookingForwardTo === 'string'
-            ? morningResponses.lookingForwardTo
-            : ''
+        const mindForToday =
+          typeof responses?.mindForToday === 'string' ? responses.mindForToday : ''
+        const topLevelSelected = Array.isArray(
+          (partsData as { selected_part_ids?: unknown })?.selected_part_ids,
+        )
+          ? (((partsData as { selected_part_ids?: unknown }).selected_part_ids as unknown[]) || []).filter(
+              (id): id is string => typeof id === 'string',
+            )
+          : []
+        const parts = Array.isArray(responses?.selectedPartIds)
+          ? (responses?.selectedPartIds.filter((id) => typeof id === 'string') as string[])
+          : topLevelSelected
+        const generatedPrompt =
+          responses && typeof responses.generatedEveningPrompt === 'object'
+            ? ((responses.generatedEveningPrompt as { text?: unknown }).text as string | undefined)
+            : undefined
+
+        const moodSelection =
+          emojiRecord && typeof (emojiRecord.mood as { id?: unknown } | undefined)?.id === 'string'
+            ? ((emojiRecord.mood as { id: string }).id)
+            : DEFAULT_MOOD_ID
+        const energySelection =
+          emojiRecord && typeof (emojiRecord.energy as { id?: unknown } | undefined)?.id === 'string'
+            ? ((emojiRecord.energy as { id: string }).id)
+            : DEFAULT_ENERGY_ID
+        const intentionFocusSelection =
+          emojiRecord &&
+          typeof (emojiRecord.intentionFocus as { id?: unknown } | undefined)?.id === 'string'
+            ? ((emojiRecord.intentionFocus as { id: string }).id)
+            : DEFAULT_INTENTION_FOCUS_ID
+
+        const emojiSelections: EmojiSelections = {
+          mood: moodSelection,
+          energy: energySelection,
+          intentionFocus: intentionFocusSelection,
+        }
+
+        const context: MorningContext = {
+          id: record.id as string,
+          intention,
+          mindForToday,
+          parts,
+          emoji: emojiSelections,
+          generatedPrompt: generatedPrompt && generatedPrompt.length > 0 ? generatedPrompt : DEFAULT_EVENING_PROMPT,
+        }
 
         if (active) {
-          setMorningContext({
-            intention,
-            worries,
-            lookingForwardTo,
-          })
+          setMorningContext(context)
+          setEveningState(
+            createEveningState({
+              mood: emojiSelections.mood,
+              energy: emojiSelections.energy,
+              intentionFocus: emojiSelections.intentionFocus,
+              parts,
+            }),
+          )
           setFetchError(null)
         }
       } catch (error) {
@@ -161,101 +360,95 @@ export function DailyCheckInForm({ variant, className, ...divProps }: DailyCheck
     }
   }, [variant])
 
-  const handleMorningChange = (key: keyof MorningState) => (event: ChangeEvent<HTMLTextAreaElement>) => {
-    setMorningState((prev) => ({ ...prev, [key]: event.target.value }))
+  const handleMorningEmojiChange = (key: keyof EmojiSelections, value: string) => {
+    setMorningState((prev) => ({ ...prev, [key]: value }))
   }
 
-  const handleEveningChange = (key: keyof EveningState) => (event: ChangeEvent<HTMLTextAreaElement>) => {
-    setEveningState((prev) => ({ ...prev, [key]: event.target.value }))
+  const handleEveningEmojiChange = (key: keyof EmojiSelections, value: string) => {
+    setEveningState((prev) => ({ ...prev, [key]: value }))
   }
 
-  const fields: FormField[] =
-    variant === 'morning'
-      ? [
-          {
-            id: 'intention',
-            label: 'What is your main intention for today?',
-            placeholder: 'e.g., To be present in my conversations.',
-            required: true,
-            value: morningState.intention,
-            onChange: handleMorningChange('intention'),
-          },
-          {
-            id: 'worries',
-            label: "What's one thing you're worried about?",
-            placeholder: 'e.g., My upcoming presentation.',
-            value: morningState.worries,
-            onChange: handleMorningChange('worries'),
-          },
-          {
-            id: 'lookingForwardTo',
-            label: 'What are you looking forward to today?',
-            placeholder: 'e.g., A walk in the park.',
-            value: morningState.lookingForwardTo,
-            onChange: handleMorningChange('lookingForwardTo'),
-          },
-        ]
-      : [
-          {
-            id: 'gratitude',
-            label: "What's one thing you're grateful for today?",
-            placeholder: 'e.g., A quiet cup of tea.',
-            value: eveningState.gratitude,
-            onChange: handleEveningChange('gratitude'),
-          },
-        ]
+  const toggleMorningPart = (partId: string) => {
+    setMorningState((prev) => ({
+      ...prev,
+      parts: prev.parts.includes(partId)
+        ? prev.parts.filter((id) => id !== partId)
+        : [...prev.parts, partId],
+    }))
+  }
 
-  const preFieldsContent =
-    variant === 'evening' ? (
-      <>
-        {morningContext?.intention && (
-          <div className="grid gap-2 text-sm">
-            <p className="text-muted-foreground">This morning, your intention was:</p>
-            <blockquote className="border-l-2 pl-3 italic">&quot;{morningContext.intention}&quot;</blockquote>
-            <Label htmlFor="reflectionOnIntention" className="mt-2">
-              How did that go?
-            </Label>
-            <Textarea
-              id="reflectionOnIntention"
-              placeholder="e.g., I made some progress, but it was a struggle at times."
-              required
-              value={eveningState.reflectionOnIntention}
-              onChange={handleEveningChange('reflectionOnIntention')}
-            />
+  const toggleEveningPart = (partId: string) => {
+    setEveningState((prev) => ({
+      ...prev,
+      parts: prev.parts.includes(partId)
+        ? prev.parts.filter((id) => id !== partId)
+        : [...prev.parts, partId],
+    }))
+  }
+
+  const partLookup = useMemo(() => {
+    const map = new Map<string, PartOption>()
+    for (const part of availableParts) {
+      map.set(part.id, part)
+    }
+    return map
+  }, [availableParts])
+
+  const renderMorningSummary = () => {
+    if (!morningContext) return null
+    const mood = toEmojiSummary(MOOD_OPTIONS, morningContext.emoji.mood)
+    const energy = toEmojiSummary(ENERGY_OPTIONS, morningContext.emoji.energy)
+    const intentionFocus = toEmojiSummary(INTENTION_FOCUS_OPTIONS, morningContext.emoji.intentionFocus)
+    return (
+      <div className="grid gap-4 rounded-lg border border-border/60 bg-muted/40 p-4">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Morning snapshot</p>
+          <div className="mt-2 flex gap-4 text-2xl">
+            <span title={mood.label} aria-label={`Morning mood: ${mood.label}`}>
+              {mood.emoji}
+            </span>
+            <span title={energy.label} aria-label={`Morning energy: ${energy.label}`}>
+              {energy.emoji}
+            </span>
+            <span title={intentionFocus.label} aria-label={`Morning intention focus: ${intentionFocus.label}`}>
+              {intentionFocus.emoji}
+            </span>
+          </div>
+        </div>
+        {morningContext.mindForToday && (
+          <div className="grid gap-1 text-sm">
+            <p className="text-muted-foreground">You shared this morning:</p>
+            <blockquote className="border-l-2 pl-3 italic">“{morningContext.mindForToday}”</blockquote>
           </div>
         )}
-        {morningContext?.worries && (
-          <div className="grid gap-2 text-sm">
-            <p className="text-muted-foreground">You were worried about:</p>
-            <blockquote className="border-l-2 pl-3 italic">&quot;{morningContext.worries}&quot;</blockquote>
-            <Label htmlFor="reflectionOnWorries" className="mt-2">
-              How are you feeling about that now?
-            </Label>
-            <Textarea
-              id="reflectionOnWorries"
-              placeholder="e.g., It wasn't as bad as I thought."
-              value={eveningState.reflectionOnWorries}
-              onChange={handleEveningChange('reflectionOnWorries')}
-            />
+        {morningContext.intention && (
+          <div className="grid gap-1 text-sm">
+            <p className="text-muted-foreground">Intention you set:</p>
+            <blockquote className="border-l-2 pl-3 italic">“{morningContext.intention}”</blockquote>
           </div>
         )}
-        {morningContext?.lookingForwardTo && (
+        {morningContext.parts.length > 0 && (
           <div className="grid gap-2 text-sm">
-            <p className="text-muted-foreground">You were looking forward to:</p>
-            <blockquote className="border-l-2 pl-3 italic">&quot;{morningContext.lookingForwardTo}&quot;</blockquote>
-            <Label htmlFor="reflectionOnLookingForwardTo" className="mt-2">
-              How was it?
-            </Label>
-            <Textarea
-              id="reflectionOnLookingForwardTo"
-              placeholder="e.g., It was wonderful!"
-              value={eveningState.reflectionOnLookingForwardTo}
-              onChange={handleEveningChange('reflectionOnLookingForwardTo')}
-            />
+            <p className="text-muted-foreground">Parts you noticed:</p>
+            <div className="flex flex-wrap gap-2">
+              {morningContext.parts.map((partId) => {
+                const part = partLookup.get(partId)
+                return (
+                  <span
+                    key={partId}
+                    className="inline-flex items-center gap-1 rounded-full bg-secondary/60 px-3 py-1 text-xs"
+                  >
+                    <span aria-hidden>{part?.emoji ?? '🧩'}</span>
+                    <span>{part?.name ?? 'Part'}</span>
+                  </span>
+                )
+              })}
+            </div>
           </div>
         )}
-      </>
-    ) : undefined
+      </div>
+    )
+  }
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -270,20 +463,23 @@ export function DailyCheckInForm({ variant, className, ...divProps }: DailyCheck
         variant === 'morning'
           ? {
               type: 'morning' as const,
-              responses: {
-                intention: morningState.intention.trim(),
-                worries: morningState.worries.trim(),
-                lookingForwardTo: morningState.lookingForwardTo.trim(),
-              },
+              mood: morningState.mood,
+              energy: morningState.energy,
+              intentionFocus: morningState.intentionFocus,
+              mindForToday: morningState.mindForToday.trim(),
+              intention: morningState.intention.trim(),
+              parts: morningState.parts,
             }
           : {
               type: 'evening' as const,
+              mood: eveningState.mood,
+              energy: eveningState.energy,
+              intentionFocus: eveningState.intentionFocus,
+              reflectionPrompt: morningContext?.generatedPrompt ?? DEFAULT_EVENING_PROMPT,
+              reflection: eveningState.reflection.trim(),
               gratitude: eveningState.gratitude.trim(),
-              responses: {
-                reflectionOnIntention: eveningState.reflectionOnIntention.trim(),
-                reflectionOnWorries: eveningState.reflectionOnWorries.trim(),
-                reflectionOnLookingForwardTo: eveningState.reflectionOnLookingForwardTo.trim(),
-              },
+              moreNotes: eveningState.moreNotes.trim(),
+              parts: eveningState.parts,
             }
 
       const response = await fetch('/api/check-ins', {
@@ -314,8 +510,10 @@ export function DailyCheckInForm({ variant, className, ...divProps }: DailyCheck
     }
   }
 
-  const submitDisabled = variant === 'evening' && (!morningContext || !!fetchError)
+  const submitDisabled =
+    variant === 'evening' && (!morningContext || !!fetchError || isFetchingContext)
   const error = fetchError ?? formError
+  const hasParts = availableParts.length > 0
 
   if (variant === 'evening' && isFetchingContext) {
     return (
@@ -327,9 +525,9 @@ export function DailyCheckInForm({ variant, className, ...divProps }: DailyCheck
           </CardHeader>
           <CardContent className="flex flex-col gap-6">
             <Skeleton className="h-6 w-1/2" />
-            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-36 w-full" />
             <Skeleton className="h-6 w-1/2" />
-            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-24 w-full" />
             <Skeleton className="h-10 w-full mt-4" />
           </CardContent>
         </Card>
@@ -337,21 +535,165 @@ export function DailyCheckInForm({ variant, className, ...divProps }: DailyCheck
     )
   }
 
+  const partsSelector = (selectedIds: string[], onToggle: (id: string) => void) => (
+    <div className="grid gap-2">
+      <Label>Any parts feel active?</Label>
+      {hasParts ? (
+        <>
+          <div className="flex flex-wrap gap-2">
+            {availableParts.map((part) => {
+              const selected = selectedIds.includes(part.id)
+              return (
+                <Button
+                  key={part.id}
+                  type="button"
+                  variant={selected ? 'default' : 'outline'}
+                  className={cn('h-auto rounded-full px-3 py-1 text-sm', selected && 'shadow-sm')}
+                  onClick={() => onToggle(part.id)}
+                >
+                  <span className="mr-1" aria-hidden>
+                    {part.emoji ?? '🧩'}
+                  </span>
+                  {part.name}
+                </Button>
+              )
+            })}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">New part?</span> Mention it below in
+            “Anything else?” or start a chat to explore together.
+          </p>
+        </>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          You can capture new parts in the “Anything else?” note or during a chat.
+        </p>
+      )}
+    </div>
+  )
+
   return (
     <CheckInTemplate
       title={variant === 'morning' ? 'Morning Check-in' : 'Evening Review'}
       description={
         variant === 'morning' ? "What's on your mind this morning?" : "Let's reflect on your day."
       }
-      fields={fields}
-      preFieldsContent={preFieldsContent}
       isLoading={isSubmitting}
       submitText={variant === 'morning' ? 'Complete Check-in' : 'Complete Review'}
       submitDisabled={submitDisabled}
       error={error}
       className={className}
       onSubmit={handleSubmit}
+      preFieldsContent={variant === 'evening' ? renderMorningSummary() : undefined}
       {...divProps}
-    />
+    >
+      <div className="grid gap-6">
+        <div className="grid gap-4">
+          <EmojiScaleInput
+            label="How are you feeling right now?"
+            options={MOOD_OPTIONS}
+            value={variant === 'morning' ? morningState.mood : eveningState.mood}
+            onChange={(value) =>
+              variant === 'morning'
+                ? handleMorningEmojiChange('mood', value)
+                : handleEveningEmojiChange('mood', value)
+            }
+          />
+          <EmojiScaleInput
+            label="How much energy do you have?"
+            options={ENERGY_OPTIONS}
+            value={variant === 'morning' ? morningState.energy : eveningState.energy}
+            onChange={(value) =>
+              variant === 'morning'
+                ? handleMorningEmojiChange('energy', value)
+                : handleEveningEmojiChange('energy', value)
+            }
+          />
+          <EmojiScaleInput
+            label="How anchored do you feel in your intention?"
+            options={INTENTION_FOCUS_OPTIONS}
+            value={
+              variant === 'morning'
+                ? morningState.intentionFocus
+                : eveningState.intentionFocus
+            }
+            onChange={(value) =>
+              variant === 'morning'
+                ? handleMorningEmojiChange('intentionFocus', value)
+                : handleEveningEmojiChange('intentionFocus', value)
+            }
+          />
+        </div>
+
+        {variant === 'morning' ? (
+          <div className="grid gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="mindForToday">What’s on your mind for today?</Label>
+              <Textarea
+                id="mindForToday"
+                placeholder="Upcoming conversations, hopes, or worries."
+                value={morningState.mindForToday}
+                onChange={(event) =>
+                  setMorningState((prev) => ({ ...prev, mindForToday: event.target.value }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="intention">What’s your intention for today?</Label>
+              <Textarea
+                id="intention"
+                placeholder="e.g., Stay grounded and curious."
+                required
+                value={morningState.intention}
+                onChange={(event) =>
+                  setMorningState((prev) => ({ ...prev, intention: event.target.value }))
+                }
+              />
+            </div>
+            {partsSelector(morningState.parts, toggleMorningPart)}
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="reflection">
+                {morningContext?.generatedPrompt ?? DEFAULT_EVENING_PROMPT}
+              </Label>
+              <Textarea
+                id="reflection"
+                placeholder="Capture what stood out, shifted, or surprised you."
+                required
+                value={eveningState.reflection}
+                onChange={(event) =>
+                  setEveningState((prev) => ({ ...prev, reflection: event.target.value }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="gratitude">Anything you’re grateful for? (optional)</Label>
+              <Textarea
+                id="gratitude"
+                placeholder="A moment of appreciation or ease."
+                value={eveningState.gratitude}
+                onChange={(event) =>
+                  setEveningState((prev) => ({ ...prev, gratitude: event.target.value }))
+                }
+              />
+            </div>
+            {partsSelector(eveningState.parts, toggleEveningPart)}
+            <div className="grid gap-2">
+              <Label htmlFor="moreNotes">Anything else you want to capture?</Label>
+              <Textarea
+                id="moreNotes"
+                placeholder="Wins, lingering parts, or messages to future you."
+                value={eveningState.moreNotes}
+                onChange={(event) =>
+                  setEveningState((prev) => ({ ...prev, moreNotes: event.target.value }))
+                }
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </CheckInTemplate>
   )
 }

--- a/components/home/CheckInCard.tsx
+++ b/components/home/CheckInCard.tsx
@@ -84,7 +84,7 @@ export function CheckInCard({ selectedDate = new Date() }: CheckInCardProps) {
       if (!isMountedRef.current) return
       setIsLoading(false)
     }
-  }, [selectedDate, targetDateString])
+  }, [targetDateString])
 
   useEffect(() => {
     fetchSelectedDateCheckIns()

--- a/docs/features/check-ins.md
+++ b/docs/features/check-ins.md
@@ -14,18 +14,21 @@ related_prs:
 ---
 
 ## What
-Structured morning and evening flows guiding users through self-reflection.
+Structured morning and evening flows guiding users through self-reflection with quick mood/energy/intention scans and lightweight notes.
 
 ## Why
 Provides a gentle, repeatable practice to capture mood, intentions, and observations.
 
 ## How it works
 - Next.js routes under /check-in/morning and /check-in/evening
-- Form components capture responses and persist via Supabase
+- Morning flow collects emoji-based ratings for mood, energy, and intention focus, plus “what’s on your mind?” and an intention note
+- Evening flow replays morning context, generates a short reflective prompt using OpenRouter, and captures reflections, gratitude, and extra notes
+- Optional multi-select chips let users mark active parts (when parts exist); new parts are nudged toward chat or the free-text note
+- Form submissions persist via Supabase with structured `parts_data` blobs for downstream agents
 - Auth middleware ensures session enforcement for protected routes
 
 ## Data model
-- check_ins (or equivalent) table storing responses with timestamps
+- `check_ins` table stores numeric mood/energy scores, textual reflection fields, and JSONB `parts_data.daily_responses` with emoji metadata, generated prompts, and selected part ids
 
 ## Configuration
 - No special flags by default; uses standard auth/session settings

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,8 +1,22 @@
 import { createBrowserClient } from '@supabase/ssr'
 import { getSupabaseKey, getSupabaseUrl } from './config'
 import { createNoopSupabaseClient, isSupabaseConfigured } from './noop-client'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '../types/database'
+
+let browserClientOverride: unknown | null = null
+
+export function setBrowserClientOverrideForTests(client: unknown | null): void {
+  if (process.env.NODE_ENV === 'test') {
+    browserClientOverride = client ?? null
+  }
+}
 
 export function createClient() {
+  if (process.env.NODE_ENV === 'test' && browserClientOverride) {
+    return browserClientOverride as SupabaseClient<Database>
+  }
+
   if (!isSupabaseConfigured()) {
     return createNoopSupabaseClient()
   }


### PR DESCRIPTION
## Summary
- add emoji-based mood/energy/intention check-in flow with parts chips and contextual prompts
- persist structured responses in Supabase via API and seed/test fixtures, including generated evening prompt
- support Supabase browser stubs for UI tests and document the refined check-in experience

## Testing
- npm run lint
- npm run typecheck
- npm test
