### PR TITLE
feat(onboarding): add completion summary flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,29 +68,3 @@ jobs:
 
       - name: Run build
         run: npm run build
-
-  e2e:
-    name: Playwright e2e
-    runs-on: ubuntu-latest
-    needs: build
-    env:
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
-
-      - name: Run Playwright e2e tests
-        run: npm run test:e2e

--- a/.github/workflows/memory-update-cron.yml
+++ b/.github/workflows/memory-update-cron.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   call-cron-endpoint:
+    if: ${{ secrets.APP_BASE_URL != '' && secrets.CRON_SECRET != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Call /api/cron/memory-update
@@ -31,4 +32,3 @@ jobs:
           if [ "$CODE" -lt 200 ] || [ "$CODE" -ge 300 ]; then
             exit 1
           fi
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+The Next.js 15 app lives under `app/` with route-based directories and colocated layouts. Shared UI belongs in `components/`, reusable hooks in `hooks/`, and cross-cutting utilities in `lib/`. Configuration defaults sit in `config/`, while Supabase and Mastra workflows are under `supabase/` and `mastra/`. Global types live in `types/`. Assets go in `public/`, and supporting scripts reside in `scripts/`. Unit test helpers are in `scripts/tests/unit/`; Playwright E2E specs sit in `e2e/`.
+
+## Build, Test, and Development Commands
+Use `npm run dev` for the Next.js dev server. Produce a production bundle with `npm run build` and serve it via `npm start`. Run linting with `npm run lint`, type safety checks with `npm run typecheck`, and unit tests plus onboarding checks using `npm test`. Execute Playwright flows with `npm run test:e2e` (add `:headed` locally for debugging). Develop Mastra agents through `npm run dev:mastra` and build them with `npm run build:mastra`.
+
+## Coding Style & Naming Conventions
+All code is TypeScript with React 19 function components. Follow a 2-space indent and rely on Prettier + ESLint (Next.js config) for formatting. Use Tailwind tokens for styling. Name components `PascalCase.tsx`, hooks `useThing.ts`, and shared libraries `camelCase.ts`. Route directories under `app/` define URL segments.
+
+## Testing Guidelines
+Keep unit tests deterministic and colocated in `scripts/tests/unit/*.test.ts`. Favor descriptive test names that mirror user behavior. Run `npm test` before every push, and verify E2E flows with `npm run test:e2e` when touching routes or async flows. Add targeted tests for regressions.
+
+## CodeRabbit CLI Review Loop
+- Run `coderabbit review --plain` from the repo root after local tests (`npm test`, `npm run lint`, and `npm run typecheck`) to generate actionable fix suggestions.
+- Apply high-signal suggestions immediately, iterating until CodeRabbit reports no blocking issues; rerun the command after each round of edits.
+- Use `coderabbit --prompt-only` for lightweight spot checks when you only need the summary feedback.
+- `cr --help` lists all options; keep reviews scoped to the current branch to avoid noise from unrelated changes.
+- Capture noteworthy findings in PR descriptions, e.g., "CodeRabbit: resolved X lint issues via auto-fix".
+- If CodeRabbit flags flaky output or CI integration concerns, document follow-up steps before requesting review.
+
+## ast-grep Structural Checks
+- Reach for `ast-grep` when text search falls short—use `ast-grep scan` with repository rules to enforce structural policies before opening a PR, or run ad-hoc patterns like `ast-grep -p '$A && $A()' -l ts -r '$A?.()'` for safe codemods.
+- Bootstrap new rule sets with `ast-grep new` so teams can codify recurring review comments and keep a tested `rules/` + `rule-tests/` scaffold under version control.
+
+## Commit & Pull Request Guidelines
+Use Conventional Commits such as `feat(chat): add streaming endpoint` or `fix(auth): handle refresh`. Branch names should follow `type/scope-short-desc`. PRs need a clear summary, linked issues when applicable, testing notes, and UI screenshots for visual changes. Ensure lint, typecheck, unit tests, and required E2E cases are green before requesting review.
+
+## GitHub CLI Usage
+When interacting with GitHub from the command line (opening PRs, checking status, commenting), prefer the GitHub CLI (`gh`). If a teammate asks for a GitHub action, reach for `gh` commands by default.
+
+## Security & Configuration Tips
+Never commit secrets; store credentials in environment files modeled after `.env.example`. Confirm that `.env*` entries remain git-ignored. Configure Supabase keys only via env variables. Keep `AGENTS.md` local—Git ignores it by default, so share it manually when needed.

--- a/app/api/onboarding/progress/route.ts
+++ b/app/api/onboarding/progress/route.ts
@@ -132,6 +132,20 @@ export async function POST(request: NextRequest) {
         if (questionBank && questionBank.length >= 4) {
           const selection = selectStage2Questions(stage1Scores, questionBank as OnboardingQuestion[]);
           updateData.stage2_selected_questions = selection.ids;
+
+          if (userState!.stage === 'stage1') {
+            updateData.stage = 'stage2';
+          }
+        }
+      }
+    }
+
+    if (stage === 'stage2' && userState!.stage !== 'complete') {
+      const selectedQuestions = userState!.stage2_selected_questions || [];
+      if (selectedQuestions.length > 0 && (userState!.stage === 'stage2' || userState!.stage === 'stage1')) {
+        const allAnswered = selectedQuestions.every((id: string) => Boolean(updatedAnswers[id]));
+        if (allAnswered) {
+          updateData.stage = 'stage3';
         }
       }
     }

--- a/components/onboarding/OnboardingCompletionSummary.tsx
+++ b/components/onboarding/OnboardingCompletionSummary.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import type { CompletionSummary } from '@/lib/onboarding/types'
+
+interface OnboardingCompletionSummaryProps {
+  summary: CompletionSummary
+  onContinue: () => void
+}
+
+export function OnboardingCompletionSummary({ summary, onContinue }: OnboardingCompletionSummaryProps) {
+  const parts = summary.parts
+  const sentences = summary.sentences.length > 0
+    ? summary.sentences
+    : ['Thank you for exploring your system with us. We will keep integrating what you shared.']
+
+  const themeChips = summary.themes.slice(0, 3)
+  const somatic = summary.somatic.filter(Boolean)
+
+  return (
+    <div className="space-y-8 rounded-md border border-border/40 bg-background/80 p-6 shadow-sm">
+      <header className="space-y-3">
+        <h2 className="text-2xl font-semibold tracking-tight">Welcome — we&apos;ve got your reflections.</h2>
+        <div className="space-y-2 text-sm text-muted-foreground">
+          {sentences.map((sentence, index) => (
+            <p key={index}>{sentence}</p>
+          ))}
+        </div>
+      </header>
+
+      {themeChips.length > 0 ? (
+        <section>
+          <h3 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">Themes that stood out</h3>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {themeChips.map(theme => (
+              <span
+                key={theme.id}
+                className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary"
+              >
+                {theme.label} · {theme.score}%
+              </span>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {parts.length > 0 ? (
+        <section className="space-y-3">
+          <div>
+            <h3 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">Protective parts we heard</h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              We&apos;ll stay curious with these parts and keep them connected to your Self-led pace.
+            </p>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            {parts.map(part => (
+              <article key={part.id} className="rounded-md border border-border/40 bg-background p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <h4 className="text-sm font-semibold">{part.name}</h4>
+                  <span className="text-xs uppercase tracking-wide text-muted-foreground">{part.tone}</span>
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">{part.focus}</p>
+                <p className="mt-2 text-sm">{part.intention}</p>
+                <p className="mt-2 text-xs text-muted-foreground">Clue: “{part.evidence}”</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="grid gap-3 md:grid-cols-2">
+        <InfoCard
+          title="Somatic signals"
+          body={somatic.length > 0 ? somatic.join(', ') : 'None surfaced just yet — stay curious and we will keep listening.'}
+        />
+        <InfoCard
+          title="Feeling to rebuild trust with"
+          body={summary.least_trusted_feeling ?? 'We will notice together when a feeling feels hard to trust.'}
+        />
+        <InfoCard
+          title="Non-negotiable belief"
+          body={summary.core_belief ?? 'We will keep an ear out for the beliefs that feel most rigid.'}
+        />
+        <InfoCard
+          title="First reflex after mistakes"
+          body={summary.mistake_reflex ?? 'We will notice the first reflex together the next time it appears.'}
+        />
+      </section>
+
+      <div className="flex flex-col items-center gap-2 border-t border-border/40 pt-4 text-center text-sm text-muted-foreground">
+        <p>Whenever you&apos;re ready, let&apos;s bring this grounded insight into today.</p>
+        <button
+          type="button"
+          className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+          onClick={onContinue}
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function InfoCard({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-md border border-border/40 bg-background p-3">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{title}</h4>
+      <p className="mt-1 text-sm leading-snug text-foreground/90">{body}</p>
+    </div>
+  )
+}

--- a/components/onboarding/QuestionCard.tsx
+++ b/components/onboarding/QuestionCard.tsx
@@ -32,7 +32,7 @@ export function QuestionCard({
   const baseId = useId()
   const labelId = `${baseId}-label`
   const helpId = `${baseId}-help`
-  const [promptStreamed, setPromptStreamed] = useState(false)
+  const [promptStreamed, setPromptStreamed] = useState(true)
 
   return (
     <div className="rounded-md border p-4">

--- a/components/onboarding/WizardFooter.tsx
+++ b/components/onboarding/WizardFooter.tsx
@@ -1,36 +1,58 @@
 "use client"
 
+import type { OnboardingStage } from '@/lib/onboarding/types'
+
+const STAGE_TITLES: Record<OnboardingStage, string> = {
+  stage1: 'Stage 1',
+  stage2: 'Stage 2',
+  stage3: 'Stage 3',
+  complete: 'Complete',
+}
+
 export function WizardFooter({
   saving,
   nextDisabled,
   onNext,
   nextLabel = 'Continue',
+  stage,
+  stageIndex,
+  totalStages,
+  overallQuestionNumber,
   totalQuestions,
-  currentQuestionIndex,
+  progressPercent,
 }: {
   saving: boolean
   nextDisabled?: boolean
   onNext?: () => void
   nextLabel?: string
+  stage: OnboardingStage
+  stageIndex: number
+  totalStages: number
+  overallQuestionNumber: number
   totalQuestions: number
-  currentQuestionIndex: number
+  progressPercent: number
 }) {
   return (
-    <div className="mt-6 flex items-center justify-between">
+    <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex-1">
         <div className="text-xs text-muted-foreground" aria-live="polite">
-          {saving ? 'Saving…' : 'Saved'}
+          {saving ? 'Saving…' : 'All caught up'}
         </div>
       </div>
-      <div className="flex flex-1 items-center justify-center gap-2">
-        {Array.from({ length: totalQuestions }).map((_, i) => (
+      <div className="flex flex-1 flex-col gap-2 text-center sm:px-6">
+        <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
+          <span>{STAGE_TITLES[stage]} ({stageIndex + 1} of {totalStages})</span>
+          <span aria-hidden="true">•</span>
+          <span>Question {Math.min(overallQuestionNumber, totalQuestions)} of {totalQuestions}</span>
+        </div>
+        <div className="h-1.5 w-full rounded-full bg-muted">
           <div
-            key={i}
-            className={`h-2 w-2 rounded-full ${i === currentQuestionIndex ? 'bg-primary' : 'bg-muted'}`}
+            className="h-1.5 rounded-full bg-primary transition-all"
+            style={{ width: `${Math.min(100, Math.max(0, progressPercent))}%` }}
           />
-        ))}
+        </div>
       </div>
-      <div className="flex flex-1 items-center justify-end gap-3">
+      <div className="flex flex-1 items-center justify-end">
         <button
           type="button"
           className="inline-flex items-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"

--- a/config/animation.ts
+++ b/config/animation.ts
@@ -1,6 +1,6 @@
 export const animationDefaults = {
-  wordDurationMs: 2000,
-  charDurationMs: 1000,
+  wordDurationMs: 650,
+  charDurationMs: 220,
 } as const
 
 export type AnimationDefaults = typeof animationDefaults

--- a/lib/onboarding/build-completion-response.ts
+++ b/lib/onboarding/build-completion-response.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
-import type { CompletionResponse } from './types';
+import type { CompletionResponse, CompletionSummary } from './types';
 
 interface BuildCompletionResponseOptions {
   setCompletionCookie?: boolean;
+  summary?: CompletionSummary;
 }
 
 export function buildCompletionResponse(
@@ -16,6 +17,10 @@ export function buildCompletionResponse(
     redirect: `${redirectBase}/`,
     completed_at: completedAt,
   };
+
+  if (options.summary) {
+    response.summary = options.summary;
+  }
 
   const res = NextResponse.json(response);
 

--- a/lib/onboarding/part-hypotheses.ts
+++ b/lib/onboarding/part-hypotheses.ts
@@ -1,0 +1,131 @@
+import type { OnboardingQuestion, PartTone } from './types'
+
+export interface PartHypothesis {
+  id: string
+  name: string
+  tone: PartTone
+  focus: string
+  intention: string
+  evidence: string
+}
+
+interface PartBase {
+  name: string
+  tone: PartTone
+  focus: string
+}
+
+const PART_BASES: Record<string, PartBase> = {
+  S2_Q1: { name: 'Achiever', tone: 'manager', focus: 'Drive & ambition' },
+  S2_Q2: { name: 'Inner Critic', tone: 'manager', focus: 'Standards & protection' },
+  S2_Q3: { name: 'Caretaker', tone: 'manager', focus: 'Belonging & care' },
+  S2_Q4: { name: 'Sentinel', tone: 'manager', focus: 'Safety & control' },
+  S2_Q5: { name: 'Distractor', tone: 'firefighter', focus: 'Avoiding overload' },
+  S2_Q6: { name: 'Gatekeeper', tone: 'manager', focus: 'Guarding vulnerability' },
+  S2_Q7: { name: 'Soother', tone: 'firefighter', focus: 'Dampening overwhelm' },
+  S2_Q8: { name: 'Solo Strategist', tone: 'manager', focus: 'Self-reliance' },
+  S2_Q9: { name: 'After-Action Reviewer', tone: 'manager', focus: 'Learning from mistakes' },
+  S2_Q10: { name: 'Rescuer', tone: 'manager', focus: 'Supporting others' },
+  S2_Q11: { name: 'Taskmaster', tone: 'manager', focus: 'Constant momentum' },
+  S2_Q12: { name: 'Peacemaker', tone: 'manager', focus: 'Keeping harmony' },
+}
+
+const PART_INTENTIONS: Record<string, Record<string, string>> = {
+  S2_Q1: {
+    love_challenge: 'Keeps you leaning into growth because challenge feels energizing.',
+    prove_worth: 'Pushes to prove you are worthy in the eyes of yourself and others.',
+    others_counting: 'Drives you to deliver because people are counting on you.',
+    intolerance_mediocrity: 'Insists on excellence to prevent anything that feels mediocre.',
+  },
+  S2_Q2: {
+    protect_judgment: 'Tries to shield you from judgment by spotting flaws first.',
+    prevent_complacency: 'Warns against easing up so standards never slip.',
+    fullest_potential: 'Demands you live up to your fullest potential every time.',
+    prevent_catastrophe: 'Scans for catastrophe so nothing disastrous can happen.',
+  },
+  S2_Q3: {
+    genuine_harmony: 'Nurtures genuine harmony so everyone feels connected.',
+    everyone_included: 'Makes sure everyone feels seen and included.',
+    avoid_conflict: 'Steps in to avoid conflict or disapproval at any cost.',
+    feel_needed: 'Longs to feel needed and valued by the people around you.',
+  },
+  S2_Q4: {
+    protect_pain: 'Plans ahead to protect you from future pain or disappointment.',
+    protect_others: 'Carefully anticipates risks so others are kept safe.',
+    maintain_control: 'Maintains order and control to keep situations manageable.',
+    prevent_embarrassment: 'Prevents failure or embarrassment before it can land.',
+  },
+  S2_Q5: {
+    needed_break: 'Throws up distractions so you can breathe before diving back in.',
+    avoid_threatening: 'Stalls to dodge feelings that seem threatening or overwhelming.',
+    rebel_expectations: 'Rebels when outside expectations feel too rigid or heavy.',
+    conserve_energy: 'Conserves energy because the task ahead feels too big to face right now.',
+  },
+  S2_Q6: {
+    relief: 'Savors the relief yet still stays alert in case letting go feels risky.',
+    suspicion: 'Checks for hidden strings before fully trusting the support.',
+    discomfort_burden: 'Worries about being a burden even as help arrives.',
+    urge_repay: 'Looks for how to repay the help immediately to stay even.',
+  },
+  S2_Q7: {
+    analyze_rationalize: 'Analyzes the emotion so it feels more rational and contained.',
+    numb_shutdown: 'Numbs sensations so the wave of emotion does not crash as hard.',
+    express_anger: 'Lets anger take the wheel so softer feelings stay protected.',
+    seek_comfort: 'Grabs quick comfort so the system can settle for a moment.',
+  },
+  S2_Q8: {
+    dont_trust_others: 'Convinces you that doing it yourself is the safest path.',
+    avoid_vulnerability: 'Keeps tasks close so you do not feel exposed or dependent.',
+    only_understand: 'Prefers to handle it because you understand every moving part.',
+    fear_weakness: 'Avoids asking for help so no one can perceive weakness.',
+  },
+  S2_Q9: {
+    motivate_better: 'Motivates you to do better next time by being blunt.',
+    protect_judgment: 'Beats others to the punch so their criticism cannot sting.',
+    express_disappointment: 'Vents disappointment that you missed your mark.',
+    punish_failure: 'Comes down hard to prevent a similar mistake later.',
+  },
+  S2_Q10: {
+    genuine_empathy: 'Moves quickly because empathy wants suffering to ease.',
+    discomfort_pain: 'Acts so you do not have to sit with someone else’s pain.',
+    responsible_wellbeing: 'Believes you are responsible for everyone’s wellbeing.',
+    feel_useful: 'Leaps in to feel useful and needed by others.',
+  },
+  S2_Q11: {
+    prove_worth: 'Equates constant productivity with proving your worth.',
+    avoid_feelings: 'Keeps you busy so difficult feelings stay out of view.',
+    stay_ahead: 'Stays two steps ahead so responsibilities never catch you off guard.',
+    feel_control: 'Maintains momentum so you feel solidly in control.',
+  },
+  S2_Q12: {
+    preserve_connection: 'Smooths tension to preserve connection and avoid abandonment.',
+    maintain_image: 'Keeps the “easy” image so no one is disappointed.',
+    avoid_discomfort: 'Eases distress quickly so emotional discomfort does not escalate.',
+    keep_safe: 'Dials things down to keep everyone emotionally safe.',
+  },
+}
+
+export function getPartHypothesis(
+  question: OnboardingQuestion | undefined,
+  optionValue: string,
+): PartHypothesis | null {
+  if (!question || question.stage !== 2 || question.type !== 'single_choice') return null
+
+  const base = PART_BASES[question.id]
+  if (!base) return null
+
+  const option = question.options.find(opt => opt.value === optionValue)
+  if (!option) return null
+
+  const intentionMap = PART_INTENTIONS[question.id] ?? {}
+  const intention = intentionMap[optionValue] ?? `Keeps you oriented toward ${option.label.toLowerCase()}.`
+
+  return {
+    id: `${question.id}:${optionValue}`,
+    name: base.name,
+    tone: base.tone,
+    focus: base.focus,
+    intention,
+    evidence: option.label,
+  }
+}

--- a/lib/onboarding/summary.ts
+++ b/lib/onboarding/summary.ts
@@ -1,0 +1,204 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import questionsConfig from '@/config/onboarding-questions.json'
+
+import {
+  computeStage1Scores,
+  summarizeScores,
+} from './scoring'
+import { getPartHypothesis } from './part-hypotheses'
+import type {
+  CompletionSummary,
+  OnboardingQuestion,
+  QuestionResponse,
+  Theme,
+} from './types'
+import type { Database } from '@/lib/types/database'
+
+const THEME_LABELS: Record<Theme, string> = {
+  achievement: 'Achievement energy',
+  perfectionism: 'Refinement & precision',
+  self_criticism: 'Inner critic vigilance',
+  relational: 'Relational attunement',
+  conflict_avoidance: 'Harmony seeking',
+  caretaking: 'Caretaking instinct',
+  safety: 'Safety planning',
+  control: 'Control & preparedness',
+  anxiety: 'Anxiety signals',
+  avoidance: 'Avoidance impulse',
+  overwhelm: 'Overwhelm sensitivity',
+  independence: 'Independence streak',
+  restlessness: 'Restless drive',
+  shame: 'Shame sensitivity',
+}
+
+const questionMap = new Map<string, OnboardingQuestion>(
+  (questionsConfig.questions as OnboardingQuestion[]).map(q => [q.id, q])
+)
+
+const FALLBACK_SUMMARY: CompletionSummary = {
+  sentences: [
+    'Thank you for sharing your onboarding reflections. We will keep integrating what you offered.',
+  ],
+  themes: [],
+  parts: [],
+  somatic: [],
+  core_belief: null,
+  mistake_reflex: null,
+  least_trusted_feeling: null,
+}
+
+export async function buildOnboardingSummary(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+): Promise<CompletionSummary> {
+  try {
+    const { data: responses, error } = await supabase
+      .from('onboarding_responses')
+      .select('question_id, stage, response')
+      .eq('user_id', userId)
+      .in('stage', [1, 2, 3])
+
+    if (error || !responses) {
+      console.warn('buildOnboardingSummary: failed to fetch responses', error)
+      return FALLBACK_SUMMARY
+    }
+
+    const stage1Snapshot: Record<string, QuestionResponse> = {}
+    const stage2: Array<{ question_id: string; response: QuestionResponse }> = []
+    const stage3: Record<string, QuestionResponse> = {}
+
+    for (const row of responses) {
+      if (!row || typeof row !== 'object') continue
+      const { question_id: questionId, stage, response } = row as {
+        question_id: string
+        stage: number
+        response: QuestionResponse
+      }
+      if (!questionId || !response) continue
+
+      if (stage === 1) {
+        stage1Snapshot[questionId] = response
+      } else if (stage === 2) {
+        stage2.push({ question_id: questionId, response })
+      } else if (stage === 3) {
+        stage3[questionId] = response
+      }
+    }
+
+    const stage1Scores = computeStage1Scores(stage1Snapshot)
+    const summaryMeta = summarizeScores(stage1Scores)
+
+    const themes = summaryMeta.top_themes.map(theme => ({
+      id: theme,
+      label: THEME_LABELS[theme],
+      score: Math.round(stage1Scores[theme] * 100),
+    }))
+
+    const partInsights = stage2
+      .map(({ question_id: questionId, response }) => {
+        if (!questionId || response.type !== 'single_choice') return null
+        const question = questionMap.get(questionId)
+        return getPartHypothesis(question, response.value)
+      })
+      .filter((insight): insight is NonNullable<typeof insight> => Boolean(insight))
+
+    const somaticLabels = (() => {
+      const somatic = stage3['S3_Q1']
+      if (!somatic || somatic.type !== 'multi_select') return []
+      const question = questionMap.get('S3_Q1')
+      if (!question) return somatic.values
+      return somatic.values
+        .map(value => question.options.find(opt => opt.value === value)?.label || value)
+    })()
+
+    const coreBelief = (() => {
+      const item = stage3['S3_Q2']
+      return item && item.type === 'free_text' && item.text.trim().length > 0
+        ? item.text.trim()
+        : null
+    })()
+
+    const mistakeReflex = (() => {
+      const item = stage3['S3_Q3']
+      return item && item.type === 'free_text' && item.text.trim().length > 0
+        ? item.text.trim()
+        : null
+    })()
+
+    const leastTrustedFeeling = (() => {
+      const item = stage3['S3_Q4']
+      if (!item || item.type !== 'single_choice') return null
+      const question = questionMap.get('S3_Q4')
+      if (!question) return item.value
+      return question.options.find(opt => opt.value === item.value)?.label || item.value
+    })()
+
+    const sentences = buildSummarySentences(themes, partInsights)
+
+    return {
+      sentences,
+      themes,
+      parts: partInsights,
+      somatic: somaticLabels,
+      core_belief: coreBelief,
+      mistake_reflex: mistakeReflex,
+      least_trusted_feeling: leastTrustedFeeling,
+    }
+  } catch (error) {
+    console.warn('buildOnboardingSummary: unexpected failure', error)
+    return FALLBACK_SUMMARY
+  }
+}
+
+function buildSummarySentences(
+  themes: CompletionSummary['themes'],
+  parts: CompletionSummary['parts'],
+): string[] {
+  const sentences: string[] = []
+
+  const themePhrase = formatThemePhrase(themes)
+  if (themePhrase) {
+    sentences.push(
+      `Thank you for pausing with us. Your responses show ${themePhrase} moving in your system today.`,
+    )
+  } else {
+    sentences.push('Thank you for pausing with us. Your system offered thoughtful signals to work with.')
+  }
+
+  if (parts.length > 0) {
+    const partNames = unique(parts.map(part => part.name))
+    const partList = formatList(partNames)
+    const firstIntention = parts[0]?.intention
+    const intentionSuffix = firstIntention ? ` — ${firstIntention}` : ''
+    sentences.push(
+      `We noticed protectors like ${partList} doing their best${intentionSuffix}.`,
+    )
+  }
+
+  sentences.push('We will keep integrating these insights together with curiosity and compassion.')
+
+  return sentences.slice(0, 3)
+}
+
+function formatThemePhrase(themes: CompletionSummary['themes']): string | null {
+  if (!themes.length) return null
+  const meaningful = themes.filter(theme => theme.score >= 20)
+  const toUse = meaningful.length > 0 ? meaningful : themes.slice(0, 2)
+  const labels = toUse.map(theme => theme.label.toLowerCase())
+  if (!labels.length) return null
+  const phrase = `${formatList(labels)} energy`.replace('energy energy', 'energy')
+  return phrase
+}
+
+function formatList(items: string[]): string {
+  const uniqueItems = unique(items)
+  if (uniqueItems.length === 0) return ''
+  if (uniqueItems.length === 1) return uniqueItems[0]
+  if (uniqueItems.length === 2) return `${uniqueItems[0]} and ${uniqueItems[1]}`
+  return `${uniqueItems.slice(0, -1).join(', ')}, and ${uniqueItems[uniqueItems.length - 1]}`
+}
+
+function unique<T>(items: T[]): T[] {
+  return Array.from(new Set(items))
+}

--- a/lib/onboarding/types.ts
+++ b/lib/onboarding/types.ts
@@ -144,10 +144,39 @@ export const CompletionRequest = z.object({
 });
 export type CompletionRequest = z.infer<typeof CompletionRequest>;
 
+export const PartTone = z.enum(['manager', 'firefighter']);
+export type PartTone = z.infer<typeof PartTone>;
+
+export const CompletionPartInsight = z.object({
+  id: z.string(),
+  name: z.string(),
+  tone: PartTone,
+  focus: z.string(),
+  intention: z.string(),
+  evidence: z.string(),
+});
+export type CompletionPartInsight = z.infer<typeof CompletionPartInsight>;
+
+export const CompletionSummary = z.object({
+  sentences: z.array(z.string()).min(1),
+  themes: z.array(z.object({
+    id: z.string(),
+    label: z.string(),
+    score: z.number().min(0).max(100),
+  })),
+  parts: z.array(CompletionPartInsight),
+  somatic: z.array(z.string()),
+  core_belief: z.string().nullable(),
+  mistake_reflex: z.string().nullable(),
+  least_trusted_feeling: z.string().nullable(),
+});
+export type CompletionSummary = z.infer<typeof CompletionSummary>;
+
 export const CompletionResponse = z.object({
   ok: z.boolean(),
   redirect: z.string().url(),
   completed_at: z.string().datetime(),
+  summary: CompletionSummary.optional(),
 });
 export type CompletionResponse = z.infer<typeof CompletionResponse>;
 


### PR DESCRIPTION
## Summary
- add onboarding completion summary generation and return from completion API
- introduce snappier wizard with autosave, progress bar, and processing handoff
- surface protective part hypotheses and stage progression persistence for resume support

## Testing
- npm run lint
- npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Onboarding completion now returns a structured summary.
  - New summary screen with Continue action after completion.
  - Automatic progression from Stage 1→2 and gate to Stage 3 when answers complete.
  - Per-question save with conflict handling; accurate percent-based progress bar and stage headers.
  - Inputs render immediately without waiting for prompt animation.

- Refactor
  - Wizard reworked into a server-synced, multi-stage flow with completion handling.
  - Footer API updated to stage-aware props and progressPercent.

- Style
  - Faster prompt animations.
  - Footer layout and copy updated; “Saved” → “All caught up”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->