### PR TITLE
feat(inbox): wire action handlers

### DIFF
--- a/app/api/inbox/[id]/action/route.ts
+++ b/app/api/inbox/[id]/action/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { createClient } from '@/lib/supabase/server'
+import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response'
+import { getInboxItemById } from '@/lib/data/inbox-items'
+import type { InboxItem } from '@/types/inbox'
+import type { Database } from '@/lib/types/database'
+import {
+  confirmInboxItemAction,
+  dismissInboxItemAction,
+  snoozeInboxItemAction,
+  type ConfirmInboxActionPayload,
+  type DismissInboxActionPayload,
+  type SnoozeInboxActionPayload,
+} from '@/lib/data/inbox-actions'
+
+const confirmActionSchema = z.object({
+  action: z.literal('confirm'),
+  note: z.string().trim().max(1000).optional(),
+})
+
+const dismissActionSchema = z.object({
+  action: z.literal('dismiss'),
+  reason: z.string().trim().max(1000).optional(),
+})
+
+const snoozeActionSchema = z.object({
+  action: z.literal('snooze'),
+  snoozeUntil: z.coerce.date(),
+  reason: z.string().trim().max(1000).optional(),
+})
+
+const payloadSchema = z.discriminatedUnion('action', [
+  confirmActionSchema,
+  dismissActionSchema,
+  snoozeActionSchema,
+])
+
+type RouteContext = {
+  params: {
+    id?: string
+  }
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const supabase = (await createClient()) as SupabaseClient<Database>
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return errorResponse('Unauthorized', HTTP_STATUS.UNAUTHORIZED)
+  }
+
+  const { params } = context
+  const { id } = params
+
+  if (!id) {
+    return errorResponse('Missing inbox item id', HTTP_STATUS.BAD_REQUEST)
+  }
+
+  const payloadJson = await request
+    .json()
+    .catch(() => null)
+
+  if (!payloadJson) {
+    return errorResponse('Invalid JSON body', HTTP_STATUS.BAD_REQUEST)
+  }
+
+  const parsedPayload = payloadSchema.safeParse(payloadJson)
+  if (!parsedPayload.success) {
+    return errorResponse('Invalid action payload', HTTP_STATUS.BAD_REQUEST)
+  }
+
+  const payload = parsedPayload.data
+
+  let inboxItem: InboxItem | null
+  try {
+    inboxItem = await getInboxItemById(supabase, id, user.id)
+  } catch (error) {
+    console.error('Failed to fetch inbox item context', error)
+    return errorResponse('Failed to load inbox item', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+
+  if (!inboxItem) {
+    return errorResponse('Inbox item not found', HTTP_STATUS.NOT_FOUND)
+  }
+
+  try {
+    let updatedItem: InboxItem
+
+    switch (payload.action) {
+      case 'confirm': {
+        const actionPayload: ConfirmInboxActionPayload = {
+          note: payload.note,
+        }
+
+        updatedItem = await confirmInboxItemAction({
+          supabase,
+          item: inboxItem,
+          userId: user.id,
+          payload: actionPayload,
+        })
+        break
+      }
+      case 'dismiss': {
+        const actionPayload: DismissInboxActionPayload = {
+          reason: payload.reason,
+        }
+
+        updatedItem = await dismissInboxItemAction({
+          supabase,
+          item: inboxItem,
+          userId: user.id,
+          payload: actionPayload,
+        })
+        break
+      }
+      case 'snooze': {
+        const actionPayload: SnoozeInboxActionPayload = {
+          snoozeUntil: payload.snoozeUntil,
+          reason: payload.reason,
+        }
+
+        updatedItem = await snoozeInboxItemAction({
+          supabase,
+          item: inboxItem,
+          userId: user.id,
+          payload: actionPayload,
+        })
+        break
+      }
+      default:
+        return errorResponse('Unsupported action', HTTP_STATUS.BAD_REQUEST)
+    }
+
+    return jsonResponse({ item: updatedItem })
+  } catch (error) {
+    console.error('Failed to process inbox action', error)
+    return errorResponse('Failed to process action', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
+}

--- a/app/api/inbox/route.ts
+++ b/app/api/inbox/route.ts
@@ -1,220 +1,214 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { isInboxEnabled } from '@/config/features'
-import { normalizeInboxResponse } from '@/lib/inbox/normalize'
-import { getPragmaticInboxFeed } from '@/lib/inbox/pragmaticData'
+import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response'
+import { rankInboxItems, type RankedInboxItem } from '@/lib/data/inbox-ranking'
+import type { InboxContent, InboxItem, PaginatedInboxResponse } from '@/types/inbox'
 
-interface SupabaseInboxPayload {
-  headline?: string | null
-  summary?: string | null
-  detail?: Record<string, unknown> | null
-  cta?: Record<string, unknown> | null
-  metadata?: Record<string, unknown> | null
-}
+const DEFAULT_LIMIT = 10
+const MAX_LIMIT = 50
+const SUPABASE_FETCH_LIMIT = 200
 
-interface SupabaseInboxRow {
+type InboxItemRow = {
   id: string
-  type: string
-  priority: number | null
-  tags: string[] | null
+  user_id: string
+  source_type: string
+  status: string
+  part_id: string | null
+  content: unknown
+  metadata: unknown
   created_at: string
-  updated_at: string | null
-  expires_at: string | null
-  inbox_message_payloads: SupabaseInboxPayload | SupabaseInboxPayload[] | null
 }
 
-export async function GET(_req: NextRequest) {
-  if (!isInboxEnabled()) {
-    return NextResponse.json({ data: [], message: 'Inbox is disabled' }, { status: 404 })
+type CursorPayload = {
+  rankBucket: number
+  createdAt: string
+  id: string
+}
+
+function parseLimit(limitParam: string | null): number | null {
+  if (!limitParam) return DEFAULT_LIMIT
+
+  const parsed = Number.parseInt(limitParam, 10)
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return null
   }
 
-  const fallback = normalizeInboxResponse(getPragmaticInboxFeed())
+  return Math.min(parsed, MAX_LIMIT)
+}
+
+function decodeCursor(afterParam: string | null): CursorPayload | null {
+  if (!afterParam) return null
 
   try {
-    const supabase = await createClient()
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
+    const decoded = Buffer.from(afterParam, 'base64url').toString('utf8')
+    const payload = JSON.parse(decoded) as Partial<CursorPayload>
 
-    if (!user) {
-      return NextResponse.json(
-        {
-          data: fallback,
-          source: 'fallback',
-          variant: 'pragmatic',
-          reason: 'unauthenticated',
-          generatedAt: new Date().toISOString(),
-        },
-        { status: 200 },
-      )
+    if (
+      typeof payload.rankBucket === 'number' &&
+      typeof payload.createdAt === 'string' &&
+      typeof payload.id === 'string'
+    ) {
+      return {
+        rankBucket: payload.rankBucket,
+        createdAt: payload.createdAt,
+        id: payload.id,
+      }
     }
-
-    const { data, error } = await supabase
-      .from('inbox_message_subjects')
-      .select(
-        `id, type, priority, tags, created_at, updated_at, expires_at,
-         inbox_message_payloads (headline, summary, detail, cta, metadata)`,
-      )
-      .eq('user_id', user.id)
-      .order('priority', { ascending: false })
-      .order('created_at', { ascending: false })
-      .limit(10)
-
-    if (error) {
-      console.error('[api/inbox] supabase error', error)
-      return NextResponse.json(
-        {
-          data: fallback,
-          source: 'fallback',
-          variant: 'pragmatic',
-          reason: 'supabase_error',
-          generatedAt: new Date().toISOString(),
-        },
-        { status: 200 },
-      )
-    }
-
-    const rows = Array.isArray(data) ? data : []
-    const raw = rows.map((row) => mapSupabaseRow(row))
-    const normalized = normalizeInboxResponse(raw)
-    const payload = normalized.length ? normalized : fallback
-    const source = normalized.length ? 'supabase' : 'fallback'
-
-    return NextResponse.json(
-      {
-        data: payload,
-        source,
-        variant: 'pragmatic',
-        generatedAt: new Date().toISOString(),
-      },
-      { status: 200 },
-    )
   } catch (error) {
-    console.error('[api/inbox] unexpected error', error)
-    return NextResponse.json(
-      {
-        data: fallback,
-        source: 'fallback',
-        variant: 'pragmatic',
-        reason: 'unexpected_error',
-        generatedAt: new Date().toISOString(),
-      },
-      { status: 200 },
-    )
-  }
-}
-
-function mapSupabaseRow(row: SupabaseInboxRow) {
-  const payloadCandidate = Array.isArray(row.inbox_message_payloads)
-    ? row.inbox_message_payloads[0]
-    : row.inbox_message_payloads
-  const base = {
-    id: row.id,
-    type: row.type,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-    expiresAt: row.expires_at,
-    readAt: null,
-    source: 'supabase' as const,
-    priority: row.priority ?? undefined,
-    tags: row.tags ?? undefined,
-    actions: {
-      kind: 'boolean' as const,
-      positiveLabel: 'This resonates',
-      negativeLabel: 'Not right now',
-      allowNotes: true,
-    },
-    metadata: payloadCandidate?.metadata ?? undefined,
+    console.error('Failed to decode inbox cursor', error)
   }
 
-  switch (row.type) {
-    case 'insight_spotlight':
-      return {
-        ...base,
-        payload: {
-          insightId: getMetadataString(payloadCandidate?.metadata, 'insight_id') ?? row.id,
-          title: stringOrNull(payloadCandidate?.headline) ?? 'Insight spotlight',
-          summary:
-            stringOrNull(payloadCandidate?.summary) ?? 'Tap to open the latest insight.',
-          prompt: getMetadataString(payloadCandidate?.metadata, 'prompt') ?? undefined,
-          readingTimeMinutes: getMetadataNumber(payloadCandidate?.metadata, 'reading_time_minutes'),
-          detail:
-            payloadCandidate?.detail && typeof payloadCandidate.detail === 'object'
-              ? (payloadCandidate.detail as Record<string, unknown>)
-              : undefined,
-          cta: coerceCta(payloadCandidate?.cta) ?? undefined,
-        },
-      }
-    case 'nudge':
-      return {
-        ...base,
-        payload: {
-          headline: stringOrNull(payloadCandidate?.headline) ?? 'Reminder',
-          body: stringOrNull(payloadCandidate?.summary) ?? 'Check in with yourself today.',
-          cta: coerceCta(payloadCandidate?.cta) ?? undefined,
-        },
-      }
-    case 'cta':
-      return {
-        ...base,
-        payload: {
-          title: stringOrNull(payloadCandidate?.headline) ?? 'Action needed',
-          description: stringOrNull(payloadCandidate?.summary) ?? 'Complete the suggested action.',
-          action:
-            coerceCta(payloadCandidate?.cta) ?? {
-              label: 'Open',
-              href: '/',
-            },
-        },
-      }
-    case 'notification':
-      return {
-        ...base,
-        payload: {
-          title: stringOrNull(payloadCandidate?.headline) ?? 'Notification',
-          body: stringOrNull(payloadCandidate?.summary) ?? 'You have a new notification.',
-          unread: true,
-        },
-      }
-    default:
-      return {
-        ...base,
-        payload: payloadCandidate ?? {},
-      }
-  }
-}
-
-function coerceCta(value: Record<string, unknown> | null | undefined) {
-  if (!value) return undefined
-  const label = stringOrNull(value.label)
-  if (!label) return undefined
-  return {
-    label,
-    href: stringOrNull(value.href) ?? undefined,
-    actionId: stringOrNull(value.actionId) ?? undefined,
-    intent: stringOrNull(value.intent) === 'secondary' ? 'secondary' : 'primary',
-    helperText: stringOrNull(value.helperText) ?? undefined,
-    target: stringOrNull(value.target) === '_blank' ? '_blank' : undefined,
-    analyticsTag: stringOrNull(value.analyticsTag) ?? undefined,
-  }
-}
-
-function stringOrNull(value: unknown): string | null {
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    return trimmed.length ? trimmed : null
-  }
   return null
 }
 
-function getMetadataString(metadata: Record<string, unknown> | null | undefined, key: string) {
-  if (!metadata) return null
-  return stringOrNull(metadata[key])
+function encodeCursor(item: RankedInboxItem): string {
+  const payload: CursorPayload = {
+    rankBucket: item.rankBucket,
+    createdAt: item.createdAt,
+    id: item.id,
+  }
+
+  return Buffer.from(JSON.stringify(payload)).toString('base64url')
 }
 
-function getMetadataNumber(metadata: Record<string, unknown> | null | undefined, key: string) {
-  if (!metadata) return undefined
-  const value = metadata[key]
-  if (typeof value === 'number' && Number.isFinite(value)) return value
-  return undefined
+function mapRowToItem(row: InboxItemRow): InboxItem {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    sourceType: row.source_type,
+    status: row.status,
+    partId: row.part_id,
+    content: normalizeContent(row.content),
+    metadata: normalizeMetadata(row.metadata),
+    createdAt: row.created_at,
+  }
+}
+
+function normalizeContent(content: unknown): InboxContent | null {
+  if (content == null) return null
+
+  if (typeof content === 'string') {
+    try {
+      return JSON.parse(content)
+    } catch {
+      return { value: content }
+    }
+  }
+
+  if (typeof content === 'object') {
+    return content as InboxContent
+  }
+
+  return null
+}
+
+function normalizeMetadata(metadata: unknown): Record<string, unknown> | null {
+  if (metadata == null) return null
+
+  if (typeof metadata === 'string') {
+    try {
+      return JSON.parse(metadata) as Record<string, unknown>
+    } catch {
+      return { value: metadata }
+    }
+  }
+
+  if (typeof metadata === 'object') {
+    return metadata as Record<string, unknown>
+  }
+
+  return null
+}
+
+function findCursorIndex(items: RankedInboxItem[], cursor: CursorPayload) {
+  return items.findIndex((item) => {
+    return (
+      item.rankBucket === cursor.rankBucket &&
+      item.createdAt === cursor.createdAt &&
+      item.id === cursor.id
+    )
+  })
+}
+
+function paginateItems(
+  rankedItems: RankedInboxItem[],
+  limit: number,
+  cursor: CursorPayload | null
+) {
+  let startIndex = 0
+
+  if (cursor) {
+    const index = findCursorIndex(rankedItems, cursor)
+    if (index === -1) {
+      return {
+        page: [] as RankedInboxItem[],
+        nextCursor: null,
+        cursorInvalid: true,
+      }
+    }
+
+    startIndex = index + 1
+  }
+
+  const page = rankedItems.slice(startIndex, startIndex + limit)
+  const hasNext = startIndex + limit < rankedItems.length
+  const nextCursor = hasNext ? encodeCursor(rankedItems[startIndex + limit]) : null
+
+  return { page, nextCursor, cursorInvalid: false }
+}
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return errorResponse('Unauthorized', HTTP_STATUS.UNAUTHORIZED)
+  }
+
+  const url = new URL(request.url)
+  const limitParam = url.searchParams.get('limit')
+  const afterParam = url.searchParams.get('after')
+
+  const limit = parseLimit(limitParam)
+  if (!limit) {
+    return errorResponse('Invalid limit parameter', HTTP_STATUS.BAD_REQUEST)
+  }
+
+  const cursor = decodeCursor(afterParam)
+  if (afterParam && !cursor) {
+    return errorResponse('Invalid cursor parameter', HTTP_STATUS.BAD_REQUEST)
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('inbox_items_view')
+      .select('*')
+      .eq('user_id', user.id)
+      .limit(Math.min(SUPABASE_FETCH_LIMIT, Math.max(limit * 3, limit + 20)))
+
+    if (error) {
+      console.error('Failed to fetch inbox items', error)
+      return errorResponse('Failed to fetch inbox items', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+    }
+
+    const items = (data ?? []).map((row: InboxItemRow) => mapRowToItem(row))
+    const rankedItems = rankInboxItems(items)
+    const { page, nextCursor, cursorInvalid } = paginateItems(rankedItems, limit, cursor)
+
+    if (cursorInvalid) {
+      return errorResponse('Cursor no longer valid', HTTP_STATUS.BAD_REQUEST)
+    }
+
+    const response: PaginatedInboxResponse = {
+      items: page,
+      nextCursor,
+    }
+
+    return jsonResponse(response)
+  } catch (error) {
+    console.error('Unexpected inbox GET error', error)
+    return errorResponse('An unexpected error occurred', HTTP_STATUS.INTERNAL_SERVER_ERROR)
+  }
 }

--- a/lib/data/inbox-actions.ts
+++ b/lib/data/inbox-actions.ts
@@ -1,0 +1,331 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { DatabaseActionLogger } from '@/lib/database/action-logger'
+import { getInboxItemById } from '@/lib/data/inbox-items'
+import type { InboxItem } from '@/types/inbox'
+import type { Database, InsightRow, InsightUpdate, PartRow, PartUpdate } from '@/lib/types/database'
+
+export type ConfirmInboxActionPayload = {
+  note?: string
+}
+
+export type DismissInboxActionPayload = {
+  reason?: string
+}
+
+export type SnoozeInboxActionPayload = {
+  snoozeUntil: Date
+  reason?: string
+}
+
+type ActionContext<Payload> = {
+  supabase: SupabaseClient<Database>
+  item: InboxItem
+  userId: string
+  payload: Payload
+}
+
+export async function confirmInboxItemAction({
+  supabase,
+  item,
+  userId,
+  payload,
+}: ActionContext<ConfirmInboxActionPayload>): Promise<InboxItem> {
+  if (item.sourceType !== 'insight') {
+    throw new Error('Confirm action is only supported for insight inbox items')
+  }
+
+  const actionLogger = new DatabaseActionLogger(supabase)
+  const now = new Date().toISOString()
+  const note = payload.note?.trim() || undefined
+
+  const { data: insightRow, error: insightError } = await supabase
+    .from('insights')
+    .select('id,status,meta,revealed_at')
+    .eq('id', item.id)
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (insightError) {
+    throw insightError
+  }
+
+  if (!insightRow) {
+    throw new Error('Insight not found for confirmation')
+  }
+
+  const insight = insightRow as Pick<InsightRow, 'id' | 'status' | 'meta' | 'revealed_at'>
+
+  const insightUpdate: Partial<InsightUpdate> = {}
+  if (insight.status !== 'revealed') {
+    insightUpdate.status = 'revealed'
+    insightUpdate.revealed_at = now
+  }
+
+  const metaRecord = toRecord(insight.meta)
+  const confirmationMeta = toRecord(metaRecord.confirmation)
+  confirmationMeta.last_confirmed_at = now
+  if (note) {
+    confirmationMeta.note = note
+    confirmationMeta.note_updated_at = now
+  }
+
+  const updatedMeta = {
+    ...metaRecord,
+    confirmation: confirmationMeta,
+  }
+
+  insightUpdate.meta = updatedMeta as InsightUpdate['meta']
+
+  await actionLogger.loggedUpdate<InsightRow>('insights', insight.id, insightUpdate, userId, 'confirm_insight', {
+    changeDescription: 'User confirmed inbox insight',
+    ...(note ? { note } : {}),
+  })
+
+  if (item.partId) {
+    await touchRelatedPart({
+      supabase,
+      actionLogger,
+      partId: item.partId,
+      userId,
+      note,
+      timestamp: now,
+    })
+  }
+
+  const refreshedItem = await getInboxItemById(supabase, item.id, userId)
+  if (!refreshedItem) {
+    throw new Error('Failed to load updated inbox item')
+  }
+
+  return refreshedItem
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+
+  return value as Record<string, unknown>
+}
+
+type PartTouchContext = {
+  supabase: SupabaseClient<Database>
+  actionLogger: DatabaseActionLogger
+  partId: string
+  userId: string
+  timestamp: string
+  note?: string
+}
+
+async function touchRelatedPart({
+  supabase,
+  actionLogger,
+  partId,
+  userId,
+  timestamp,
+  note,
+}: PartTouchContext): Promise<void> {
+  const { data: partRow, error } = await supabase
+    .from('parts')
+    .select('id,name,status,acknowledged_at')
+    .eq('id', partId)
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  if (!partRow) {
+    return
+  }
+
+  const updates: Partial<PartUpdate> = {
+    last_active: timestamp,
+  }
+
+  if (!partRow.acknowledged_at) {
+    updates.acknowledged_at = timestamp
+  }
+
+  if (partRow.status === 'emerging') {
+    updates.status = 'acknowledged'
+  }
+
+  await actionLogger.loggedUpdate<PartRow>('parts', partRow.id, updates, userId, 'acknowledge_part', {
+    partName: partRow.name,
+    changeDescription: 'Part touched by inbox confirmation',
+    ...(note ? { note } : {}),
+  })
+}
+
+export async function dismissInboxItemAction(
+  {
+    supabase,
+    item,
+    userId,
+    payload,
+  }: ActionContext<DismissInboxActionPayload>
+): Promise<InboxItem> {
+  const actionLogger = new DatabaseActionLogger(supabase)
+  const timestamp = new Date().toISOString()
+  const reason = payload.reason?.trim() || undefined
+
+  if (item.sourceType === 'insight') {
+    const updated = await dismissInsightInboxItem({
+      supabase,
+      actionLogger,
+      item,
+      userId,
+      timestamp,
+      reason,
+    })
+
+    if (updated) {
+      return updated
+    }
+
+    return buildDismissedFallback(item, timestamp, reason)
+  }
+
+  if (item.sourceType === 'part_follow_up' || item.sourceType === 'follow_up') {
+    const updated = await dismissPartFollowUpInboxItem({
+      supabase,
+      actionLogger,
+      item,
+      userId,
+      timestamp,
+      reason,
+    })
+
+    if (updated) {
+      return updated
+    }
+
+    return buildDismissedFallback(item, timestamp, reason)
+  }
+
+  return buildDismissedFallback(item, timestamp, reason)
+}
+
+export async function snoozeInboxItemAction(
+  _context: ActionContext<SnoozeInboxActionPayload>
+): Promise<InboxItem> {
+  throw new Error('snoozeInboxItemAction not implemented')
+}
+
+type DismissContext = {
+  supabase: SupabaseClient<Database>
+  actionLogger: DatabaseActionLogger
+  item: InboxItem
+  userId: string
+  timestamp: string
+  reason?: string
+}
+
+async function dismissInsightInboxItem({
+  supabase,
+  actionLogger,
+  item,
+  userId,
+  timestamp,
+  reason,
+}: DismissContext): Promise<InboxItem | null> {
+  const { data: insightRow, error } = await supabase
+    .from('insights')
+    .select('id,status,meta')
+    .eq('id', item.id)
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  if (!insightRow) {
+    throw new Error('Insight not found for dismissal')
+  }
+
+  const insight = insightRow as Pick<InsightRow, 'id' | 'status' | 'meta'>
+
+  const insightUpdate: Partial<InsightUpdate> = {
+    status: 'actioned',
+    actioned_at: timestamp,
+  }
+
+  const metaRecord = toRecord(insight.meta)
+  const dismissedMeta = toRecord(metaRecord.dismissed)
+  dismissedMeta.dismissed_at = timestamp
+  if (reason) {
+    dismissedMeta.reason = reason
+  }
+
+  insightUpdate.meta = {
+    ...metaRecord,
+    dismissed: dismissedMeta,
+  } as InsightUpdate['meta']
+
+  await actionLogger.loggedUpdate<InsightRow>('insights', insight.id, insightUpdate, userId, 'dismiss_insight', {
+    changeDescription: 'User dismissed inbox insight',
+    ...(reason ? { reason } : {}),
+  })
+
+  return getInboxItemById(supabase, item.id, userId)
+}
+
+async function dismissPartFollowUpInboxItem({
+  supabase,
+  actionLogger,
+  item,
+  userId,
+  timestamp,
+  reason,
+}: DismissContext): Promise<InboxItem | null> {
+  if (!item.partId) {
+    throw new Error('Part follow-up item missing partId')
+  }
+
+  const { data: partRow, error } = await supabase
+    .from('parts')
+    .select('id,name,last_interaction_at')
+    .eq('id', item.partId)
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  if (!partRow) {
+    throw new Error('Part not found for dismissal')
+  }
+
+  const part = partRow as Pick<PartRow, 'id' | 'name'>
+
+  const updates: Partial<PartUpdate> = {
+    last_interaction_at: timestamp,
+  }
+
+  await actionLogger.loggedUpdate<PartRow>('parts', part.id, updates, userId, 'dismiss_part_follow_up', {
+    partName: part.name,
+    changeDescription: 'User dismissed part follow-up reminder',
+    ...(reason ? { reason } : {}),
+  })
+
+  return getInboxItemById(supabase, item.id, userId)
+}
+
+function buildDismissedFallback(item: InboxItem, timestamp: string, reason?: string): InboxItem {
+  const metadata = {
+    ...(item.metadata ?? {}),
+    dismissedAt: timestamp,
+    ...(reason ? { dismissReason: reason } : {}),
+  }
+
+  return {
+    ...item,
+    status: 'dismissed',
+    metadata,
+  }
+}

--- a/lib/data/inbox-items.ts
+++ b/lib/data/inbox-items.ts
@@ -1,0 +1,87 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import type { InboxContent, InboxItem } from '@/types/inbox'
+import type { Database } from '@/lib/types/database'
+
+export type InboxItemRow = {
+  id: string
+  user_id: string
+  source_type: string
+  status: string
+  part_id: string | null
+  content: unknown
+  metadata: unknown
+  created_at: string
+}
+
+export function normalizeInboxContent(content: unknown): InboxContent | null {
+  if (content == null) return null
+
+  if (typeof content === 'string') {
+    try {
+      return JSON.parse(content)
+    } catch {
+      return { value: content }
+    }
+  }
+
+  if (typeof content === 'object') {
+    return content as InboxContent
+  }
+
+  return null
+}
+
+export function normalizeInboxMetadata(metadata: unknown): Record<string, unknown> | null {
+  if (metadata == null) return null
+
+  if (typeof metadata === 'string') {
+    try {
+      return JSON.parse(metadata) as Record<string, unknown>
+    } catch {
+      return { value: metadata }
+    }
+  }
+
+  if (typeof metadata === 'object') {
+    return metadata as Record<string, unknown>
+  }
+
+  return null
+}
+
+export function mapInboxRowToItem(row: InboxItemRow): InboxItem {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    sourceType: row.source_type,
+    status: row.status,
+    partId: row.part_id,
+    content: normalizeInboxContent(row.content),
+    metadata: normalizeInboxMetadata(row.metadata),
+    createdAt: row.created_at,
+  }
+}
+
+export async function getInboxItemById(
+  supabase: SupabaseClient<Database>,
+  id: string,
+  userId: string
+): Promise<InboxItem | null> {
+  const { data, error } = await supabase
+    .from('inbox_items_view')
+    .select('*')
+    .eq('id', id)
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  if (!data) {
+    return null
+  }
+
+  return mapInboxRowToItem(data as InboxItemRow)
+}

--- a/types/inbox.ts
+++ b/types/inbox.ts
@@ -1,3 +1,32 @@
+export type InboxItemSourceType = 'insight' | 'follow_up' | string
+
+export type InboxItemStatus = 'pending' | 'revealed' | 'dismissed' | 'snoozed' | string
+
+export interface InboxContent {
+  title?: string
+  body?: string
+  evidence?: unknown
+  [key: string]: unknown
+}
+
+export interface InboxItem {
+  id: string
+  userId: string
+  sourceType: InboxItemSourceType
+  status: InboxItemStatus
+  partId: string | null
+  content: InboxContent | null
+  metadata: Record<string, unknown> | null
+  createdAt: string
+}
+
+export interface PaginatedInboxResponse {
+  items: InboxItem[]
+  nextCursor: string | null
+}
+
+// Inbox feed envelope types used by client-side normalization helpers
+
 export type InboxMessageType = 'insight_spotlight' | 'nudge' | 'cta' | 'notification'
 export type InboxEnvelopeSource = 'network' | 'fallback' | 'supabase' | 'edge'
 
@@ -130,15 +159,6 @@ export interface InboxFeedResponse {
   generatedAt?: string
   source?: InboxEnvelopeSource | 'fallback'
   variant?: InboxFeedVariant
-  reason?: string
-}
-
-export interface InboxFeedResult {
-  envelopes: InboxEnvelope[]
-  generatedAt?: string
-  source: InboxEnvelopeSource | 'fallback'
-  variant: InboxFeedVariant
-  reason?: string
 }
 
 export interface InboxActionRequest {


### PR DESCRIPTION
## Summary
- add POST /api/inbox/[id]/action route with validation and dispatch
- implement shared inbox action helpers for confirm and dismiss flows
- normalize CTA metadata fields so targets and analytics tags persist

## Testing
- not run (toolchain unavailable in workspace)