### PR TITLE
Move memory maintenance to background cron

### DIFF
--- a/app/api/cron/memory-update/route.ts
+++ b/app/api/cron/memory-update/route.ts
@@ -1,6 +1,7 @@
 import { DAY_MS } from '@/config/time'
 import { requireCronAuth } from '@/lib/api/cron-auth'
 import { listActiveUsersSince, reconstructMemory, loadTodayData, generateMemoryUpdate, saveNewSnapshot, markUpdatesProcessed } from '@/lib/memory/service'
+import { summarizePendingUpdates } from '@/lib/services/memory'
 import { errorResponse, jsonResponse, HTTP_STATUS } from '@/lib/api/response'
 
 async function runDailyMemoryUpdate(): Promise<Response> {
@@ -28,7 +29,10 @@ async function runDailyMemoryUpdate(): Promise<Response> {
     }
   }
 
-  return jsonResponse({ cutoff, processed: users.length, results })
+  const summaryOutcome = await summarizePendingUpdates()
+  console.log('[CRON] summarizePendingUpdates outcome', summaryOutcome)
+
+  return jsonResponse({ cutoff, processed: users.length, results, summaries: summaryOutcome.processed })
 }
 
 export async function GET(req: Request) {

--- a/lib/services/memory.ts
+++ b/lib/services/memory.ts
@@ -1,0 +1,50 @@
+import { isMemoryV2Enabled } from '@/lib/memory/config'
+import { ensureOverviewExists } from '@/lib/memory/snapshots/scaffold'
+import { listUsersWithPendingUpdates } from '@/lib/memory/updates'
+import { summarizePendingUpdatesForUser } from '@/lib/memory/update-runner'
+
+export async function scaffoldUserMemory(opts: { userId: string }): Promise<void> {
+  const userId = opts?.userId
+  if (!userId) return
+  if (!isMemoryV2Enabled()) return
+
+  try {
+    await ensureOverviewExists(userId)
+  } catch (error) {
+    console.warn('[MEMORY] scaffoldUserMemory failed', { userId, error })
+  }
+}
+
+interface SummarizePendingUpdatesOptions {
+  userId?: string
+  limit?: number
+}
+
+export async function summarizePendingUpdates(opts: SummarizePendingUpdatesOptions = {}): Promise<{ processed: number }> {
+  if (!isMemoryV2Enabled()) return { processed: 0 }
+
+  const userIds = opts.userId ? [opts.userId] : await listUsersWithPendingUpdates()
+  if (!userIds.length) return { processed: 0 }
+
+  const limit = opts.limit
+  let processed = 0
+
+  for (const userId of userIds) {
+    try {
+      await scaffoldUserMemory({ userId })
+      const outcome = await summarizePendingUpdatesForUser(userId, limit ? { limit } : undefined)
+      if (!outcome.skipped && outcome.itemCount > 0) {
+        processed += outcome.itemCount
+        console.log('[MEMORY] Summarized pending updates', {
+          userId,
+          processed: outcome.itemCount,
+          digest: outcome.digest,
+        })
+      }
+    } catch (error) {
+      console.warn('[MEMORY] summarizePendingUpdates failed', { userId, error })
+    }
+  }
+
+  return { processed }
+}


### PR DESCRIPTION
## Summary
- remove memory scaffolding and summarization from the chat handler so it only streams
- add a reusable memory service that schedules scaffolding and summarization for background work
- wire the existing memory cron route to run the new summarization workflow and report stats

## Testing
- npm run lint