### PR TITLE
fix(ci): skip opencode gracefully without secrets

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,22 +30,31 @@ jobs:
           node-version: 20
 
       - name: Install OpenCode
-        if: ${{ github.event_name == 'pull_request' && env.GOOGLE_API_KEY != '' }}
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
+          if [ -z "$GOOGLE_API_KEY" ]; then
+            echo "GOOGLE_API_KEY not configured; skipping OpenCode install."
+            exit 0
+          fi
           curl -fsSL https://opencode.ai/install | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           rm -rf ~/.opencode/config.toml || true
 
       - name: Analyze and Update Docs via AI
         id: ai-update
-        if: ${{ github.event_name == 'pull_request' && env.GOOGLE_API_KEY != '' }}
+        if: ${{ github.event_name == 'pull_request' }}
         continue-on-error: true
         env:
           GOOGLE_API_KEY: ${{ env.GOOGLE_API_KEY }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
-        run: node .github/scripts/docs-update-ai.mjs
+        run: |
+          if [ -z "$GOOGLE_API_KEY" ]; then
+            echo "GOOGLE_API_KEY not configured; skipping docs update."
+            exit 0
+          fi
+          node .github/scripts/docs-update-ai.mjs
 
       - name: Check for AI-generated changes
         id: docs-check


### PR DESCRIPTION
## Summary
- move GOOGLE_API_KEY checks into shell scripts so workflow parsing never touches secrets context
- allow docs automation to skip cleanly when the key is missing while still running for PRs

## Testing
- not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved documentation CI workflow for pull requests: AI-driven steps now run conditionally at runtime and gracefully skip when the required API key isn’t configured, showing clear skip messages.
  - Ensures the rest of the workflow proceeds as before, including checks for AI-generated changes.
  - Reduces PR noise by avoiding YAML-level gating and failures due to missing secrets, with no impact on users who don’t use the AI docs update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->