### PR TITLE
fix(ci): harden doc automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           args: --no-git --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
       - name: Upload SARIF to Code Scanning
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ name: Documentation
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
 
 jobs:
   docs:
@@ -10,17 +12,25 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Skip push event
+        if: ${{ github.event_name != 'pull_request' }}
+        run: echo "Docs automation runs only for pull_request events; skipping."
+
       - uses: actions/checkout@v4
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           node-version: 20
 
       - name: Install OpenCode
-        if: ${{ secrets.GOOGLE_API_KEY != '' }}
+        if: ${{ github.event_name == 'pull_request' && secrets.GOOGLE_API_KEY != '' }}
+        env:
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: |
           curl -fsSL https://opencode.ai/install | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -28,16 +38,18 @@ jobs:
 
       - name: Analyze and Update Docs via AI
         id: ai-update
-        if: ${{ secrets.GOOGLE_API_KEY != '' }}
+        if: ${{ github.event_name == 'pull_request' && secrets.GOOGLE_API_KEY != '' }}
         continue-on-error: true
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
         run: node .github/scripts/docs-update-ai.mjs
 
       - name: Check for AI-generated changes
         id: docs-check
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           if [ -n "$(git diff --name-only docs/)" ]; then
             echo "has-changes=true" >> $GITHUB_OUTPUT
@@ -46,7 +58,7 @@ jobs:
           fi
 
       - name: Commit Documentation Updates
-        if: steps.docs-check.outputs.has-changes == 'true'
+        if: ${{ github.event_name == 'pull_request' && steps.docs-check.outputs.has-changes == 'true' }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action Bot"
@@ -55,7 +67,7 @@ jobs:
           git push
 
       - name: Add PR Comment
-        if: steps.docs-check.outputs.has-changes == 'true'
+        if: ${{ github.event_name == 'pull_request' && steps.docs-check.outputs.has-changes == 'true' }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -67,8 +79,8 @@ jobs:
             })
 
       - name: Verify Documentation Requirements
-        if: steps.docs-check.outputs.has-changes == 'false'
+        if: ${{ github.event_name == 'pull_request' && steps.docs-check.outputs.has-changes == 'false' }}
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
         run: node .github/scripts/docs-check.mjs


### PR DESCRIPTION
## Summary
- keep gitleaks sarif artifact available so downstream jobs run
- ensure docs workflow exports the opencode api key and skips push events cleanly
- retry OpenCode calls once before failing to make docs automation more reliable

## Testing
- not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of AI-assisted documentation updates with automatic retries.

* **Chores**
  * Updated documentation automation to run only on pull requests, skipping push events and requiring a valid API key.
  * Ensured commits, PR comments, and checks occur only when changes are detected, reducing noise.
  * Enhanced base revision detection for more accurate change analysis.
  * Adjusted secrets scanning to disable artifact uploads in CI for improved security hygiene.
  * Minor formatting cleanups for workflow consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->