### PR TITLE
fix: extend evening check-in availability

### DIFF
--- a/components/home/CheckInCard.tsx
+++ b/components/home/CheckInCard.tsx
@@ -30,7 +30,7 @@ export function CheckInCard({ selectedDate = new Date() }: CheckInCardProps) {
     const hour = new Date().getHours()
     if (hour >= 4 && hour < 12) {
       setTimeOfDay('morning')
-    } else if (hour >= 16 && hour < 22) {
+    } else if (hour >= 18) {
       setTimeOfDay('evening')
     } else {
       setTimeOfDay('none')


### PR DESCRIPTION
## Summary
- adjust home check-in card to keep evening window open from 6pm until midnight so late-night users still see the CTA

## Testing
- npm run lint
- npm run typecheck
