### PR TITLE
feat: harmonize today and chat widths

### DIFF
--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { GuardedLink } from '@/components/common/GuardedLink'
+import { PageContainer } from '@/components/common/PageContainer'
 import PersonaSwitcher from '@/components/dev/PersonaSwitcher'
 import { showDevToggle } from '@/config/features'
 import { CheckInCard } from '@/components/home/CheckInCard'
@@ -24,51 +25,53 @@ export default function HomePage() {
       }}
     >
       {/* Header */}
-      <header className="px-4 pt-6 pb-2 max-w-md w-full mx-auto">
-        <div
-          className="flex items-center justify-between text-sm"
-          style={{ color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.75))' }}
-        >
-          <span className="font-medium" style={{ color: 'rgba(255,255,255,var(--eth-user-opacity))' }}>{greeting}</span>
-          <GuardedLink
-            href="/profile"
-            aria-label="profile"
-            className="size-6 rounded-full border border-border/40 bg-card/20 backdrop-blur"
-          />
-        </div>
-        <div className="mt-2 flex items-center gap-2">
-          {showDevToggle && (
-            <button
-              type="button"
-              className="text-xs underline"
-              style={{ color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.7))' }}
-              onClick={() => {
-                try {
-                  localStorage.setItem('IFS_DEV_MODE', 'true')
-                } catch {}
-                location.reload()
-              }}
-            >
-              Enable Dev Mode
-            </button>
-          )}
-          <div className="ml-auto">
-            <PersonaSwitcher />
+      <header className="pt-6 pb-2">
+        <PageContainer>
+          <div
+            className="flex items-center justify-between text-sm"
+            style={{ color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.75))' }}
+          >
+            <span className="font-medium" style={{ color: 'rgba(255,255,255,var(--eth-user-opacity))' }}>{greeting}</span>
+            <GuardedLink
+              href="/profile"
+              aria-label="profile"
+              className="size-6 rounded-full border border-border/40 bg-card/20 backdrop-blur"
+            />
           </div>
-        </div>
+          <div className="mt-2 flex items-center gap-2">
+            {showDevToggle && (
+              <button
+                type="button"
+                className="text-xs underline"
+                style={{ color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.7))' }}
+                onClick={() => {
+                  try {
+                    localStorage.setItem('IFS_DEV_MODE', 'true')
+                  } catch {}
+                  location.reload()
+                }}
+              >
+                Enable Dev Mode
+              </button>
+            )}
+            <div className="ml-auto">
+              <PersonaSwitcher />
+            </div>
+          </div>
+        </PageContainer>
       </header>
 
       {/* Week Selector with Streak System */}
-      <div className="max-w-md w-full mx-auto px-4 mt-2">
+      <PageContainer className="mt-2">
         <WeekSelector 
           selectedDate={selectedDate} 
           onDateChange={setSelectedDate}
         />
-      </div>
+      </PageContainer>
 
       {/* Action cards */}
-      <main className="flex-1 px-4 py-6 flex items-start justify-center">
-        <div className="w-full max-w-md grid grid-cols-2 gap-3">
+      <main className="flex-1 py-6">
+        <PageContainer className="grid grid-cols-2 gap-3">
           <CheckInCard selectedDate={selectedDate} />
 
           {/* Daily meditations (spans 2 columns) */}
@@ -98,7 +101,7 @@ export default function HomePage() {
               Tap to explore more insights
             </div>
           </div>
-        </div>
+        </PageContainer>
       </main>
     </div>
   )

--- a/components/common/PageContainer.tsx
+++ b/components/common/PageContainer.tsx
@@ -1,0 +1,51 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+
+import { cn } from "@/lib/utils"
+
+const SIZE_MAP = {
+  narrow: "max-w-xl",
+  comfortable: "max-w-[52rem]",
+  wide: "max-w-5xl",
+  full: "max-w-none",
+} as const
+
+const PADDING_MAP = {
+  none: "px-0",
+  tight: "px-3 sm:px-4 md:px-6",
+  default: "px-4 sm:px-6 lg:px-8",
+} as const
+
+type PageContainerSize = keyof typeof SIZE_MAP
+type PageContainerPadding = keyof typeof PADDING_MAP
+
+type PageContainerProps = React.HTMLAttributes<HTMLDivElement> & {
+  size?: PageContainerSize
+  padding?: PageContainerPadding
+  asChild?: boolean
+}
+
+export function PageContainer({
+  className,
+  size = "comfortable",
+  padding = "default",
+  asChild = false,
+  children,
+  ...props
+}: PageContainerProps) {
+  const Component = asChild ? Slot : "div"
+
+  return (
+    <Component
+      className={cn(
+        "mx-auto w-full",
+        SIZE_MAP[size],
+        PADDING_MAP[padding],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </Component>
+  )
+}

--- a/components/ethereal/EtherealChat.tsx
+++ b/components/ethereal/EtherealChat.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "next/navigation"
 import { StreamingText } from "./StreamingText"
 import { TaskList } from "@/components/tasks/TaskList"
 import { ActiveTaskOverlay } from "./ActiveTaskOverlay"
+import { PageContainer } from "@/components/common/PageContainer"
 
 // Minimal, bubble-less chat presentation
 export function EtherealChat() {
@@ -121,8 +122,8 @@ export function EtherealChat() {
       </div>
 
       {/* Messages area */}
-      <div className="relative z-10 flex-1 overflow-y-auto px-4 pb-[120px] pt-[calc(env(safe-area-inset-top)+16px)]">
-        <div className="mx-auto flex max-w-[820px] flex-col gap-6">
+      <div className="relative z-10 flex-1 overflow-y-auto pb-[120px] pt-[calc(env(safe-area-inset-top)+16px)]">
+        <PageContainer className="flex flex-col gap-6">
           {(messages as ChatMessage[]).map((m) => (
             <motion.div
               key={m.id}
@@ -161,22 +162,22 @@ export function EtherealChat() {
             </motion.div>
           ))}
           <div ref={messagesEndRef} />
-        </div>
+        </PageContainer>
       </div>
 
       {/* Task overlay for current streaming message */}
       {currentTasks?.length ? (
-        <div className="pointer-events-none absolute inset-x-0 bottom-[calc(100px+env(safe-area-inset-bottom))] z-20 flex justify-center px-3">
-          <div className="pointer-events-auto w-full max-w-[900px]">
+        <div className="pointer-events-none absolute inset-x-0 bottom-[calc(100px+env(safe-area-inset-bottom))] z-20">
+          <PageContainer className="pointer-events-auto">
             <ActiveTaskOverlay tasks={currentTasks} />
-          </div>
+          </PageContainer>
         </div>
       ) : null}
 
       {/* Translucent input bar (always visible) */}
       <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20 pb-[calc(12px+env(safe-area-inset-bottom))]">
-        <div className="mx-auto w-full max-w-[900px] px-3">
-          <div className="pointer-events-auto rounded-2xl border border-white/15 bg-white/10 p-2 backdrop-blur-xl shadow-[0_8px_40px_rgba(0,0,0,0.25)]">
+        <PageContainer className="pointer-events-auto">
+          <div className="rounded-2xl border border-white/15 bg-white/10 p-2 backdrop-blur-xl shadow-[0_8px_40px_rgba(0,0,0,0.25)]">
             <Textarea
               ref={inputRef}
               value={text}
@@ -199,7 +200,7 @@ export function EtherealChat() {
               </Button>
             </div>
           </div>
-        </div>
+        </PageContainer>
       </div>
 
       {/* Confirm end session dialog */}


### PR DESCRIPTION
## Summary
- add shared PageContainer with width/padding variants
- clamp Today page and Ethereal chat content to the same comfortable column
- keep chat backgrounds full-bleed while aligning interactive overlays

## Testing
- npm run lint
- npm run typecheck
- npm test

## CodeRabbit
- review completed with no findings