### PR TITLE
feat(inbox): add GET endpoint

### DIFF
--- a/app/api/inbox/route.ts
+++ b/app/api/inbox/route.ts
@@ -1,0 +1,214 @@
+import { NextRequest } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response'
+import { rankInboxItems, type RankedInboxItem } from '@/lib/data/inbox-ranking'
+import type { InboxContent, InboxItem, PaginatedInboxResponse } from '@/types/inbox'
+
+const DEFAULT_LIMIT = 10
+const MAX_LIMIT = 50
+const SUPABASE_FETCH_LIMIT = 200
+
+type InboxItemRow = {
+  id: string
+  user_id: string
+  source_type: string
+  status: string
+  part_id: string | null
+  content: unknown
+  metadata: unknown
+  created_at: string
+}
+
+type CursorPayload = {
+  rankBucket: number
+  createdAt: string
+  id: string
+}
+
+function parseLimit(limitParam: string | null): number | null {
+  if (!limitParam) return DEFAULT_LIMIT
+
+  const parsed = Number.parseInt(limitParam, 10)
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return null
+  }
+
+  return Math.min(parsed, MAX_LIMIT)
+}
+
+function decodeCursor(afterParam: string | null): CursorPayload | null {
+  if (!afterParam) return null
+
+  try {
+    const decoded = Buffer.from(afterParam, 'base64url').toString('utf8')
+    const payload = JSON.parse(decoded) as Partial<CursorPayload>
+
+    if (
+      typeof payload.rankBucket === 'number' &&
+      typeof payload.createdAt === 'string' &&
+      typeof payload.id === 'string'
+    ) {
+      return {
+        rankBucket: payload.rankBucket,
+        createdAt: payload.createdAt,
+        id: payload.id,
+      }
+    }
+  } catch (error) {
+    console.error('Failed to decode inbox cursor', error)
+  }
+
+  return null
+}
+
+function encodeCursor(item: RankedInboxItem): string {
+  const payload: CursorPayload = {
+    rankBucket: item.rankBucket,
+    createdAt: item.createdAt,
+    id: item.id,
+  }
+
+  return Buffer.from(JSON.stringify(payload)).toString('base64url')
+}
+
+function mapRowToItem(row: InboxItemRow): InboxItem {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    sourceType: row.source_type,
+    status: row.status,
+    partId: row.part_id,
+    content: normalizeContent(row.content),
+    metadata: normalizeMetadata(row.metadata),
+    createdAt: row.created_at,
+  }
+}
+
+function normalizeContent(content: unknown): InboxContent | null {
+  if (content == null) return null
+
+  if (typeof content === 'string') {
+    try {
+      return JSON.parse(content)
+    } catch {
+      return { value: content }
+    }
+  }
+
+  if (typeof content === 'object') {
+    return content as InboxContent
+  }
+
+  return null
+}
+
+function normalizeMetadata(metadata: unknown): Record<string, unknown> | null {
+  if (metadata == null) return null
+
+  if (typeof metadata === 'string') {
+    try {
+      return JSON.parse(metadata) as Record<string, unknown>
+    } catch {
+      return { value: metadata }
+    }
+  }
+
+  if (typeof metadata === 'object') {
+    return metadata as Record<string, unknown>
+  }
+
+  return null
+}
+
+function findCursorIndex(items: RankedInboxItem[], cursor: CursorPayload) {
+  return items.findIndex((item) => {
+    return (
+      item.rankBucket === cursor.rankBucket &&
+      item.createdAt === cursor.createdAt &&
+      item.id === cursor.id
+    )
+  })
+}
+
+function paginateItems(
+  rankedItems: RankedInboxItem[],
+  limit: number,
+  cursor: CursorPayload | null
+) {
+  let startIndex = 0
+
+  if (cursor) {
+    const index = findCursorIndex(rankedItems, cursor)
+    if (index === -1) {
+      return {
+        page: [] as RankedInboxItem[],
+        nextCursor: null,
+        cursorInvalid: true,
+      }
+    }
+
+    startIndex = index + 1
+  }
+
+  const page = rankedItems.slice(startIndex, startIndex + limit)
+  const hasNext = startIndex + limit < rankedItems.length
+  const nextCursor = hasNext ? encodeCursor(rankedItems[startIndex + limit]) : null
+
+  return { page, nextCursor, cursorInvalid: false }
+}
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return errorResponse('Unauthorized', HTTP_STATUS.UNAUTHORIZED)
+  }
+
+  const url = new URL(request.url)
+  const limitParam = url.searchParams.get('limit')
+  const afterParam = url.searchParams.get('after')
+
+  const limit = parseLimit(limitParam)
+  if (!limit) {
+    return errorResponse('Invalid limit parameter', HTTP_STATUS.BAD_REQUEST)
+  }
+
+  const cursor = decodeCursor(afterParam)
+  if (afterParam && !cursor) {
+    return errorResponse('Invalid cursor parameter', HTTP_STATUS.BAD_REQUEST)
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('inbox_items_view')
+      .select('*')
+      .eq('user_id', user.id)
+      .limit(Math.min(SUPABASE_FETCH_LIMIT, Math.max(limit * 3, limit + 20)))
+
+    if (error) {
+      console.error('Failed to fetch inbox items', error)
+      return errorResponse('Failed to fetch inbox items', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+    }
+
+    const items = (data ?? []).map((row: InboxItemRow) => mapRowToItem(row))
+    const rankedItems = rankInboxItems(items)
+    const { page, nextCursor, cursorInvalid } = paginateItems(rankedItems, limit, cursor)
+
+    if (cursorInvalid) {
+      return errorResponse('Cursor no longer valid', HTTP_STATUS.BAD_REQUEST)
+    }
+
+    const response: PaginatedInboxResponse = {
+      items: page,
+      nextCursor,
+    }
+
+    return jsonResponse(response)
+  } catch (error) {
+    console.error('Unexpected inbox GET error', error)
+    return errorResponse('An unexpected error occurred', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+}

--- a/lib/data/inbox-ranking.ts
+++ b/lib/data/inbox-ranking.ts
@@ -1,0 +1,48 @@
+import type { InboxItem } from '@/types/inbox'
+
+export interface RankedInboxItem extends InboxItem {
+  rankBucket: number
+}
+
+function getRankBucket(item: InboxItem): number {
+  const sourceType = item.sourceType.toLowerCase()
+  const status = item.status.toLowerCase()
+
+  if (sourceType === 'insight') {
+    if (status === 'revealed') return 0
+    if (status === 'pending') return 1
+  }
+
+  return 2
+}
+
+function compareCreatedAtDesc(a: InboxItem, b: InboxItem): number {
+  const aTime = new Date(a.createdAt).getTime()
+  const bTime = new Date(b.createdAt).getTime()
+
+  if (Number.isNaN(aTime) && Number.isNaN(bTime)) return 0
+  if (Number.isNaN(aTime)) return 1
+  if (Number.isNaN(bTime)) return -1
+
+  return bTime - aTime
+}
+
+export function rankInboxItems(items: InboxItem[]): RankedInboxItem[] {
+  return items
+    .map((item) => ({
+      ...item,
+      rankBucket: getRankBucket(item),
+    }))
+    .sort((a, b) => {
+      if (a.rankBucket !== b.rankBucket) {
+        return a.rankBucket - b.rankBucket
+      }
+
+      const recencyComparison = compareCreatedAtDesc(a, b)
+      if (recencyComparison !== 0) {
+        return recencyComparison
+      }
+
+      return a.id.localeCompare(b.id)
+    })
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
-    "test:unit": "npm exec tsx scripts/tests/unit/scoring.test.ts && npm exec tsx scripts/tests/unit/selector.test.ts && npm exec tsx scripts/tests/unit/prompt.test.ts && npm exec tsx scripts/tests/unit/security.test.ts && npm exec tsx scripts/tests/unit/rollback.test.ts && npm exec tsx scripts/tests/unit/part-schemas.test.ts",
+    "test:unit": "npm exec tsx scripts/tests/unit/scoring.test.ts && npm exec tsx scripts/tests/unit/selector.test.ts && npm exec tsx scripts/tests/unit/prompt.test.ts && npm exec tsx scripts/tests/unit/security.test.ts && npm exec tsx scripts/tests/unit/inbox-api.test.ts && npm exec tsx scripts/tests/unit/rollback.test.ts && npm exec tsx scripts/tests/unit/part-schemas.test.ts",
     "test:integration": "tsx scripts/tests/integration/check-ins.test.ts",
     "test:ui": "tsx scripts/tests/ui/check-in-slots.test.tsx",
     "test": "npm run test:unit && npm run test:integration && npm run test:ui && tsx scripts/test-onboarding.ts",

--- a/scripts/tests/unit/inbox-api.test.ts
+++ b/scripts/tests/unit/inbox-api.test.ts
@@ -1,0 +1,99 @@
+import { strict as assert } from 'node:assert'
+import { NextRequest } from 'next/server'
+import { setServerClientOverrideForTests } from '@/lib/supabase/server'
+
+process.env.NODE_ENV = 'test'
+process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://supabase.local'
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'anon-key'
+
+const mockRows = [
+  {
+    id: 'revealed-insight',
+    user_id: 'test-user',
+    source_type: 'insight',
+    status: 'revealed',
+    part_id: 'part-1',
+    content: { title: 'Revealed Insight' },
+    metadata: null,
+    created_at: '2025-09-20T12:00:00.000Z',
+  },
+  {
+    id: 'pending-insight',
+    user_id: 'test-user',
+    source_type: 'insight',
+    status: 'pending',
+    part_id: 'part-2',
+    content: { title: 'Pending Insight' },
+    metadata: null,
+    created_at: '2025-09-20T13:00:00.000Z',
+  },
+  {
+    id: 'follow-up',
+    user_id: 'test-user',
+    source_type: 'follow_up',
+    status: 'new',
+    part_id: 'part-3',
+    content: { title: 'Follow Up' },
+    metadata: null,
+    created_at: '2025-09-19T09:00:00.000Z',
+  },
+]
+
+const serverClient = {
+  auth: {
+    async getUser() {
+      return { data: { user: { id: 'test-user' } } }
+    },
+  },
+  from(table: string) {
+    assert.equal(table, 'inbox_items_view', 'expected inbox_items_view query')
+    const builder: any = {
+      select() {
+        return builder
+      },
+      eq(column: string, value: unknown) {
+        assert.equal(column, 'user_id')
+        assert.equal(value, 'test-user')
+        return builder
+      },
+      limit(limit: number) {
+        assert(limit >= 2)
+        return Promise.resolve({ data: mockRows, error: null })
+      },
+    }
+
+    return builder
+  },
+}
+
+setServerClientOverrideForTests(serverClient as any)
+
+async function main() {
+  const { GET } = await import('@/app/api/inbox/route')
+
+  const request = new NextRequest('http://localhost/api/inbox?limit=2')
+  const response = await GET(request)
+
+  assert.equal(response.status, 200, 'expected success status')
+
+  const body = (await response.json()) as any
+  assert.equal(body.items.length, 2, 'should return requested limit of items')
+  assert.deepEqual(
+    body.items.map((item: any) => item.id),
+    ['revealed-insight', 'pending-insight'],
+    'items should be ranked by priority order',
+  )
+  assert.equal(body.items[0].content.title, 'Revealed Insight')
+  assert.ok(body.nextCursor, 'expected next cursor to be present')
+
+  console.log('Inbox GET endpoint unit test passed.')
+}
+
+main()
+  .catch((error) => {
+    console.error('Inbox GET endpoint unit test failed:', error)
+    process.exitCode = 1
+  })
+  .finally(() => {
+    setServerClientOverrideForTests(null)
+  })

--- a/types/inbox.ts
+++ b/types/inbox.ts
@@ -1,0 +1,26 @@
+export type InboxItemSourceType = 'insight' | 'follow_up' | string
+
+export type InboxItemStatus = 'pending' | 'revealed' | 'dismissed' | 'snoozed' | string
+
+export interface InboxContent {
+  title?: string
+  body?: string
+  evidence?: unknown
+  [key: string]: unknown
+}
+
+export interface InboxItem {
+  id: string
+  userId: string
+  sourceType: InboxItemSourceType
+  status: InboxItemStatus
+  partId: string | null
+  content: InboxContent | null
+  metadata: Record<string, unknown> | null
+  createdAt: string
+}
+
+export interface PaginatedInboxResponse {
+  items: InboxItem[]
+  nextCursor: string | null
+}


### PR DESCRIPTION
## Summary
- add GET /api/inbox route to serve ranked, cursor-paginated inbox items
- introduce shared inbox types and ranking helper
- cover the endpoint with a unit test and wire it into the suite

## Testing
- npm run lint
- npm run typecheck
- npm run test:unit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an Inbox API endpoint with cursor-based pagination, supporting limit and after parameters and returning a nextCursor for seamless page navigation.
- Improvements
  - Consistent, priority-first ordering of inbox items with sensible recency tiebreakers.
  - More robust validation and error responses for authentication, limits, and cursors.
  - Normalized item content and metadata for reliable display.
- Tests
  - New unit tests verify pagination behavior, item ordering, limit adherence, and response structure to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->