### PR TITLE
Frontend: adopt Vercel AI SDK useChat; remove custom SSE hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Guidelines
+
+- Prefer GitHub CLI (`gh`) for creating and updating pull requests from this repository.
+- Document any deviations from standard workflows in this file so future agents stay aligned.

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -24,10 +24,9 @@ export interface Message {
 
 export interface ChatState {
   messages: Message[];
-  isStreaming: boolean;
+  isLoading: boolean;
   currentStreamingId?: string;
   hasActiveSession?: boolean;
   // Map assistant message id -> list of task events
   tasksByMessage?: Record<string, TaskEvent[]>;
 }
-


### PR DESCRIPTION
## Summary
- wrap the chat hook around the SDK's `useChat` for messages, streaming status, and errors while keeping session persistence and task updates
- refactor Ethereal chat UI to rely on the hook's `input`, `handleSubmit`, and `isLoading` helpers instead of custom state
- note in AGENTS.md that pull requests should be opened with the GitHub CLI

## Testing
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Chat input is now controlled with form-based submission for more consistent keyboard and button behavior.
  - Clearer loading state during message send; input and submit are disabled while processing.

- Bug Fixes
  - Improved auth gating to prevent premature redirects and welcome messages before auth completes.
  - More reliable focus and scroll behavior during loading and after sends.

- Documentation
  - Added AGENTS.md with guidelines for using the GitHub CLI for pull requests and documenting workflow deviations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->