### PR TITLE
feat: add inbox items view

### DIFF
--- a/QWEN.md
+++ b/QWEN.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -4,11 +4,12 @@ import { useState } from 'react'
 import { GuardedLink } from '@/components/common/GuardedLink'
 import { PageContainer } from '@/components/common/PageContainer'
 import PersonaSwitcher from '@/components/dev/PersonaSwitcher'
-import { showDevToggle } from '@/config/features'
+import { showDevToggle, isInboxEnabled } from '@/config/features'
 import { CheckInSlots } from '@/components/home/CheckInSlots'
 import { WeekSelector } from '@/components/home/WeekSelector'
 import { useUser } from '@/context/UserContext'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Inbox } from '@/components/inbox/Inbox'
 import { User as UserIcon } from 'lucide-react'
 
 export default function HomePage() {
@@ -18,6 +19,8 @@ export default function HomePage() {
   const avatarAlt = trimmedName ? `${trimmedName}'s avatar` : 'User avatar'
   const userInitial =
     trimmedName?.match(/\p{L}|\p{N}/u)?.[0]?.toUpperCase() ?? null
+
+  const inboxEnabled = isInboxEnabled()
   
   // Get current time for greeting
   const now = new Date()
@@ -92,35 +95,42 @@ export default function HomePage() {
         <PageContainer className="grid grid-cols-2 gap-3">
           <CheckInSlots selectedDate={selectedDate} />
 
-          {/* Daily meditations (spans 2 columns) */}
-          <div className="col-span-2 rounded-xl border border-border/40 bg-card/20 backdrop-blur p-4 mt-2">
-            <div
-              className="text-xs font-semibold"
-              style={{
-                color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.75))',
-                letterSpacing: 'var(--eth-letter-spacing-user)',
-              }}
-            >
-              DAILY MEDITATIONS
-            </div>
-            <div className="mt-3 text-sm">
-              <blockquote className="italic">“So whatever you want to do, just do it… Making a damn fool of yourself is absolutely essential.”</blockquote>
-              <div
-                className="text-xs mt-2"
-                style={{ color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.65))' }}
-              >
-                — Gloria Steinem
-              </div>
-            </div>
-            <div
-              className="mt-3 text-xs"
-              style={{ color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.65))' }}
-            >
-              Tap to explore more insights
-            </div>
-          </div>
+          {inboxEnabled ? <Inbox /> : <DailyMeditationsCard />}
         </PageContainer>
       </main>
+    </div>
+  )
+}
+
+function DailyMeditationsCard() {
+  return (
+    <div className="col-span-2 mt-2 rounded-xl border border-border/40 bg-card/20 p-4 backdrop-blur">
+      <div
+        className="text-xs font-semibold"
+        style={{
+          color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.75))',
+          letterSpacing: 'var(--eth-letter-spacing-user)',
+        }}
+      >
+        DAILY MEDITATIONS
+      </div>
+      <div className="mt-3 text-sm">
+        <blockquote className="italic">
+          “So whatever you want to do, just do it… Making a damn fool of yourself is absolutely essential.”
+        </blockquote>
+        <div
+          className="mt-2 text-xs"
+          style={{ color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.65))' }}
+        >
+          — Gloria Steinem
+        </div>
+      </div>
+      <div
+        className="mt-3 text-xs"
+        style={{ color: 'rgba(255,255,255,calc(var(--eth-user-opacity)*0.65))' }}
+      >
+        Tap to explore more insights
+      </div>
     </div>
   )
 }

--- a/app/api/inbox/clean/route.ts
+++ b/app/api/inbox/clean/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      data: [],
+      generatedAt: new Date().toISOString(),
+      variant: 'clean',
+      message: 'Clean inbox pipeline is not enabled yet. Configure Supabase edge function `inbox_feed`.',
+    },
+    { status: 501 },
+  )
+}

--- a/app/api/inbox/events/route.ts
+++ b/app/api/inbox/events/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { errorResponse, HTTP_STATUS } from '@/lib/api/response'
+import { isInboxActionsEnabled, isInboxEnabled } from '@/config/features'
+import type { InboxActionRequest } from '@/types/inbox'
+
+export async function POST(req: NextRequest) {
+  if (!isInboxEnabled()) {
+    return errorResponse('Inbox disabled', HTTP_STATUS.NOT_FOUND)
+  }
+  if (!isInboxActionsEnabled()) {
+    return errorResponse('Inbox actions disabled', HTTP_STATUS.FORBIDDEN)
+  }
+
+  const payload = (await req.json()) as InboxActionRequest
+  if (!payload?.subjectId) {
+    return errorResponse('subjectId is required', HTTP_STATUS.BAD_REQUEST)
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return errorResponse('Unauthorized', HTTP_STATUS.UNAUTHORIZED)
+  }
+
+  const eventType = payload.eventType ?? 'cta_clicked'
+  const attributes: Record<string, unknown> = {}
+  if (payload.action) attributes.action = payload.action
+  if (payload.notes) attributes.notes = payload.notes
+
+  const { error } = await supabase.from('inbox_message_events').insert({
+    subject_id: payload.subjectId,
+    user_id: user.id,
+    event_type: eventType,
+    attributes,
+  })
+
+  if (error) {
+    console.error('[api/inbox/events] failed to insert event', error)
+    return errorResponse('Failed to record inbox event', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+
+  return new NextResponse(null, { status: HTTP_STATUS.NO_CONTENT })
+}

--- a/app/api/inbox/route.ts
+++ b/app/api/inbox/route.ts
@@ -1,0 +1,220 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { isInboxEnabled } from '@/config/features'
+import { normalizeInboxResponse } from '@/lib/inbox/normalize'
+import { getPragmaticInboxFeed } from '@/lib/inbox/pragmaticData'
+
+interface SupabaseInboxPayload {
+  headline?: string | null
+  summary?: string | null
+  detail?: Record<string, unknown> | null
+  cta?: Record<string, unknown> | null
+  metadata?: Record<string, unknown> | null
+}
+
+interface SupabaseInboxRow {
+  id: string
+  type: string
+  priority: number | null
+  tags: string[] | null
+  created_at: string
+  updated_at: string | null
+  expires_at: string | null
+  inbox_message_payloads: SupabaseInboxPayload | SupabaseInboxPayload[] | null
+}
+
+export async function GET(_req: NextRequest) {
+  if (!isInboxEnabled()) {
+    return NextResponse.json({ data: [], message: 'Inbox is disabled' }, { status: 404 })
+  }
+
+  const fallback = normalizeInboxResponse(getPragmaticInboxFeed())
+
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json(
+        {
+          data: fallback,
+          source: 'fallback',
+          variant: 'pragmatic',
+          reason: 'unauthenticated',
+          generatedAt: new Date().toISOString(),
+        },
+        { status: 200 },
+      )
+    }
+
+    const { data, error } = await supabase
+      .from('inbox_message_subjects')
+      .select(
+        `id, type, priority, tags, created_at, updated_at, expires_at,
+         inbox_message_payloads (headline, summary, detail, cta, metadata)`,
+      )
+      .eq('user_id', user.id)
+      .order('priority', { ascending: false })
+      .order('created_at', { ascending: false })
+      .limit(10)
+
+    if (error) {
+      console.error('[api/inbox] supabase error', error)
+      return NextResponse.json(
+        {
+          data: fallback,
+          source: 'fallback',
+          variant: 'pragmatic',
+          reason: 'supabase_error',
+          generatedAt: new Date().toISOString(),
+        },
+        { status: 200 },
+      )
+    }
+
+    const rows = Array.isArray(data) ? data : []
+    const raw = rows.map((row) => mapSupabaseRow(row))
+    const normalized = normalizeInboxResponse(raw)
+    const payload = normalized.length ? normalized : fallback
+    const source = normalized.length ? 'supabase' : 'fallback'
+
+    return NextResponse.json(
+      {
+        data: payload,
+        source,
+        variant: 'pragmatic',
+        generatedAt: new Date().toISOString(),
+      },
+      { status: 200 },
+    )
+  } catch (error) {
+    console.error('[api/inbox] unexpected error', error)
+    return NextResponse.json(
+      {
+        data: fallback,
+        source: 'fallback',
+        variant: 'pragmatic',
+        reason: 'unexpected_error',
+        generatedAt: new Date().toISOString(),
+      },
+      { status: 200 },
+    )
+  }
+}
+
+function mapSupabaseRow(row: SupabaseInboxRow) {
+  const payloadCandidate = Array.isArray(row.inbox_message_payloads)
+    ? row.inbox_message_payloads[0]
+    : row.inbox_message_payloads
+  const base = {
+    id: row.id,
+    type: row.type,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    expiresAt: row.expires_at,
+    readAt: null,
+    source: 'supabase' as const,
+    priority: row.priority ?? undefined,
+    tags: row.tags ?? undefined,
+    actions: {
+      kind: 'boolean' as const,
+      positiveLabel: 'This resonates',
+      negativeLabel: 'Not right now',
+      allowNotes: true,
+    },
+    metadata: payloadCandidate?.metadata ?? undefined,
+  }
+
+  switch (row.type) {
+    case 'insight_spotlight':
+      return {
+        ...base,
+        payload: {
+          insightId: getMetadataString(payloadCandidate?.metadata, 'insight_id') ?? row.id,
+          title: stringOrNull(payloadCandidate?.headline) ?? 'Insight spotlight',
+          summary:
+            stringOrNull(payloadCandidate?.summary) ?? 'Tap to open the latest insight.',
+          prompt: getMetadataString(payloadCandidate?.metadata, 'prompt') ?? undefined,
+          readingTimeMinutes: getMetadataNumber(payloadCandidate?.metadata, 'reading_time_minutes'),
+          detail:
+            payloadCandidate?.detail && typeof payloadCandidate.detail === 'object'
+              ? (payloadCandidate.detail as Record<string, unknown>)
+              : undefined,
+          cta: coerceCta(payloadCandidate?.cta) ?? undefined,
+        },
+      }
+    case 'nudge':
+      return {
+        ...base,
+        payload: {
+          headline: stringOrNull(payloadCandidate?.headline) ?? 'Reminder',
+          body: stringOrNull(payloadCandidate?.summary) ?? 'Check in with yourself today.',
+          cta: coerceCta(payloadCandidate?.cta) ?? undefined,
+        },
+      }
+    case 'cta':
+      return {
+        ...base,
+        payload: {
+          title: stringOrNull(payloadCandidate?.headline) ?? 'Action needed',
+          description: stringOrNull(payloadCandidate?.summary) ?? 'Complete the suggested action.',
+          action:
+            coerceCta(payloadCandidate?.cta) ?? {
+              label: 'Open',
+              href: '/',
+            },
+        },
+      }
+    case 'notification':
+      return {
+        ...base,
+        payload: {
+          title: stringOrNull(payloadCandidate?.headline) ?? 'Notification',
+          body: stringOrNull(payloadCandidate?.summary) ?? '',
+          unread: true,
+        },
+      }
+    default:
+      return {
+        ...base,
+        payload: payloadCandidate ?? {},
+      }
+  }
+}
+
+function coerceCta(value: Record<string, unknown> | null | undefined) {
+  if (!value) return undefined
+  const label = stringOrNull(value.label)
+  if (!label) return undefined
+  return {
+    label,
+    href: stringOrNull(value.href) ?? undefined,
+    actionId: stringOrNull(value.actionId) ?? undefined,
+    intent: stringOrNull(value.intent) === 'secondary' ? 'secondary' : 'primary',
+    helperText: stringOrNull(value.helperText) ?? undefined,
+    target: stringOrNull(value.target) === '_blank' ? '_blank' : undefined,
+    analyticsTag: stringOrNull(value.analyticsTag) ?? undefined,
+  }
+}
+
+function stringOrNull(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length ? trimmed : null
+  }
+  return null
+}
+
+function getMetadataString(metadata: Record<string, unknown> | null | undefined, key: string) {
+  if (!metadata) return null
+  return stringOrNull(metadata[key])
+}
+
+function getMetadataNumber(metadata: Record<string, unknown> | null | undefined, key: string) {
+  if (!metadata) return undefined
+  const value = metadata[key]
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  return undefined
+}

--- a/be-clean/README.md
+++ b/be-clean/README.md
@@ -1,0 +1,21 @@
+# Clean Inbox Backend
+
+## Summary
+- Proposes normalized Supabase schema (`schema.sql`) for inbox subjects, payloads, and reaction events.
+- Provides edge function scaffolding (`edge-function.ts`) that maps SQL rows into `InboxEnvelope` contracts shared with the frontend.
+- Adds service client helper for secure service-role access in serverless contexts.
+
+## Reaction Logging Plan
+- `inbox_message_events` table tracks `delivered`, `opened`, `dismissed`, and `cta_clicked` events with JSON attributes for flexible metadata.
+- Edge function exposes `logInboxReaction` helper to record events from Next.js API routes or Supabase Edge Functions.
+- Analytics pipeline can later sink events into ClickHouse/BigQuery via Supabase Functions or webhooks without changing the frontend contract.
+
+## Open Questions
+- Should we denormalize insight spotlight payloads for faster reads, or keep JSONB payloads for flexibility?
+- How should we expire or archive inbox subjects once `expires_at` passes—cron job or trigger?
+
+## Verification
+- `npm run lint`
+- `npm run typecheck`
+- `npm test`
+- No runtime Supabase verification performed yet (design-time scaffolding only).

--- a/be-clean/edge-function.ts
+++ b/be-clean/edge-function.ts
@@ -1,0 +1,162 @@
+import type { InboxEnvelope } from '@/types/inbox'
+import { normalizeInboxResponse } from '@/lib/inbox/normalize'
+import { createSupabaseClient } from './supabaseClient'
+
+interface HandlerOptions {
+  userId: string
+  limit?: number
+}
+
+type InboxPayloadRow = {
+  headline?: string | null
+  summary?: string | null
+  detail?: Record<string, unknown> | null
+  cta?: Record<string, unknown> | null
+  metadata?: Record<string, unknown> | null
+}
+
+type InboxSubjectRow = {
+  id: string
+  type: InboxEnvelope['type']
+  priority: number | null
+  tags: string[] | null
+  created_at: string
+  updated_at: string | null
+  expires_at: string | null
+  payload: InboxPayloadRow | InboxPayloadRow[] | null
+}
+
+export async function fetchInboxFeed({ userId, limit = 3 }: HandlerOptions): Promise<InboxEnvelope[]> {
+  const supabase = createSupabaseClient()
+  const { data, error } = await supabase
+    .from('inbox_message_subjects')
+    .select(
+      `id, type, priority, tags, created_at, updated_at, expires_at,
+       payload:inbox_message_payloads(headline, summary, detail, cta, metadata)`
+    )
+    .eq('user_id', userId)
+    .order('priority', { ascending: false })
+    .order('created_at', { ascending: false })
+    .limit(limit)
+
+  if (error) throw error
+
+  const rows = (data as InboxSubjectRow[]) || []
+  const raw = rows.map((row) => toRawEnvelope(row))
+  return normalizeInboxResponse(raw)
+}
+
+export async function logInboxReaction({
+  userId,
+  subjectId,
+  eventType,
+  metadata,
+}: {
+  userId: string
+  subjectId: string
+  eventType: 'opened' | 'dismissed' | 'cta_clicked'
+  metadata?: Record<string, unknown>
+}) {
+  const supabase = createSupabaseClient()
+  const { error } = await supabase.from('inbox_message_events').insert({
+    subject_id: subjectId,
+    user_id: userId,
+    event_type: eventType,
+    attributes: metadata ?? {},
+  })
+  if (error) throw error
+}
+
+function toRawEnvelope(row: InboxSubjectRow) {
+  const payload = Array.isArray(row.payload) ? row.payload[0] : row.payload
+  const base = {
+    id: row.id,
+    type: row.type,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    expiresAt: row.expires_at,
+    readAt: null,
+    source: 'supabase' as const,
+    priority: row.priority ?? undefined,
+    tags: row.tags ?? undefined,
+  }
+
+  switch (row.type) {
+    case 'insight_spotlight':
+      return {
+        ...base,
+        payload: {
+          insightId: getMetadataString(payload?.metadata, 'insight_id') ?? row.id,
+          title: stringOrNull(payload?.headline) ?? stringOrNull(payload?.summary) ?? 'Insight spotlight',
+          summary: stringOrNull(payload?.summary) ?? stringOrNull(payload?.headline) ?? 'Tap to open insight detail',
+          prompt: getMetadataString(payload?.metadata, 'prompt') ?? undefined,
+          detail: payload?.detail && typeof payload.detail === 'object' ? payload.detail : undefined,
+          cta: coerceCta(payload?.cta),
+        },
+      }
+    case 'nudge':
+      return {
+        ...base,
+        payload: {
+          headline: stringOrNull(payload?.headline) ?? 'Reminder',
+          body: stringOrNull(payload?.summary) ?? 'Check in with yourself today.',
+          cta: coerceCta(payload?.cta) ?? undefined,
+        },
+      }
+    case 'cta':
+      return {
+        ...base,
+        payload: {
+          title: stringOrNull(payload?.headline) ?? 'Action needed',
+          description: stringOrNull(payload?.summary) ?? 'Complete the suggested action.',
+          action:
+            coerceCta(payload?.cta) ?? {
+              label: 'Open',
+              href: '/',
+            },
+        },
+      }
+    case 'notification':
+      return {
+        ...base,
+        payload: {
+          title: stringOrNull(payload?.headline) ?? 'Notification',
+          body: stringOrNull(payload?.summary) ?? '',
+          unread: true,
+        },
+      }
+    default:
+      return {
+        ...base,
+        payload: payload ?? {},
+      }
+  }
+}
+
+function coerceCta(value: Record<string, unknown> | null | undefined) {
+  if (!value) return undefined
+  const label = stringOrNull(value.label)
+  if (!label) return undefined
+  return {
+    label,
+    href: stringOrNull(value.href) ?? undefined,
+    actionId: stringOrNull(value.actionId) ?? undefined,
+    intent: stringOrNull(value.intent) === 'secondary' ? 'secondary' : 'primary',
+    helperText: stringOrNull(value.helperText) ?? undefined,
+    target: stringOrNull(value.target) === '_blank' ? '_blank' : undefined,
+  }
+}
+
+function stringOrNull(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length ? trimmed : null
+  }
+  return null
+}
+
+function getMetadataString(metadata: Record<string, unknown> | null | undefined, key: string) {
+  if (!metadata) return null
+  const value = metadata[key]
+  return stringOrNull(value)
+}

--- a/be-clean/schema.sql
+++ b/be-clean/schema.sql
@@ -1,0 +1,53 @@
+-- Inbox message tables (normalized)
+create type inbox_message_type as enum ('insight_spotlight', 'nudge', 'cta', 'notification');
+
+create table if not exists inbox_message_subjects (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  type inbox_message_type not null,
+  priority int2 not null default 5,
+  tags text[] default array[]::text[],
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  expires_at timestamptz
+);
+
+create table if not exists inbox_message_payloads (
+  subject_id uuid primary key references inbox_message_subjects(id) on delete cascade,
+  headline text,
+  summary text,
+  detail jsonb not null default '{}'::jsonb,
+  cta jsonb,
+  metadata jsonb not null default '{}'::jsonb
+);
+
+create table if not exists inbox_message_events (
+  id uuid primary key default gen_random_uuid(),
+  subject_id uuid not null references inbox_message_subjects(id) on delete cascade,
+  user_id uuid not null,
+  event_type text not null check (event_type in ('delivered', 'opened', 'dismissed', 'cta_clicked')),
+  occurred_at timestamptz not null default now(),
+  attributes jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_inbox_subject_user_priority
+  on inbox_message_subjects (user_id, priority desc, created_at desc);
+
+create index if not exists idx_inbox_events_subject
+  on inbox_message_events (subject_id, occurred_at desc);
+
+create policy "Users can view own inbox subjects"
+  on inbox_message_subjects
+  for select using (auth.uid() = user_id);
+
+create policy "Users manage own inbox payloads"
+  on inbox_message_payloads
+  using (auth.uid() = (select user_id from inbox_message_subjects s where s.id = subject_id));
+
+create policy "Users can insert reaction events"
+  on inbox_message_events
+  for insert with check (auth.uid() = user_id);
+
+alter table inbox_message_subjects enable row level security;
+alter table inbox_message_payloads enable row level security;
+alter table inbox_message_events enable row level security;

--- a/be-clean/supabaseClient.ts
+++ b/be-clean/supabaseClient.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js'
+
+export function createSupabaseClient() {
+  const url = process.env.SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !serviceKey) {
+    throw new Error('Missing Supabase credentials for inbox edge function')
+  }
+  return createClient(url, serviceKey)
+}

--- a/be-pragmatic/README.md
+++ b/be-pragmatic/README.md
@@ -1,0 +1,20 @@
+# Pragmatic Inbox Backend
+
+## Summary
+- Ships `/api/inbox` Next.js route that returns a hydrated inbox feed from `lib/inbox/pragmaticData`.
+- Shares envelope normalization logic with the frontend to guarantee contract safety even for mocked data.
+- Designed to swap in Supabase RPC later by replacing `getPragmaticInboxFeed()` implementation.
+
+## Seed Data
+- `lib/inbox/pragmaticData.ts` delivers the shipping feed, keeping mocks colocated with network logic for quick iteration.
+- Data tags align with the frontend registry so new message types can be toggled in one place.
+
+## Open Questions
+- Should pragmatic feed support user personalization via query params before the clean backend lands?
+- Do we need persistence for dismissals in the pragmatic path, or can we keep them session-only?
+
+## Verification
+- `npm run lint`
+- `npm run typecheck`
+- `npm test`
+- Unit coverage relies on `scripts/tests/unit/inbox-normalize.test.ts` to ensure envelopes remain well-formed.

--- a/components/inbox/Inbox.tsx
+++ b/components/inbox/Inbox.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import type { InboxFeedVariant } from '@/types/inbox'
+import { InboxShelf } from '@/components/inbox/InboxShelf'
+
+interface InboxProps {
+  variant?: InboxFeedVariant
+  className?: string
+}
+
+export function Inbox({ variant = 'pragmatic', className }: InboxProps) {
+  return <InboxShelf variant={variant} className={className} />
+}

--- a/components/inbox/InboxCardRegistry.tsx
+++ b/components/inbox/InboxCardRegistry.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import type { InboxEnvelope, InboxQuickActionValue } from '@/types/inbox'
+import { InsightSpotlightCard, type InsightSpotlightEnvelope } from '@/components/inbox/cards/InsightSpotlightCard'
+
+export interface InboxCardRegistryContext {
+  onOpen?: (envelope: InboxEnvelope) => void
+  onQuickAction?: (envelope: InboxEnvelope, action: InboxQuickActionValue) => void
+}
+
+export function renderInboxCard(envelope: InboxEnvelope, context: InboxCardRegistryContext) {
+  switch (envelope.type) {
+    case 'insight_spotlight':
+      return (
+        <InsightSpotlightCard
+          key={envelope.id}
+          envelope={envelope as InsightSpotlightEnvelope}
+          onOpen={(entry) => context.onOpen?.(entry)}
+          onQuickAction={(entry, action) => context.onQuickAction?.(entry, action)}
+        />
+      )
+    case 'nudge':
+    case 'cta':
+    case 'notification':
+    default:
+      return (
+        <div
+          key={envelope.id}
+          className="rounded-xl border border-border/40 bg-card/10 p-4 text-xs text-foreground/60"
+        >
+          Additional inbox content type {envelope.type} is not implemented yet.
+        </div>
+      )
+  }
+}

--- a/components/inbox/InboxShelf.tsx
+++ b/components/inbox/InboxShelf.tsx
@@ -1,0 +1,302 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { cn } from '@/lib/utils'
+import { emitInboxEvent } from '@/lib/analytics/inbox'
+import { renderInboxCard } from '@/components/inbox/InboxCardRegistry'
+import { useInboxFeed } from '@/hooks/useInboxFeed'
+import type {
+  InboxEnvelope,
+  InboxFeedVariant,
+  InboxQuickActionValue,
+} from '@/types/inbox'
+
+interface InboxShelfProps {
+  variant?: InboxFeedVariant
+  className?: string
+}
+
+export function InboxShelf({ variant = 'pragmatic', className }: InboxShelfProps) {
+  const {
+    status,
+    envelopes,
+    reload,
+    source,
+    variant: activeVariant,
+    markAsRead,
+    submitAction,
+  } = useInboxFeed({ variant })
+  const [activeEnvelope, setActiveEnvelope] = useState<InboxEnvelope | null>(null)
+  const [pendingAction, setPendingAction] = useState<{
+    envelope: InboxEnvelope
+    action: InboxQuickActionValue
+  } | null>(null)
+  const [noteDraft, setNoteDraft] = useState('')
+
+  const hasPreviewBadge = useMemo(() => source === 'fallback', [source])
+
+  const handleOpen = (envelope: InboxEnvelope) => {
+    markAsRead(envelope.id)
+    setActiveEnvelope(envelope)
+    emitInboxEvent('inbox_card_opened', {
+      envelopeId: envelope.id,
+      messageType: envelope.type,
+      source: envelope.source,
+      metadata: { variant: activeVariant },
+    })
+  }
+
+  const handleClose = () => {
+    if (activeEnvelope) {
+      emitInboxEvent('inbox_card_dismissed', {
+        envelopeId: activeEnvelope.id,
+        messageType: activeEnvelope.type,
+        source: activeEnvelope.source,
+        metadata: { variant: activeVariant },
+      })
+    }
+    setActiveEnvelope(null)
+  }
+
+  const completeQuickAction = async (
+    envelope: InboxEnvelope,
+    action: InboxQuickActionValue,
+    notes?: string,
+  ) => {
+    try {
+      await submitAction(envelope.id, action, notes)
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('[inbox] quick action failed', error)
+      }
+    } finally {
+      setPendingAction(null)
+      setNoteDraft('')
+    }
+  }
+
+  const handleQuickAction = (envelope: InboxEnvelope, action: InboxQuickActionValue) => {
+    markAsRead(envelope.id)
+    if (envelope.actions?.kind === 'boolean' && envelope.actions.allowNotes) {
+      setPendingAction({ envelope, action })
+      setNoteDraft('')
+      return
+    }
+    void completeQuickAction(envelope, action)
+  }
+
+  return (
+    <section
+      className={cn(
+        'col-span-2 rounded-xl border border-border/40 bg-card/20 backdrop-blur p-4 mt-2',
+        className,
+      )}
+      aria-labelledby="today-inbox-heading"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <h2
+          id="today-inbox-heading"
+          className="text-xs font-semibold tracking-[0.24em] text-foreground/70"
+        >
+          INBOX
+        </h2>
+        <div className="flex items-center gap-2">
+          {hasPreviewBadge ? (
+            <span className="rounded-full border border-border/60 px-2 py-1 text-[10px] uppercase tracking-wide text-foreground/60">
+              Preview data
+            </span>
+          ) : null}
+          {status === 'error' ? (
+            <button
+              type="button"
+              onClick={reload}
+              className="text-[11px] underline text-foreground/70 hover:text-foreground"
+            >
+              Retry
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-3 space-y-3">
+        {status === 'loading' ? (
+          <div className="animate-pulse rounded-lg border border-border/30 bg-card/10 p-4 text-sm text-foreground/50">
+            Loading inbox…
+          </div>
+        ) : null}
+
+        {status === 'error' ? (
+          <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+            We could not reach your inbox. Please retry in a moment.
+          </div>
+        ) : null}
+
+        {status === 'empty' ? (
+          <div className="rounded-lg border border-border/30 bg-card/10 p-4 text-sm text-foreground/60">
+            Nothing new just yet—check back after your next reflection.
+          </div>
+        ) : null}
+
+        {(status === 'success' || (status === 'loading' && envelopes.length)) ? (
+          <div className="space-y-3">
+            {envelopes.map((envelope) => (
+              <div key={envelope.id}>
+                {renderInboxCard(envelope, {
+                  onOpen: handleOpen,
+                  onQuickAction: (entry, action) => handleQuickAction(entry, action),
+                })}
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <Dialog open={Boolean(activeEnvelope)} onOpenChange={(isOpen) => (!isOpen ? handleClose() : null)}>
+        <DialogContent>
+          {activeEnvelope ? renderEnvelopeDetail(activeEnvelope) : null}
+          <DialogFooter className="pt-2">
+            {renderEnvelopeFooter(activeEnvelope, handleClose)}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(pendingAction)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingAction(null)
+            setNoteDraft('')
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Share a bit more?</DialogTitle>
+            <DialogDescription>
+              Optional notes help us fine-tune future nudges.
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            autoFocus
+            value={noteDraft}
+            onChange={(event) => setNoteDraft(event.target.value)}
+            placeholder="Add more context (optional)"
+            className="min-h-[120px]"
+          />
+          <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                if (pendingAction) {
+                  void completeQuickAction(pendingAction.envelope, pendingAction.action)
+                }
+              }}
+            >
+              Skip notes
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                if (pendingAction) {
+                  void completeQuickAction(pendingAction.envelope, pendingAction.action, noteDraft.trim() || undefined)
+                }
+              }}
+            >
+              Submit
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  )
+}
+
+function renderEnvelopeDetail(envelope: InboxEnvelope) {
+  switch (envelope.type) {
+    case 'insight_spotlight':
+      return renderInsightDetail(envelope)
+    case 'nudge':
+    case 'cta':
+    case 'notification':
+    default:
+      return (
+        <DialogHeader>
+          <DialogTitle>Coming soon</DialogTitle>
+          <DialogDescription>We are preparing an updated experience for this inbox item.</DialogDescription>
+        </DialogHeader>
+      )
+  }
+}
+
+function renderInsightDetail(envelope: Extract<InboxEnvelope, { type: 'insight_spotlight' }>) {
+  const { payload } = envelope
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{payload.title}</DialogTitle>
+        <DialogDescription>{payload.summary}</DialogDescription>
+      </DialogHeader>
+      <ScrollArea className="max-h-64 pr-4 text-sm text-foreground/80">
+        {payload.detail?.body ? (
+          <p className="whitespace-pre-wrap leading-relaxed">{payload.detail.body}</p>
+        ) : null}
+        {payload.detail?.sources?.length ? (
+          <div className="mt-4 space-y-2 text-xs">
+            <div className="font-semibold uppercase tracking-wide text-foreground/60">Sources</div>
+            <ul className="space-y-1">
+              {payload.detail.sources.map((source) => (
+                <li key={`${envelope.id}-${source.url}`}>
+                  <Link
+                    href={source.url}
+                    className="text-foreground/70 underline hover:text-foreground"
+                  >
+                    {source.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </ScrollArea>
+    </>
+  )
+}
+
+function renderEnvelopeFooter(envelope: InboxEnvelope | null, onClose: () => void) {
+  if (!envelope) return null
+  if (envelope.type === 'insight_spotlight' && envelope.payload.cta?.href) {
+    return (
+      <Link
+        href={envelope.payload.cta.href}
+        onClick={onClose}
+        target={envelope.payload.cta.target || '_self'}
+        className="inline-flex items-center justify-center rounded-full bg-foreground px-4 py-2 text-sm font-medium text-background transition hover:bg-foreground/90"
+      >
+        {envelope.payload.cta.label}
+      </Link>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClose}
+      className="inline-flex items-center justify-center rounded-full border border-border/60 px-4 py-2 text-sm text-foreground/70"
+    >
+      Close
+    </button>
+  )
+}

--- a/components/inbox/cards/InsightSpotlightCard.tsx
+++ b/components/inbox/cards/InsightSpotlightCard.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import type { InboxEnvelope, InboxQuickActionValue } from '@/types/inbox'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+
+export type InsightSpotlightEnvelope = Extract<InboxEnvelope, { type: 'insight_spotlight' }>
+
+interface InsightSpotlightCardProps {
+  envelope: InsightSpotlightEnvelope
+  onOpen?: (envelope: InsightSpotlightEnvelope) => void
+  onQuickAction?: (envelope: InsightSpotlightEnvelope, action: InboxQuickActionValue) => void
+  className?: string
+}
+
+export function InsightSpotlightCard({ envelope, onOpen, onQuickAction, className }: InsightSpotlightCardProps) {
+  const { payload } = envelope
+  const readingTime = typeof payload.readingTimeMinutes === 'number' && payload.readingTimeMinutes > 0
+    ? `${payload.readingTimeMinutes} min read`
+    : undefined
+  const actions = envelope.actions?.kind === 'boolean' ? envelope.actions : null
+  const positiveLabel = actions?.positiveLabel ?? 'This resonates'
+  const negativeLabel = actions?.negativeLabel ?? 'Not today'
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border border-border/40 bg-card/20 backdrop-blur p-4',
+        className,
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => onOpen?.(envelope)}
+        className="w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        aria-label={`Open insight ${payload.title}`}
+      >
+        <div className="text-[10px] font-semibold tracking-[0.24em] text-foreground/60">
+          INSIGHT SPOTLIGHT
+        </div>
+        <div className="mt-3 flex items-start justify-between gap-2">
+          <div>
+            <p className="text-base font-semibold leading-tight text-foreground">{payload.title}</p>
+            <p className="mt-2 text-sm text-foreground/80">{payload.summary}</p>
+          </div>
+          {readingTime ? (
+            <span className="rounded-full border border-border/60 px-2 py-1 text-[10px] uppercase tracking-wide text-foreground/70">
+              {readingTime}
+            </span>
+          ) : null}
+        </div>
+        {payload.cta?.helperText ? (
+          <p className="mt-3 text-xs text-foreground/60">{payload.cta.helperText}</p>
+        ) : (
+          <p className="mt-3 text-xs text-foreground/60">Tap to open insight detail</p>
+        )}
+      </button>
+
+      {actions ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          <Button
+            type="button"
+            size="sm"
+            className="rounded-full px-4"
+            onClick={() => onQuickAction?.(envelope, 'yes')}
+          >
+            {positiveLabel}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            className="rounded-full px-4"
+            onClick={() => onQuickAction?.(envelope, 'no')}
+          >
+            {negativeLabel}
+          </Button>
+          {actions.allowNotes ? (
+            <span className="text-[11px] text-foreground/60">
+              Add a note after choosing if you want to explain more.
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/components/inbox/index.ts
+++ b/components/inbox/index.ts
@@ -1,0 +1,2 @@
+export { InboxShelf } from './InboxShelf'
+export { Inbox } from './Inbox'

--- a/config/features.ts
+++ b/config/features.ts
@@ -21,6 +21,10 @@ const devMode = isDevMode()
 const gardenGridEnvOverride =
   process.env.NEXT_PUBLIC_IFS_GARDEN_GRID_VIEW ?? process.env.IFS_GARDEN_GRID_VIEW
 
+const inboxFlag = process.env.NEXT_PUBLIC_IFS_INBOX ?? process.env.IFS_INBOX
+const inboxActionsFlag =
+  process.env.NEXT_PUBLIC_IFS_INBOX_ACTIONS ?? process.env.IFS_INBOX_ACTIONS
+
 const gardenFlag = process.env.ENABLE_GARDEN ?? process.env.NEXT_PUBLIC_ENABLE_GARDEN
 const gardenStatus: FeatureStatus =
   gardenFlag === undefined ? 'enabled' : isTrue(gardenFlag) ? 'enabled' : 'disabled'
@@ -92,4 +96,17 @@ export function isGardenGridViewEnabled(): boolean {
     return true
   }
   return isTrue(gardenGridEnvOverride)
+}
+
+export function isInboxEnabled(): boolean {
+  if (devMode) return true
+  if (typeof window !== 'undefined' && clientDevOverride()) return true
+  return inboxFlag === undefined ? false : isTrue(inboxFlag)
+}
+
+export function isInboxActionsEnabled(): boolean {
+  if (!isInboxEnabled()) return false
+  if (devMode) return true
+  if (typeof window !== 'undefined' && clientDevOverride()) return true
+  return inboxActionsFlag === undefined ? true : isTrue(inboxActionsFlag)
 }

--- a/fe/README.md
+++ b/fe/README.md
@@ -1,0 +1,16 @@
+# Frontend Inbox Implementation
+
+## Summary
+- Replaced the Today page meditation card with `InboxShelf`, a reusable surface in `components/inbox/` backed by `useInboxFeed`.
+- Added inbox typing contracts (`types/inbox.ts`), analytics stubs, and normalization utilities for resilient rendering.
+- Implemented modal detail view for insight spotlight cards with accessibility and Tailwind-consistent styling.
+
+## Open Questions
+- Do we promote multiple inbox cards at once on the Today page grid, or keep a single spotlight for MVP?
+- Should `useInboxFeed` expose pagination metadata now or defer until additional card types exist?
+
+## Verification
+- `npm run lint`
+- `npm run typecheck`
+- `npm test`
+- Visual spot-check recommended once dev server is available.

--- a/hooks/useInboxFeed.ts
+++ b/hooks/useInboxFeed.ts
@@ -1,0 +1,179 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { emitInboxEvent } from '@/lib/analytics/inbox'
+import { getMockInboxEnvelopes } from '@/lib/inbox/mockData'
+import { fetchInboxFeed, submitInboxEvent } from '@/lib/inbox/client'
+import type {
+  InboxEnvelope,
+  InboxFeedVariant,
+  InboxQuickActionValue,
+} from '@/types/inbox'
+
+export interface InboxFeedState {
+  status: 'loading' | 'success' | 'empty' | 'error'
+  envelopes: InboxEnvelope[]
+  error: Error | null
+  source: 'network' | 'fallback'
+  variant: InboxFeedVariant
+}
+
+export interface UseInboxFeedOptions {
+  variant?: InboxFeedVariant
+  fallback?: InboxEnvelope[]
+}
+
+interface UseInboxFeedReturn extends InboxFeedState {
+  reload: () => Promise<void>
+  markAsRead: (envelopeId: string) => void
+  submitAction: (envelopeId: string, action: InboxQuickActionValue, notes?: string) => Promise<void>
+}
+
+export function useInboxFeed(options: UseInboxFeedOptions = {}): UseInboxFeedReturn {
+  const variant: InboxFeedVariant = options.variant ?? 'pragmatic'
+  const controllerRef = useRef<AbortController | null>(null)
+
+  const fallbackEnvelopes = useMemo(() => {
+    if (Array.isArray(options.fallback) && options.fallback.length > 0) {
+      return options.fallback
+    }
+    return getMockInboxEnvelopes()
+  }, [options.fallback])
+
+  const [state, setState] = useState<InboxFeedState>({
+    status: 'loading',
+    envelopes: [],
+    error: null,
+    source: 'network',
+    variant,
+  })
+
+  const runFetch = useCallback(async () => {
+    controllerRef.current?.abort()
+    const controller = new AbortController()
+    controllerRef.current = controller
+
+    setState({ status: 'loading', envelopes: [], error: null, source: 'network', variant })
+
+    try {
+      const normalized = await fetchInboxFeed(variant, { signal: controller.signal })
+
+      if (controller.signal.aborted) return
+
+      if (!normalized.length) {
+        setState({ status: 'empty', envelopes: [], error: null, source: 'network', variant })
+        return
+      }
+
+      setState({ status: 'success', envelopes: normalized, error: null, source: 'network', variant })
+      emitInboxEvent('inbox_feed_loaded', {
+        envelopeId: normalized[0]?.id ?? 'unknown',
+        messageType: normalized[0]?.type ?? 'insight_spotlight',
+        source: 'network',
+        metadata: { variant, count: normalized.length },
+      })
+    } catch (error) {
+      if (controller.signal.aborted) return
+      if (fallbackEnvelopes.length) {
+        setState({ status: 'success', envelopes: fallbackEnvelopes, error: null, source: 'fallback', variant })
+      } else {
+        setState({
+          status: 'error',
+          envelopes: [],
+          error: error instanceof Error ? error : new Error('Unknown inbox error'),
+          source: 'network',
+          variant,
+        })
+      }
+    }
+  }, [fallbackEnvelopes, variant])
+
+  useEffect(() => {
+    runFetch()
+    return () => {
+      controllerRef.current?.abort()
+    }
+  }, [runFetch])
+
+  const reload = useCallback(async () => {
+    await runFetch()
+  }, [runFetch])
+
+  const markAsRead = useCallback((envelopeId: string) => {
+    setState((prev) => ({
+      ...prev,
+      envelopes: prev.envelopes.map((envelope) =>
+        envelope.id === envelopeId ? { ...envelope, readAt: envelope.readAt ?? new Date().toISOString() } : envelope,
+      ),
+    }))
+
+    void submitInboxEvent({ subjectId: envelopeId, eventType: 'opened' }).catch((err) => {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('[inbox] failed to submit opened event', err)
+      }
+    })
+  }, [])
+
+  const submitAction = useCallback(
+    async (envelopeId: string, action: InboxQuickActionValue, notes?: string) => {
+      setState((prev) => ({
+        ...prev,
+        envelopes: prev.envelopes.map((envelope) =>
+          envelope.id === envelopeId
+            ? {
+                ...envelope,
+                readAt: envelope.readAt ?? new Date().toISOString(),
+                metadata: {
+                  ...envelope.metadata,
+                  lastAction: action,
+                },
+              }
+            : envelope,
+        ),
+      }))
+
+      emitInboxEvent('inbox_quick_action', {
+        envelopeId,
+        messageType: state.envelopes.find((entry) => entry.id === envelopeId)?.type ?? 'insight_spotlight',
+        source: state.source,
+        metadata: {
+          variant,
+          action,
+        },
+      })
+
+      try {
+        await submitInboxEvent({
+          subjectId: envelopeId,
+          eventType: 'cta_clicked',
+          action,
+          notes,
+        })
+        if (notes) {
+          emitInboxEvent('inbox_notes_submitted', {
+            envelopeId,
+            messageType: state.envelopes.find((entry) => entry.id === envelopeId)?.type ?? 'insight_spotlight',
+            source: state.source,
+            metadata: {
+              variant,
+              hasNotes: true,
+            },
+          })
+        }
+      } catch (error) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn('[inbox] quick action submission failed', error)
+        }
+        throw error
+      }
+    },
+    [state.envelopes, state.source, variant],
+  )
+
+  return {
+    ...state,
+    reload,
+    markAsRead,
+    submitAction,
+  }
+}

--- a/lib/analytics/inbox.ts
+++ b/lib/analytics/inbox.ts
@@ -1,0 +1,20 @@
+import { track } from '@/lib/analytics'
+import type { InboxAnalyticsEvent, InboxAnalyticsPayload } from '@/types/inbox'
+
+export function emitInboxEvent(
+  event: InboxAnalyticsEvent,
+  payload: InboxAnalyticsPayload,
+): void {
+  const finalPayload = {
+    ...payload,
+    timestamp: new Date().toISOString(),
+  }
+
+  try {
+    track(event, finalPayload)
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('[analytics:inbox] failed to emit event', event, error)
+    }
+  }
+}

--- a/lib/inbox/client.ts
+++ b/lib/inbox/client.ts
@@ -1,0 +1,52 @@
+import { normalizeInboxResponse } from '@/lib/inbox/normalize'
+import type {
+  InboxActionRequest,
+  InboxEnvelope,
+  InboxFeedResponse,
+  InboxFeedVariant,
+} from '@/types/inbox'
+
+const ENDPOINT_BY_VARIANT: Record<InboxFeedVariant, string> = {
+  pragmatic: '/api/inbox',
+  clean: '/api/inbox/clean',
+}
+
+type FetchOptions = {
+  signal?: AbortSignal
+}
+
+export async function fetchInboxFeed(
+  variant: InboxFeedVariant = 'pragmatic',
+  options: FetchOptions = {},
+): Promise<InboxEnvelope[]> {
+  const endpoint = ENDPOINT_BY_VARIANT[variant] ?? ENDPOINT_BY_VARIANT.pragmatic
+  const response = await fetch(endpoint, {
+    method: 'GET',
+    signal: options.signal,
+    headers: {
+      Accept: 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch inbox feed (${response.status})`)
+  }
+
+  const body: InboxFeedResponse | InboxEnvelope[] = await response.json()
+  const payload = Array.isArray(body) ? body : body.data
+  return normalizeInboxResponse(payload)
+}
+
+export async function submitInboxEvent(request: InboxActionRequest): Promise<void> {
+  const response = await fetch('/api/inbox/events', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(request),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to submit inbox event (${response.status})`)
+  }
+}

--- a/lib/inbox/mockData.ts
+++ b/lib/inbox/mockData.ts
@@ -1,0 +1,47 @@
+import type { InboxEnvelope } from '@/types/inbox'
+
+export const mockInboxEnvelopes: InboxEnvelope[] = [
+  {
+    id: 'mock-insight-spotlight-1',
+    type: 'insight_spotlight',
+    createdAt: new Date().toISOString(),
+    updatedAt: null,
+    readAt: null,
+    expiresAt: null,
+    source: 'fallback',
+    priority: 10,
+    tags: ['sample', 'dev'],
+    actions: {
+      kind: 'boolean',
+      positiveLabel: 'This resonates',
+      negativeLabel: 'Not today',
+      allowNotes: true,
+    },
+    payload: {
+      insightId: 'mock-insight-1',
+      title: 'Your parts are most talkative after evening reflections',
+      summary:
+        'In the past week you logged the most breakthroughs when reflecting between 8–9pm. Matching that rhythm could improve tomorrow’s check-in.',
+      readingTimeMinutes: 2,
+      detail: {
+        body: `Recent reflection logs show longer, calmer responses after sunset. Keeping a gentle ritual—like dimming lights or revisiting your planner—may help sustain that gain.`,
+        sources: [
+          { label: 'Reflection log • 7 entries', url: '/journal' },
+          { label: 'Insight archive', url: '/insights' },
+        ],
+      },
+      cta: {
+        label: 'Open insight',
+        href: '/insights/mock-insight-1',
+        intent: 'primary',
+      },
+    },
+  },
+]
+
+export function getMockInboxEnvelopes(): InboxEnvelope[] {
+  return mockInboxEnvelopes.map((entry) => ({
+    ...entry,
+    createdAt: entry.createdAt ?? new Date().toISOString(),
+  }))
+}

--- a/lib/inbox/normalize.ts
+++ b/lib/inbox/normalize.ts
@@ -1,0 +1,242 @@
+import type {
+  InboxEnvelope,
+  InboxEnvelopeSource,
+  InboxEnvelopeBase,
+  InboxMessageType,
+  InsightSpotlightMessage,
+  CallToActionMessage,
+  InboxCTA,
+  NudgeMessage,
+  NotificationMessage,
+  InboxActionSchema,
+} from '@/types/inbox'
+
+const allowedTypes: InboxMessageType[] = [
+  'insight_spotlight',
+  'nudge',
+  'cta',
+  'notification',
+]
+
+const allowedSources: InboxEnvelopeSource[] = ['network', 'fallback', 'supabase', 'edge']
+
+export function normalizeInboxResponse(input: unknown): InboxEnvelope[] {
+  if (!Array.isArray(input)) return []
+  const items: InboxEnvelope[] = []
+  for (const candidate of input) {
+    const envelope = coerceInboxEnvelope(candidate)
+    if (envelope) items.push(envelope)
+  }
+  return items
+}
+
+export function coerceInboxEnvelope(candidate: unknown): InboxEnvelope | null {
+  if (!isRecord(candidate)) return null
+
+  const type = safeString(candidate.type)
+  if (!type || !allowedTypes.includes(type as InboxMessageType)) return null
+
+  const createdAt = coerceDate(candidate.createdAt)
+  const updatedAt = optionalDate(candidate.updatedAt)
+  const expiresAt = optionalDate(candidate.expiresAt)
+  const readAt = optionalDate(candidate.readAt)
+  const priority = typeof candidate.priority === 'number' ? candidate.priority : undefined
+  const tags = Array.isArray(candidate.tags)
+    ? candidate.tags.filter((tag): tag is string => typeof tag === 'string')
+    : undefined
+
+  const sourceRaw = safeString(candidate.source)
+  const source: InboxEnvelopeSource = sourceRaw && allowedSources.includes(sourceRaw as InboxEnvelopeSource)
+    ? (sourceRaw as InboxEnvelopeSource)
+    : 'network'
+
+  const actions = coerceActions(candidate.actions)
+  const metadata = isRecord(candidate.metadata) ? candidate.metadata : undefined
+
+  const base: InboxEnvelopeBase = {
+    id: safeString(candidate.id) || `inbox-${type}-${createdAt}`,
+    type: type as InboxMessageType,
+    createdAt,
+    updatedAt: updatedAt ?? null,
+    expiresAt: expiresAt ?? null,
+    readAt: readAt ?? null,
+    source,
+    priority,
+    tags,
+    actions,
+    metadata,
+  }
+
+  const payloadCandidate = candidate.payload
+  switch (type) {
+    case 'insight_spotlight': {
+      const payload = coerceInsightSpotlightPayload(payloadCandidate)
+      if (!payload) return null
+      return { ...base, type: 'insight_spotlight', payload }
+    }
+    case 'nudge': {
+      const payload = coerceNudgePayload(payloadCandidate)
+      if (!payload) return null
+      return { ...base, type: 'nudge', payload }
+    }
+    case 'cta': {
+      const payload = coerceCtaPayload(payloadCandidate)
+      if (!payload) return null
+      return { ...base, type: 'cta', payload }
+    }
+    case 'notification': {
+      const payload = coerceNotificationPayload(payloadCandidate)
+      if (!payload) return null
+      return { ...base, type: 'notification', payload }
+    }
+    default:
+      return null
+  }
+}
+
+function coerceInsightSpotlightPayload(candidate: unknown): InsightSpotlightMessage | null {
+  if (!isRecord(candidate)) return null
+  const insightId = safeString(candidate.insightId)
+  const title = safeString(candidate.title)
+  const summary = safeString(candidate.summary)
+  if (!insightId || !title || !summary) return null
+
+  const readingTimeMinutes = typeof candidate.readingTimeMinutes === 'number' && candidate.readingTimeMinutes >= 0
+    ? Math.round(candidate.readingTimeMinutes)
+    : undefined
+  const prompt = safeString(candidate.prompt)
+
+  const detailCandidate = isRecord(candidate.detail)
+    ? {
+        body: safeString(candidate.detail.body) ?? '',
+        sources: Array.isArray(candidate.detail.sources)
+          ? candidate.detail.sources
+              .map((entry) => {
+                if (!isRecord(entry)) return null
+                const label = safeString(entry.label)
+                const url = safeString(entry.url)
+                if (!label || !url) return null
+                return { label, url }
+              })
+              .filter((entry): entry is { label: string; url: string } => Boolean(entry))
+          : undefined,
+      }
+    : undefined
+
+  const cta = coerceInboxCta(candidate.cta)
+
+  return {
+    insightId,
+    title,
+    summary,
+    prompt: prompt ?? undefined,
+    readingTimeMinutes,
+    detail: detailCandidate?.body ? detailCandidate : undefined,
+    cta: cta ?? undefined,
+  }
+}
+
+function coerceNudgePayload(candidate: unknown): NudgeMessage | null {
+  if (!isRecord(candidate)) return null
+  const headline = safeString(candidate.headline)
+  const body = safeString(candidate.body)
+  if (!headline || !body) return null
+  const cta = coerceInboxCta(candidate.cta)
+  return {
+    headline,
+    body,
+    cta: cta ?? undefined,
+  }
+}
+
+function coerceCtaPayload(candidate: unknown): CallToActionMessage | null {
+  if (!isRecord(candidate)) return null
+  const title = safeString(candidate.title)
+  const description = safeString(candidate.description)
+  const action = coerceInboxCta(candidate.action)
+  if (!title || !description || !action) return null
+  return {
+    title,
+    description,
+    action,
+  }
+}
+
+function coerceNotificationPayload(candidate: unknown): NotificationMessage | null {
+  if (!isRecord(candidate)) return null
+  const title = safeString(candidate.title)
+  const body = safeString(candidate.body)
+  if (!title || !body) return null
+  const unread = typeof candidate.unread === 'boolean' ? candidate.unread : false
+  const link = isRecord(candidate.link)
+    ? {
+        label: safeString(candidate.link.label) ?? '',
+        href: safeString(candidate.link.href) ?? '#',
+        target: safeString(candidate.link.target) as '_blank' | '_self' | undefined,
+        analyticsTag: safeString(candidate.link.analyticsTag) ?? undefined,
+      }
+    : undefined
+  return {
+    title,
+    body,
+    unread,
+    link: link?.label && link?.href ? link : undefined,
+  }
+}
+
+function coerceActions(candidate: unknown): InboxActionSchema | undefined {
+  if (!isRecord(candidate)) return undefined
+  const kind = safeString(candidate.kind)
+  if (kind === 'boolean') {
+    return {
+      kind: 'boolean',
+      positiveLabel: safeString(candidate.positiveLabel) ?? undefined,
+      negativeLabel: safeString(candidate.negativeLabel) ?? undefined,
+      allowNotes: typeof candidate.allowNotes === 'boolean' ? candidate.allowNotes : undefined,
+    }
+  }
+  return undefined
+}
+
+function coerceInboxCta(candidate: unknown): InboxCTA | null {
+  if (!isRecord(candidate)) return null
+  const label = safeString(candidate.label)
+  if (!label) return null
+  const href = safeString(candidate.href) ?? undefined
+  const actionId = safeString(candidate.actionId) ?? undefined
+  const intent = safeString(candidate.intent)
+  const helperText = safeString(candidate.helperText) ?? undefined
+  return {
+    label,
+    href,
+    actionId,
+    intent: intent === 'secondary' ? 'secondary' : 'primary',
+    helperText,
+  }
+}
+
+function coerceDate(value: unknown): string {
+  const candidate = safeString(value)
+  const date = candidate ? new Date(candidate) : new Date()
+  if (Number.isNaN(date.getTime())) {
+    return new Date().toISOString()
+  }
+  return date.toISOString()
+}
+
+function optionalDate(value: unknown): string | null {
+  if (value === null || value === undefined) return null
+  const coerced = coerceDate(value)
+  return coerced
+}
+
+function safeString(value: unknown): string | null {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim()
+  }
+  return null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/lib/inbox/pragmaticData.ts
+++ b/lib/inbox/pragmaticData.ts
@@ -1,0 +1,45 @@
+import type { InboxEnvelope } from '@/types/inbox'
+
+const issuedAt = () => new Date().toISOString()
+
+export function getPragmaticInboxFeed(): InboxEnvelope[] {
+  return [
+    {
+      id: 'pragmatic-insight-spotlight-1',
+      type: 'insight_spotlight',
+      createdAt: issuedAt(),
+      updatedAt: null,
+      readAt: null,
+      expiresAt: null,
+      source: 'network',
+      priority: 9,
+      tags: ['today', 'reflection'],
+      actions: {
+        kind: 'boolean',
+        positiveLabel: 'Sounds helpful',
+        negativeLabel: 'Maybe later',
+        allowNotes: true,
+      },
+      payload: {
+        insightId: 'insight-today-highlight',
+        title: 'Spotlight: Your calmest check-ins land right after journaling',
+        summary:
+          'When you journal before the nightly check-in, your parts respond with 25% fewer escalations. Let’s keep that cadence tonight.',
+        readingTimeMinutes: 3,
+        detail: {
+          body: `Over the past 10 sessions, the ones preceded by a short journal entry trended more grounded and required fewer follow-up prompts. Try a 3-minute jot-down to set the tone before tonight's check-in.`,
+          sources: [
+            { label: 'Check-in timeline', url: '/timeline' },
+            { label: 'Parts Explorer', url: '/parts' },
+          ],
+        },
+        cta: {
+          label: 'Review insight',
+          href: '/insights/insight-today-highlight',
+          intent: 'primary',
+          helperText: 'Review the full reflection before this evening.',
+        },
+      },
+    },
+  ]
+}

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -117,7 +117,10 @@ export interface Database {
       }
     }
     Views: {
-      [_ in never]: never
+      inbox_items_view: {
+        Row: InboxItemsViewRow
+        Relationships: []
+      }
     }
     Functions: {
       update_part_confidence: {
@@ -261,6 +264,7 @@ export interface PartRow {
   first_noticed: string
   acknowledged_at: string | null
   last_active: string
+  last_interaction_at: string | null
   last_charged_at: string | null
   last_charge_intensity: number | null
   created_at: string
@@ -288,6 +292,7 @@ export interface PartInsert {
   first_noticed?: string
   acknowledged_at?: string | null
   last_active?: string
+  last_interaction_at?: string | null
   last_charged_at?: string | null
   last_charge_intensity?: number | null
   created_at?: string
@@ -315,6 +320,7 @@ export interface PartUpdate {
   first_noticed?: string
   acknowledged_at?: string | null
   last_active?: string
+  last_interaction_at?: string | null
   last_charged_at?: string | null
   last_charge_intensity?: number | null
   created_at?: string
@@ -641,6 +647,17 @@ export interface InsightUpdate {
   meta?: Json
   created_at?: string
   updated_at?: string
+}
+
+export interface InboxItemsViewRow {
+  user_id: string
+  source_type: 'insight' | 'part_follow_up'
+  source_id: string
+  status: InsightStatus
+  content: Json
+  part_id: string | null
+  metadata: Json
+  created_at: string
 }
 
 // API Response Types

--- a/mastra/tools/part-tools.ts
+++ b/mastra/tools/part-tools.ts
@@ -42,6 +42,7 @@ function makeStubPart(userId: string, overrides: Partial<PartRow> = {}): PartRow
     first_noticed: overrides.first_noticed ?? now,
     acknowledged_at: overrides.acknowledged_at ?? null,
     last_active: overrides.last_active ?? now,
+    last_interaction_at: overrides.last_interaction_at ?? now,
     last_charged_at: overrides.last_charged_at ?? null,
     last_charge_intensity: overrides.last_charge_intensity ?? null,
     created_at: overrides.created_at ?? now,

--- a/scripts/tests/unit/inbox-normalize.test.ts
+++ b/scripts/tests/unit/inbox-normalize.test.ts
@@ -1,0 +1,67 @@
+async function main() {
+  const modulePath = '@/lib/inbox/normalize?test=' + Date.now()
+  const { normalizeInboxResponse, coerceInboxEnvelope } = await import(modulePath)
+
+  const validPayload = {
+    id: 'test-1',
+    type: 'insight_spotlight',
+    createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+    source: 'network',
+    payload: {
+      insightId: 'insight-123',
+      title: 'A clear pattern emerges',
+      summary: 'You respond best after breathing exercises.',
+      readingTimeMinutes: 2,
+      detail: {
+        body: 'Breathing exercises before check-ins appear to reduce reactivity.',
+        sources: [{ label: 'Breath log', url: '/breath' }],
+      },
+      cta: {
+        label: 'See insight',
+        href: '/insights/insight-123',
+      },
+    },
+  }
+
+  const result = normalizeInboxResponse([validPayload])
+  assert(result.length === 1, 'Expected valid payload to pass normalization')
+  assert(result[0]?.payload?.detail?.sources?.[0]?.label === 'Breath log', 'Expected sources to remain intact')
+
+  const invalidPayload = {
+    id: 'invalid',
+    type: 'unknown',
+    createdAt: 'not-a-date',
+    payload: {},
+  }
+
+  const mixed = normalizeInboxResponse([validPayload, invalidPayload])
+  assert(mixed.length === 1, 'Invalid payload should be filtered out')
+
+  const coerced = coerceInboxEnvelope({
+    id: 'coerced-1',
+    type: 'cta',
+    payload: {
+      title: 'Complete onboarding',
+      description: 'Finish your onboarding flow to unlock insights.',
+      action: {
+        label: 'Finish onboarding',
+        href: '/onboarding',
+      },
+    },
+  })
+  assert(coerced !== null, 'Coercion should bridge missing optional fields')
+  assert(coerced?.createdAt, 'Coerced envelope should have a createdAt value')
+
+  console.log('Inbox normalization tests passed.')
+}
+
+function assert(condition: unknown, message: string) {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+main().catch((error) => {
+  console.error('Inbox normalization tests failed:', error)
+  process.exit(1)
+})

--- a/supabase/migrations/104_inbox_items_view.sql
+++ b/supabase/migrations/104_inbox_items_view.sql
@@ -1,0 +1,60 @@
+-- Inbox MVP schema updates
+-- Migration: 104_inbox_items_view
+-- Created: 2025-09-21
+
+alter table public.parts
+  add column if not exists last_interaction_at timestamptz;
+
+update public.parts
+set last_interaction_at = coalesce(last_active, updated_at, created_at)
+where last_interaction_at is null;
+
+comment on column public.parts.last_interaction_at is 'Timestamp of the most recent user interaction used for Inbox follow-ups.';
+
+drop view if exists public.inbox_items_view;
+
+create view public.inbox_items_view as
+select
+  i.user_id,
+  'insight'::text as source_type,
+  i.id as source_id,
+  i.status,
+  i.content,
+  null::uuid as part_id,
+  coalesce(i.meta, '{}'::jsonb)
+    || jsonb_build_object(
+      'insight_type', i.type,
+      'rating', i.rating,
+      'revealed_at', i.revealed_at,
+      'actioned_at', i.actioned_at
+    ) as metadata,
+  i.created_at
+from public.insights i
+where i.status in ('pending', 'revealed')
+
+union all
+
+select
+  p.user_id,
+  'part_follow_up'::text as source_type,
+  p.id as source_id,
+  'pending'::text as status,
+  jsonb_build_object(
+    'title', concat('Reconnect with ', p.name),
+    'body', 'This part has not been interacted with for at least 14 days.',
+    'kind', 'stale_part_follow_up'
+  ) as content,
+  p.id as part_id,
+  jsonb_build_object(
+    'last_interaction_at', p.last_interaction_at,
+    'days_since_interaction', greatest(0, floor(extract(epoch from (now() - coalesce(p.last_interaction_at, p.updated_at, p.created_at))) / 86400)::int),
+    'reason', 'stale_part_follow_up'
+  ) as metadata,
+  coalesce(p.last_interaction_at, p.updated_at, p.created_at) as created_at
+from public.parts p
+where coalesce(p.last_interaction_at, p.updated_at, p.created_at) <= now() - interval '14 days';
+
+grant select on public.inbox_items_view to authenticated;
+grant select on public.inbox_items_view to service_role;
+
+comment on view public.inbox_items_view is 'Unified inbox feed containing insight cards and part follow-up prompts for the Inbox MVP.';

--- a/sys-arch/README.md
+++ b/sys-arch/README.md
@@ -1,0 +1,25 @@
+# Inbox Architecture Decisions
+
+## Overview
+- Frontend consumes an abstract `InboxEnvelope` contract rendered through a registry-driven `InboxShelf` surface.
+- Data enters via `useInboxFeed`, which can target the pragmatic API route immediately and the clean Supabase pipeline once ready.
+- Analytics instrumentation (`emitInboxEvent`) keeps UX and backend telemetry aligned.
+
+## Variant Comparison
+| Aspect | Pragmatic (Next.js API) | Clean (Supabase Edge) |
+| --- | --- | --- |
+| Delivery | Static JSON feed via `getPragmaticInboxFeed()` | Edge function joins normalized tables with per-user filters |
+| Latency | Served from Vercel edge/cacheable responses | Close to data, leverages Supabase region locality |
+| Personalization | Requires manual extension or query params | Full fidelity with SQL filters + RLS |
+| Reaction Logging | Not persistent (pending session store) | `inbox_message_events` table with policy-aligned inserts |
+| Effort | ✅ Ready now | 🚧 Requires migration + ops playbook |
+
+## Recommendation
+- Ship the pragmatic route first to unblock Today page testing and fast iteration.
+- Begin Supabase migration immediately so the clean pipeline can replace the pragmatic feed without frontend changes.
+- When enabling the clean path, keep the pragmatic endpoint as a fallback for unauthenticated/dev flows.
+
+## Follow-ups
+1. Define dismissal persistence (local storage vs Supabase event) before launching multi-card inbox.
+2. Align analytics taxonomy between frontend `emitInboxEvent` and backend `inbox_message_events` before GA.
+3. Introduce a lightweight pagination cursor in `InboxFeedResponse` when we add more than five envelopes per user.

--- a/types/inbox.ts
+++ b/types/inbox.ts
@@ -1,0 +1,140 @@
+export type InboxMessageType = 'insight_spotlight' | 'nudge' | 'cta' | 'notification'
+export type InboxEnvelopeSource = 'network' | 'fallback' | 'supabase' | 'edge'
+
+export type InboxEventType = 'delivered' | 'opened' | 'dismissed' | 'cta_clicked'
+export type InboxQuickActionValue = 'yes' | 'no'
+
+export interface InboxCTA {
+  label: string
+  href?: string
+  actionId?: string
+  intent?: 'primary' | 'secondary'
+  helperText?: string
+  target?: '_self' | '_blank'
+  analyticsTag?: string
+}
+
+export interface InboxBooleanActionSchema {
+  kind: 'boolean'
+  positiveLabel?: string
+  negativeLabel?: string
+  allowNotes?: boolean
+}
+
+export type InboxActionSchema = InboxBooleanActionSchema
+
+export interface InboxEnvelopeBase {
+  id: string
+  type: InboxMessageType
+  createdAt: string
+  updatedAt: string | null
+  expiresAt: string | null
+  readAt: string | null
+  source: InboxEnvelopeSource
+  priority?: number
+  tags?: string[]
+  actions?: InboxActionSchema
+  metadata?: Record<string, unknown>
+}
+
+export interface InsightSpotlightDetailSource {
+  label: string
+  url: string
+}
+
+export interface InsightSpotlightDetail {
+  body?: string
+  sources?: InsightSpotlightDetailSource[]
+}
+
+export interface InsightSpotlightMessage {
+  insightId: string
+  title: string
+  summary: string
+  prompt?: string
+  readingTimeMinutes?: number
+  detail?: InsightSpotlightDetail
+  cta?: InboxCTA
+}
+
+export interface NudgeMessage {
+  headline: string
+  body: string
+  cta?: InboxCTA
+}
+
+export interface CallToActionMessage {
+  title: string
+  description: string
+  action: InboxCTA
+}
+
+export interface NotificationLink {
+  label: string
+  href: string
+  target?: '_self' | '_blank'
+  analyticsTag?: string
+}
+
+export interface NotificationMessage {
+  title: string
+  body: string
+  unread?: boolean
+  link?: NotificationLink
+}
+
+export type InsightSpotlightEnvelope = InboxEnvelopeBase & {
+  type: 'insight_spotlight'
+  payload: InsightSpotlightMessage
+}
+
+export type NudgeEnvelope = InboxEnvelopeBase & {
+  type: 'nudge'
+  payload: NudgeMessage
+}
+
+export type CallToActionEnvelope = InboxEnvelopeBase & {
+  type: 'cta'
+  payload: CallToActionMessage
+}
+
+export type NotificationEnvelope = InboxEnvelopeBase & {
+  type: 'notification'
+  payload: NotificationMessage
+}
+
+export type InboxEnvelope =
+  | InsightSpotlightEnvelope
+  | NudgeEnvelope
+  | CallToActionEnvelope
+  | NotificationEnvelope
+
+export type InboxFeedVariant = 'pragmatic' | 'clean'
+
+export type InboxAnalyticsEvent =
+  | 'inbox_feed_loaded'
+  | 'inbox_card_opened'
+  | 'inbox_card_dismissed'
+  | 'inbox_quick_action'
+  | 'inbox_notes_submitted'
+
+export interface InboxAnalyticsPayload {
+  envelopeId: string
+  messageType: InboxMessageType
+  source: InboxEnvelopeSource
+  metadata?: Record<string, unknown>
+}
+
+export interface InboxFeedResponse {
+  data: InboxEnvelope[]
+  generatedAt?: string
+  source?: InboxEnvelopeSource | 'fallback'
+  variant?: InboxFeedVariant
+}
+
+export interface InboxActionRequest {
+  subjectId: string
+  eventType?: InboxEventType
+  action?: InboxQuickActionValue
+  notes?: string
+}


### PR DESCRIPTION
## Summary
- add nullable `last_interaction_at` tracking to `parts`
- add `inbox_items_view` view unioning insights and stale part follow-ups
- update generated types and dev stubs to reflect the new schema

## Testing
- npm run lint
- npm run typecheck (fails: lib/memory_v2/rollback.ts imports non-existent newTxnId)
