### PR TITLE
fix: keep evening CTA and handle older check_ins schema

### DIFF
--- a/app/api/check-ins/route.ts
+++ b/app/api/check-ins/route.ts
@@ -217,7 +217,6 @@ export async function POST(req: NextRequest) {
           somatic_markers: null,
           gratitude: null,
           reflection: null,
-          processed: false,
         })
         .select()
 
@@ -286,7 +285,6 @@ export async function POST(req: NextRequest) {
         intention: null,
         parts_data: partsData,
         somatic_markers: null,
-        processed: false,
       })
       .select()
 

--- a/components/home/CheckInCard.tsx
+++ b/components/home/CheckInCard.tsx
@@ -147,7 +147,7 @@ export function CheckInCard({ selectedDate = new Date() }: CheckInCardProps) {
           <div className="text-xs opacity-90">Evening</div>
           <div className="text-lg font-semibold">Daily review</div>
           <p className="mt-2 text-sm text-indigo-100/90">Take a moment to wind down your day.</p>
-          <GuardedLink href="/check-in">
+          <GuardedLink href="/check-in/evening">
             <Button className="mt-4 bg-white text-black hover:bg-white/90">Begin</Button>
           </GuardedLink>
         </div>
@@ -170,7 +170,7 @@ export function CheckInCard({ selectedDate = new Date() }: CheckInCardProps) {
         <div className="text-xs opacity-90">Morning</div>
         <div className="text-lg font-semibold">Fresh start!</div>
         <p className="mt-2 text-sm text-green-100/90">Set your intention and ease into the day.</p>
-        <GuardedLink href="/check-in">
+        <GuardedLink href="/check-in/morning">
           <Button className="mt-4 bg-white text-black hover:bg-white/90">Begin</Button>
         </GuardedLink>
       </div>
@@ -183,7 +183,7 @@ export function CheckInCard({ selectedDate = new Date() }: CheckInCardProps) {
         <div className="text-xs opacity-90">Evening</div>
         <div className="text-lg font-semibold">Daily review</div>
         <p className="mt-2 text-sm text-indigo-100/90">Reflect on your day and notice what changed.</p>
-        <GuardedLink href="/check-in">
+        <GuardedLink href={hasMorning ? '/check-in/evening' : '/check-in/morning'}>
           <Button className="mt-4 bg-white text-black hover:bg-white/90">Begin</Button>
         </GuardedLink>
       </div>

--- a/scripts/seed-check-ins.ts
+++ b/scripts/seed-check-ins.ts
@@ -178,8 +178,6 @@ async function seedUser(supabase: ReturnType<typeof createClient>, userId: strin
         gratitude: e.gratitude,
         parts_data: partsData,
         somatic_markers: e.somatic,
-        processed: false,
-        processed_at: null,
         created_at: new Date(dateOnly + (e.type === 'morning' ? 'T09:00:00Z' : 'T20:00:00Z')).toISOString(),
         updated_at: new Date().toISOString()
       }

--- a/scripts/tests/ui/check-in-card.test.tsx
+++ b/scripts/tests/ui/check-in-card.test.tsx
@@ -204,7 +204,7 @@ test('renders the morning check-in entry point with navigation link', async (t) 
   const title = await screen.findByText('Fresh start!')
   assert.ok(title)
   const link = await screen.findByRole('link', { name: /begin/i })
-  assert.equal(link.getAttribute('href'), '/check-in')
+  assert.equal(link.getAttribute('href'), '/check-in/morning')
 })
 
 test('renders the evening variant during evening hours', async (t) => {
@@ -223,6 +223,8 @@ test('renders the evening variant during evening hours', async (t) => {
   const label = await screen.findByText('Daily review')
   assert.ok(label)
   await screen.findByText('Evening')
+  const link = await screen.findByRole('link', { name: /begin/i })
+  assert.equal(link.getAttribute('href'), '/check-in/evening')
 })
 
 test('hides the call-to-action outside check-in windows', async (t) => {


### PR DESCRIPTION
## Summary
- stop sending the deprecated `processed` column when creating check-ins so older databases accept new payloads
- update the home check-in card to route morning/evening CTAs directly to the right flow and use the evening window after 6pm
- refresh seeds and UI tests to reflect the schema change and new navigation targets

## Testing
- npm run lint
- npm run typecheck
- npm run test:integration
- npm run test:ui
