### PR TITLE
Schedule insights and update digest cron jobs

### DIFF
--- a/docs/current/features/insights.md
+++ b/docs/current/features/insights.md
@@ -1,19 +1,20 @@
 ---
 title: Feature: Insights (Phase 2)
 owner: @brandongalang
-status: in_development
-last_updated: 2025-10-12
+status: beta
+last_updated: 2025-10-24
 feature_flag: null
 code_paths:
   - app/api/insights/*
   - lib/insights/generator.ts
   - app/api/cron/generate-insights/route.ts
+  - vercel.json
 related_prs:
   - #41
 ---
 
 ## What
-Phase 2 feature for generating insights and patterns across user sessions and parts over time. Currently in active development with API scaffolding in place.
+Phase 2 feature for generating insights and patterns across user sessions and parts over time. The automated cron pipeline now generates daily insights in production while remaining agent and UI integrations continue to iterate.
 
 ## Why
 Surface trends and patterns across sessions and parts over time.
@@ -27,10 +28,13 @@ Surface trends and patterns across sessions and parts over time.
 - insights table (or equivalent) reserved; exact schema may evolve
 
 ## Configuration
-- Cron pipeline not yet enabled; when ready wire through `vercel.json` (similar to memory-update cron) and provision its own `CRON_SECRET`
+- Daily Vercel Cron schedule hits `/api/cron/generate-insights` at **08:30 UTC** (`vercel.json`)
+- Cron requests reuse the shared `CRON_SECRET` header handled by `requireCronAuth`
 
 ## Testing
 - Smoke scripts available via npm run smoke:insights
 
 ## Operational notes
-- Treat as behind a manual switch; do not enable broadly until core logic is complete
+- Monitor Vercel Cron logs (`vercel -> Settings -> Cron Jobs -> generate-insights`) for non-200 responses—there are no automatic retries
+- Use `npm run smoke:insights` after deployments that touch the workflow to confirm the cron can still enqueue summaries
+- Keep the workflow idempotent; the handler skips users within the configured cooldown window and silently ignores empty outputs

--- a/docs/current/operations/user-memory.md
+++ b/docs/current/operations/user-memory.md
@@ -17,11 +17,15 @@ This backend feature maintains an evolving, agent-readable "user memory" hub. It
 6. **Queue cleanup**: `markUpdatesProcessed` remains during the transition to keep legacy flags in sync while the queue-driven flow stabilizes.
 
 ## API
-- `POST /api/cron/memory-update`
+- `GET /api/cron/memory-update` (also accepts `POST` for manual triggers)
   - Header: `Authorization: Bearer <CRON_SECRET>`
   - Finds users active in last 24h, runs the update pipeline for each
   - **Enhanced**: Finalizes stale sessions, enqueues queue entries, and processes pending memory updates for all users
   - Returns per-user result, latest version if saved, queue summary, and change-log stats
+- `GET /api/cron/update-digest` (also accepts `POST`)
+  - Header: `Authorization: Bearer <CRON_SECRET>`
+  - Iterates over users with pending `memory_updates`, executes Mastra summarizer workflow, and records digest telemetry
+  - Returns `{ processed, results }` including per-user success or error payloads for observability
 - `POST /api/memory/preflight`
   - Authenticated user endpoint invoked before chat agent boot
   - Checks for pending queue items and, if present, runs a scoped `summarizePendingUpdates({ userId })`
@@ -52,7 +56,10 @@ The Memory V2 system stores part profiles, relationships, and user context as ma
 - **2025-10-17 PRD cutover**: Interactive agents and background jobs no longer write to markdown. Update digests and change logs are persisted via Supabase `observations` / `timeline_events`, while markdown snapshots remain available for read-only hydration during the transition.
 
 ## Scheduling
-- Primary scheduler: **Vercel Cron** configured in `vercel.json` with `0 8 * * *` (08:00 UTC daily).
+- Primary scheduler: **Vercel Cron** configured in `vercel.json`.
+  - 08:00 UTC — `/api/cron/memory-update`
+  - 08:10 UTC — `/api/cron/update-digest`
+  - 08:30 UTC — `/api/cron/generate-insights` (insights pipeline consumes the fresh digests)
 - Secrets live in Vercel project settings:
   - `CRON_SECRET`: shared between the cron definition and the Next.js runtime.
   - `APP_BASE_URL` / `BASE_URL`: used by the cron handler for absolute links and logging.

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,14 @@
     {
       "path": "/api/cron/memory-update",
       "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/update-digest",
+      "schedule": "10 8 * * *"
+    },
+    {
+      "path": "/api/cron/generate-insights",
+      "schedule": "30 8 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add Vercel cron schedules for `/api/cron/update-digest` and `/api/cron/generate-insights` with staggered start times after the memory refresh
- document the automated insight generation flow and updated cron chain across feature docs and operational runbooks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69003375764c8323b9e85831d453d113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded backend scheduled maintenance tasks to support improved service operations and data processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->