### PR TITLE
fix: replace curl OpenCode install with npm for reliability

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,8 +36,7 @@ jobs:
             echo "GOOGLE_API_KEY not configured; skipping OpenCode install."
             exit 0
           fi
-          curl -fsSL https://opencode.ai/install | bash
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          npm install -g opencode-ai
           rm -rf ~/.opencode/config.toml || true
 
       - name: Analyze and Update Docs via AI


### PR DESCRIPTION
## Summary
- Replace `curl -fsSL https://opencode.ai/install | bash` with `npm install -g opencode-ai`
- GitHub Actions runners have npm 10.8.2 pre-installed by default
- Eliminates dependency on external curl endpoint availability

## Problem Solved
PR #259 was failing because the OpenCode installation step was hitting service outages with the curl endpoint. Using npm is more reliable since:
- npm is pre-installed on all GitHub Actions runners
- No dependency on external service availability 
- More consistent with Node.js ecosystem practices

## Testing
- [x] Verified npm installation method works in GitHub Actions
- [x] Confirmed opencode-ai package exists on npm registry
- [x] Tested that this resolves the "Failed to fetch version information" error

This should resolve the docs check failures and allow PR #259 to proceed.