### PR TITLE
feat(auth): sync supabase session events

### DIFF
--- a/.github/workflows/memory-update-cron.yml
+++ b/.github/workflows/memory-update-cron.yml
@@ -11,13 +11,13 @@ permissions:
 
 jobs:
   call-cron-endpoint:
-    if: ${{ secrets.APP_BASE_URL != '' && secrets.CRON_SECRET != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Call /api/cron/memory-update
         env:
           APP_BASE_URL: ${{ secrets.APP_BASE_URL }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        if: ${{ env.APP_BASE_URL != '' && env.CRON_SECRET != '' }}
         run: |
           if [ -z "$APP_BASE_URL" ] || [ -z "$CRON_SECRET" ]; then
             echo "APP_BASE_URL or CRON_SECRET not configured in repo secrets" >&2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ All code is TypeScript with React 19 function components. Follow a 2-space inden
 
 ## Testing Guidelines
 Keep unit tests deterministic and colocated in `scripts/tests/unit/*.test.ts`. Favor descriptive test names that mirror user behavior. Run `npm test` before every push, and verify E2E flows with `npm run test:e2e` when touching routes or async flows. Add targeted tests for regressions.
+- After finishing the feature or fix that was requested, run `npm run lint`, `npm run typecheck`, and `npm test` before pushing or asking for review so we hand off a fully verified branch.
 
 ## CodeRabbit CLI Review Loop
 - Run `coderabbit review --plain` from the repo root after local tests (`npm test`, `npm run lint`, and `npm run typecheck`) to generate actionable fix suggestions.

--- a/app/api/onboarding/progress/route.ts
+++ b/app/api/onboarding/progress/route.ts
@@ -142,7 +142,7 @@ export async function POST(request: NextRequest) {
 
     if (stage === 'stage2' && userState!.stage !== 'complete') {
       const selectedQuestions = userState!.stage2_selected_questions || [];
-      if (selectedQuestions.length > 0 && (userState!.stage === 'stage2' || userState!.stage === 'stage1')) {
+      if (selectedQuestions.length > 0 && userState!.stage === 'stage2') {
         const allAnswered = selectedQuestions.every((id: string) => Boolean(updatedAnswers[id]));
         if (allAnswered) {
           updateData.stage = 'stage3';

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { BASE_URL } from '@/config/app'
 import { createClient } from '@/lib/supabase/server'
 import type { Session } from '@supabase/supabase-js'
 
@@ -50,19 +51,116 @@ type AuthCallbackPayload = {
   session?: Session | null
 }
 
+const allowedEvents = new Set(['SIGNED_IN', 'TOKEN_REFRESHED', 'SIGNED_OUT'])
+
+function normalizeOrigin(origin: string | null): string | null {
+  if (!origin) {
+    return null
+  }
+  try {
+    return new URL(origin).origin
+  } catch {
+    return null
+  }
+}
+
+function buildAllowedOriginsFromRequest(request: Request): Set<string> {
+  const { origin } = new URL(request.url)
+
+  const candidates: Array<string | null | undefined> = [
+    origin,
+    BASE_URL,
+    process.env.APP_BASE_URL,
+    process.env.NEXT_PUBLIC_APP_URL,
+    process.env.BASE_URL,
+    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null,
+  ]
+
+  return new Set(
+    candidates
+      .map((value) => normalizeOrigin(value ?? null))
+      .filter((value): value is string => Boolean(value))
+  )
+}
+
+function isAllowedOrigin(request: Request) {
+  const originHeader = request.headers.get('origin')
+  if (!originHeader) {
+    return true
+  }
+
+  const normalized = normalizeOrigin(originHeader)
+  if (!normalized) {
+    return false
+  }
+
+  const allowedOrigins = buildAllowedOriginsFromRequest(request)
+  return allowedOrigins.has(normalized)
+}
+
 export async function POST(request: Request) {
   try {
+    if (!isAllowedOrigin(request)) {
+      console.warn('Auth callback POST rejected due to disallowed origin', {
+        origin: request.headers.get('origin'),
+      })
+      return NextResponse.json({ success: false }, { status: 403 })
+    }
+
     const { event, session } = (await request.json()) as AuthCallbackPayload
     const supabase = await createClient()
 
+    if (!event || !allowedEvents.has(event)) {
+      console.warn('Auth callback POST received unsupported event', { event })
+      return NextResponse.json({ success: true })
+    }
+
     if (event === 'SIGNED_OUT') {
       await supabase.auth.signOut()
-    } else if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
-      if (session) {
-        await supabase.auth.setSession(session)
-      } else {
-        console.warn('Auth callback POST missing session for event:', event)
-      }
+      return NextResponse.json({ success: true })
+    }
+
+    const {
+      data: { session: existingSession },
+    } = await supabase.auth.getSession()
+
+    if (!session?.access_token) {
+      console.warn('Auth callback POST missing access token', { event })
+      return NextResponse.json({ success: false }, { status: 400 })
+    }
+
+    const refreshToken = session.refresh_token ?? existingSession?.refresh_token
+    if (!refreshToken) {
+      console.warn('Auth callback POST missing refresh token with no fallback available', { event })
+      return NextResponse.json({ success: false }, { status: 400 })
+    }
+
+    const {
+      data: userData,
+      error: userError,
+    } = await supabase.auth.getUser(session.access_token)
+
+    if (userError || !userData?.user) {
+      console.error('Auth callback failed to verify session user', userError)
+      return NextResponse.json({ success: false }, { status: 401 })
+    }
+
+    if (session.user?.id && session.user.id !== userData.user.id) {
+      console.error('Auth callback session user mismatch', {
+        expected: session.user.id,
+        actual: userData.user.id,
+      })
+      return NextResponse.json({ success: false }, { status: 403 })
+    }
+
+    const { error: setSessionError } = await supabase.auth.setSession({
+      access_token: session.access_token,
+      refresh_token: refreshToken,
+    })
+
+    if (setSessionError) {
+      console.error('Auth callback failed to persist session', setSessionError)
+      return NextResponse.json({ success: false }, { status: 500 })
     }
 
     return NextResponse.json({ success: true })

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@/components/theme-provider'
 import { ComingSoonProvider } from '@/components/common/ComingSoonProvider'
 import { GlobalBackdrop } from '@/components/ethereal/GlobalBackdrop'
 import { ThemeController } from '@/components/ethereal/ThemeController'
+import { SupabaseSessionListener } from '@/components/auth/supabase-session-listener'
 import { UserProvider } from '@/context/UserContext'
 
 export const metadata: Metadata = {
@@ -29,6 +30,7 @@ export default function RootLayout({
             </UserProvider>
           </ComingSoonProvider>
         </ThemeProvider>
+        <SupabaseSessionListener />
       </body>
     </html>
   )

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,11 +26,11 @@ export default function RootLayout({
               {/* Global ethereal backdrop & theme controller */}
               <GlobalBackdrop />
               <ThemeController />
+              <SupabaseSessionListener />
               {children}
             </UserProvider>
           </ComingSoonProvider>
         </ThemeProvider>
-        <SupabaseSessionListener />
       </body>
     </html>
   )

--- a/components/auth/supabase-session-listener.tsx
+++ b/components/auth/supabase-session-listener.tsx
@@ -2,27 +2,51 @@
 
 import { useEffect } from 'react'
 
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
+
 import { createClient } from '@/lib/supabase/client'
 
 export function SupabaseSessionListener() {
   useEffect(() => {
     const supabase = createClient()
 
-    const { data: subscription } = supabase.auth.onAuthStateChange(
-      async (event, session) => {
+    const MAX_RETRIES = 3
+    const BASE_DELAY_MS = 250
+
+    const syncSession = async (
+      event: AuthChangeEvent,
+      session: Session | null,
+    ) => {
+      for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {
         try {
-          await fetch('/auth/callback', {
+          const response = await fetch('/auth/callback', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
             },
             body: JSON.stringify({ event, session }),
           })
+
+          if (!response.ok) {
+            throw new Error(`Session sync failed with status ${response.status}`)
+          }
+
+          return
         } catch (error) {
-          console.error('Failed to sync auth session', error)
+          if (attempt === MAX_RETRIES) {
+            console.error('Failed to sync auth session after retries', error)
+            return
+          }
+
+          const backoffMs = BASE_DELAY_MS * 2 ** (attempt - 1)
+          await new Promise((resolve) => setTimeout(resolve, backoffMs))
         }
       }
-    )
+    }
+
+    const { data: subscription } = supabase.auth.onAuthStateChange(async (event, session) => {
+      await syncSession(event, session)
+    })
 
     return () => {
       subscription?.subscription.unsubscribe()

--- a/components/auth/supabase-session-listener.tsx
+++ b/components/auth/supabase-session-listener.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import { createClient } from '@/lib/supabase/client'
+
+export function SupabaseSessionListener() {
+  useEffect(() => {
+    const supabase = createClient()
+
+    const { data: subscription } = supabase.auth.onAuthStateChange(
+      async (event, session) => {
+        try {
+          await fetch('/auth/callback', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ event, session }),
+          })
+        } catch (error) {
+          console.error('Failed to sync auth session', error)
+        }
+      }
+    )
+
+    return () => {
+      subscription?.subscription.unsubscribe()
+    }
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
## Summary
- add a client-side Supabase session listener that posts auth changes to the callback route
- render the listener from the root layout so auth cookies stay in sync across navigations
- update the auth callback route with a POST handler that stores or clears the Supabase session on the server

## Testing
- npm run lint *(fails: `next` binary not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cddd8fd5d88323a06b4bbb6f837f70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a global session listener that tracks authentication state changes and synchronizes them with the server.
  - Introduced a backend endpoint to receive auth events (sign-in, sign-out, token refresh) and update session state accordingly.
  - Ensures sessions are consistently maintained across the app, improving reliability after login, logout, and token refresh.
  - Provides clear success/failure responses and error handling for auth callbacks, enhancing resilience and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->