### PR TITLE
Fix Supabase auth guard and backfill runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,31 +4,37 @@
 # -----------------------------------------------------------------------------
 # Core application URLs
 # -----------------------------------------------------------------------------
-NEXT_PUBLIC_APP_URL="http://localhost:3000"             # Public origin exposed to the browser for links and OAuth callbacks.
-APP_BASE_URL="http://localhost:3000"                    # Server-render base URL fallback when Vercel vars are absent.
-BASE_URL="http://localhost:3000"                        # Optional explicit base URL override (e.g. reverse proxy).
-API_BASE_URL="http://localhost:3000/api"                # Optional API host override for external clients.
-NEXT_PUBLIC_MASTRA_API_URL="http://localhost:4111"      # Mastra dev server base URL (npm run dev:mastra).
-OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"      # Override to point at self-hosted OpenRouter compatible proxy.
-VERCEL_URL=""                                           # Managed by Vercel in production; leave blank locally.
+NEXT_PUBLIC_APP_URL="https://your-production-domain.example"   # Production public origin for the deployed app.
+APP_BASE_URL="https://your-production-domain.example"           # Server-render base URL used in production.
+BASE_URL="https://your-production-domain.example"               # Explicit base URL override (leave as localhost for dev).
+API_BASE_URL="https://your-production-domain.example/api"      # Optional API host override for external clients.
+NEXT_PUBLIC_MASTRA_API_URL="http://localhost:4111"             # Mastra dev server base URL (npm run dev:mastra).
+OPENROUTER_BASE_URL="http://127.0.0.1:4000"                    # Self-hosted OpenRouter-compatible proxy (local testing).
+VERCEL_URL=""                                                  # Managed by Vercel in production; leave blank locally.
 
 # -----------------------------------------------------------------------------
 # Supabase configuration
 # -----------------------------------------------------------------------------
-NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co"    # Required: Supabase project URL for client and server.
-NEXT_PUBLIC_SUPABASE_ANON_KEY="public-anon-key"                # Required: Public anon key used in the browser.
-SUPABASE_URL="https://your-project.supabase.co"                # Optional: Server override; defaults to NEXT_PUBLIC_SUPABASE_URL.
-SUPABASE_ANON_KEY="public-anon-key"                            # Optional: Server override; defaults to NEXT_PUBLIC_SUPABASE_ANON_KEY.
-SUPABASE_SERVICE_ROLE_KEY="service-role-key"                   # Required for server scripts and Edge adapters; never expose client-side.
+NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co"            # Production Supabase project URL.
+NEXT_PUBLIC_SUPABASE_ANON_KEY="sb_public_anon_key"                     # Production anon key.
+SUPABASE_URL="https://your-project.supabase.co"                        # Server override; defaults to NEXT_PUBLIC_SUPABASE_URL.
+SUPABASE_ANON_KEY="sb_public_anon_key"                                 # Server override; defaults to NEXT_PUBLIC_SUPABASE_ANON_KEY.
+SUPABASE_SERVICE_ROLE_KEY="supabase_service_role_key"                 # Production service role key (server only).
+SUPABASE_ACCESS_TOKEN="supabase_service_access_token"                 # Service access token for Supabase CLI/Admin.
+SUPABASE_DB_PASSWORD="supabase_db_password"                           # Database password (staging/production as provisioned).
 STAGING_SUPABASE_URL="https://staging-your-project.supabase.co"        # Scripts only: staging Supabase URL for seeding commands.
 STAGING_SUPABASE_SERVICE_ROLE_KEY="staging-service-role-key"           # Scripts only: staging service role key.
 TARGET_ENV="development"                                      # Scripts only: set to 'staging' to target staging resources.
 IFS_DEV_FORCE_NO_SUPABASE="false"                              # When 'true', bypass Supabase entirely (local offline/dev).
+SUPABASE_AUTH_EXTERNAL_GOOGLE_REDIRECT_URI="https://your-project.supabase.co/auth/v1/callback"  # Google OAuth redirect.
+SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID="your-google-client-id.apps.googleusercontent.com"
+SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET="your-google-client-secret"
 
 # -----------------------------------------------------------------------------
 # Authentication & webhooks
 # -----------------------------------------------------------------------------
 CRON_SECRET="local-cron-secret"                         # Optional: Protects cron endpoints; set in production & Vercel Cron.
+NEXT_PUBLIC_GOOGLE_CLIENT_ID="your-google-client-id.apps.googleusercontent.com"  # Browser-side Google OAuth client.
 
 # -----------------------------------------------------------------------------
 # Feature flags & dev personas
@@ -64,7 +70,7 @@ USER_MEMORY_CHECKPOINT_EVERY="50"                             # Snapshot frequen
 # -----------------------------------------------------------------------------
 # AI & tooling provider credentials
 # -----------------------------------------------------------------------------
-OPENROUTER_API_KEY="your_openrouter_api_key_here"             # Required for LLM-powered features (OpenRouter token).
+OPENROUTER_API_KEY="your_openrouter_api_key_here"             # Required for LLM-powered features (OpenRouter token or proxy key).
 ANTHROPIC_API_KEY="your_anthropic_api_key_here"               # Optional: Anthropic models (sk-ant-api03-...).
 PERPLEXITY_API_KEY="your_perplexity_api_key_here"             # Optional: Perplexity models (pplx-...).
 OPENAI_API_KEY="your_openai_api_key_here"                     # Optional: OpenAI models (sk-proj-...).

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -51,7 +51,7 @@ type AuthCallbackPayload = {
   session?: Session | null
 }
 
-const allowedEvents = new Set(['SIGNED_IN', 'TOKEN_REFRESHED', 'SIGNED_OUT'])
+const allowedEvents = new Set(['INITIAL_SESSION', 'SIGNED_IN', 'TOKEN_REFRESHED', 'SIGNED_OUT'])
 
 function normalizeOrigin(origin: string | null): string | null {
   if (!origin) {
@@ -125,6 +125,11 @@ export async function POST(request: Request) {
     } = await supabase.auth.getSession()
 
     if (!session?.access_token) {
+      if (event === 'INITIAL_SESSION') {
+        console.info('Auth callback received initial session with no active session; clearing cookies')
+        await supabase.auth.signOut()
+        return NextResponse.json({ success: true })
+      }
       console.warn('Auth callback POST missing access token', { event })
       return NextResponse.json({ success: false }, { status: 400 })
     }

--- a/docs/runbooks/supabase-user-backfill.md
+++ b/docs/runbooks/supabase-user-backfill.md
@@ -1,0 +1,51 @@
+# Runbook: Backfill Missing `public.users` Rows
+
+Production incident: chat session inserts can fail with `error code 23503` and message `insert or update on table "sessions" violates foreign key constraint "sessions_user_id_fkey"`. This occurs when a Supabase auth user exists without a matching row in `public.users`.
+
+## When to use this runbook
+- Logs show the foreign key violation above when starting a chat session or storing a message.
+- Supabase CLI / dashboard data explorer reveals entries in `auth.users` that are missing from `public.users`.
+
+## Background
+- Historically we relied on the `public.handle_new_user` trigger to mirror `auth.users` into `public.users`.
+- Accounts created before that trigger existed—or during outages where it failed—lack a profile, so any session insert referencing that user breaks.
+- The application now calls `ChatSessionService.ensureUserRecord()` before starting a session, but we still need to repair existing data.
+
+## Backfill procedure
+1. **Open the SQL editor** in the Supabase dashboard for the impacted project (or connect via `psql` using the service-role key).
+2. **Execute the backfill statement**:
+   ```sql
+   insert into public.users (id, email, name)
+   select au.id,
+          au.email,
+          coalesce(au.raw_user_meta_data->>'full_name', au.raw_user_meta_data->>'name', au.email)
+   from auth.users au
+   where not exists (
+     select 1
+     from public.users pu
+     where pu.id = au.id
+   );
+   ```
+   - The query is idempotent; re-running it is safe.
+   - Expect `INSERT 0 <n>` where `<n>` equals the number of missing users.
+3. **Verify** by selecting a sample user:
+   ```sql
+   select id, email, name
+   from public.users
+   where id = '<affected-user-id>';
+   ```
+4. **Redeploy / retry** the failing action in production. The application should now complete the session insert without errors.
+
+## Post-backfill checks
+- Review Supabase logs for 5–10 minutes to ensure no new `sessions_user_id_fkey` violations occur.
+- Ask the affected user to refresh and start a chat; confirm success.
+- Consider adding a dashboard alert for new occurrences of the constraint violation.
+
+## Related code
+- `lib/session-service.ts` → `ensureUserRecord`
+- `lib/api/supabaseGuard.ts` → uses `auth.getUser()` for verified identity
+- `supabase/migrations/012_handle_new_users.sql` → trigger that mirrors `auth.users`
+
+## Mitigation status
+- ✅ Runtime safeguard added in code.
+- ⏳ Historical data must be backfilled using the steps above.


### PR DESCRIPTION
## Summary
- switch Supabase guard to call auth.getUser and guard mismatched sessions
- ensure chat sessions upsert a public.users record before inserts
- document the production backfill procedure and sanitize env example

## Testing
- not run