### PR TITLE
docs: clarify supabase migration order

### DIFF
--- a/supabase/MIGRATIONS.md
+++ b/supabase/MIGRATIONS.md
@@ -11,21 +11,29 @@ Current migration files (in recommended apply order):
 5. 005_insights.sql
 6. 006_user_memory.sql (neutralized in Memory v2; drops legacy table if present)
 7. 007_check_ins.sql
-8. 007_handle_new_users.sql
-9. 008_add_charge_to_parts.sql
-10. 008_message_feedback.sql
-11. 014_events.sql (Memory v2 events ledger)
-12. 015_idempotency_records.sql (Memory v2 idempotency)
+8. 008_add_charge_to_parts.sql
+9. 009_onboarding_schema.sql
+10. 010_onboarding_rls.sql
+11. 011_onboarding_seed.sql
+12. 012_handle_new_users.sql
+13. 013_message_feedback.sql
+14. 014_events.sql (Memory v2 events ledger)
+15. 015_idempotency_records.sql (Memory v2 idempotency)
+16. 016_cleanup_legacy.sql
+17. 017_memory_updates.sql
+18. 017_part_notes.sql
+19. 018_sessions_auth_context.sql
+20. 022_add_avatar_url_to_users.sql
+21. 104_inbox_items_view.sql
 
 Notes about duplicate numeric prefixes
-- There are two files with the prefix `007_` and two with `008_`.
+- There are two files with the prefix `017_`.
 - Supabase applies migrations in lexicographic order of the full filename, so the effective order is stable:
-  - `007_check_ins.sql` < `007_handle_new_users.sql`
-  - `008_add_charge_to_parts.sql` < `008_message_feedback.sql`
-- Because these migrations may already be applied in existing environments, do NOT rename these files retroactively.
+  - `017_memory_updates.sql` < `017_part_notes.sql`
+- Because these migrations were applied in shared environments, do **not** rename them retroactively. New migrations should continue with the next unused numeric prefix.
 
 Bootstrapping a fresh environment
-- The recommended path is to let the Supabase CLI apply the migrations in filename order:
+- Let the Supabase CLI apply the migrations in filename order:
   - `supabase start`
   - `supabase db reset` (for a clean slate)
   - `supabase db migrate`
@@ -33,9 +41,9 @@ Bootstrapping a fresh environment
 
 Future clean-up plan (optional)
 - Legacy migrations 002_agent_actions.sql and 006_user_memory.sql have been neutralized to support the Memory v2 baseline without re-numbering.
-- If and when we confirm these migrations are not applied to any shared/long-lived environment, we can re-number to a clean, unique baseline. Until then, avoid renaming to preserve applied state integrity.
+- If and when we confirm duplicate-prefixed migrations are not applied to any shared/long-lived environment, we can re-number to a clean, unique baseline. Until then, avoid renaming to preserve applied state integrity.
 
 Verification
-- A small script exists to flag duplicate numeric prefixes:
+- A script exists to flag duplicate numeric prefixes:
   - `npm run migrations:verify`
-- It will warn if any numeric prefix (e.g., `007`) is used by multiple files.
+- It will warn if any numeric prefix (e.g., `017_`) is used by multiple files so that we avoid introducing additional conflicts.


### PR DESCRIPTION
## Summary
- document the current lexicographic order through 104_inbox_items_view.sql
- explain the intentional 017 duplicate prefix and guidance for new migrations
- remind maintainers about the migrations:verify guardrail

## Testing
- npm run migrations:verify